### PR TITLE
feat: add Letta Code GitHub Action

### DIFF
--- a/.github/workflows/letta.yml
+++ b/.github/workflows/letta.yml
@@ -1,0 +1,25 @@
+name: Letta Code
+
+on:
+  issues:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, labeled]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  letta:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: letta-ai/letta-code-action@v0
+        with:
+          letta_api_key: ${{ secrets.LETTA_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Adds the Letta Code GitHub Action to enable `@letta-code` mentions in issues and PRs.

## What it does
- Mention `@letta-code` in any issue or PR comment
- Agent can read files, run commands, make commits
- Maintains conversation context across interactions

## Setup required
Add `LETTA_API_KEY` to repository secrets (Settings → Secrets → Actions)

## Test plan
- [ ] Add LETTA_API_KEY secret
- [ ] Create test issue and mention @letta-code
- [ ] Verify agent responds

🤖 Generated with [Letta Code](https://letta.com)