### PR TITLE
fix: resolve CLI via package main export instead of subpath

### DIFF
--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+
+describe("CLI resolution", () => {
+  test("resolves @letta-ai/letta-code via package main export", () => {
+    // This is the resolution strategy used by findCli().
+    // Previously we resolved "@letta-ai/letta-code/letta.js" which fails
+    // with ERR_PACKAGE_PATH_NOT_EXPORTED because the subpath isn't in the
+    // package.json exports field. The main export "." maps to "./letta.js".
+    const require = createRequire(import.meta.url);
+    const resolved = require.resolve("@letta-ai/letta-code");
+    expect(resolved).toBeDefined();
+    expect(resolved.endsWith("letta.js")).toBe(true);
+    expect(existsSync(resolved)).toBe(true);
+  });
+
+  test("subpath resolution fails without explicit export", () => {
+    // This documents why we can't use the subpath directly.
+    const require = createRequire(import.meta.url);
+    expect(() => {
+      require.resolve("@letta-ai/letta-code/letta.js");
+    }).toThrow();
+  });
+});

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -305,10 +305,12 @@ export class SubprocessTransport {
     }
 
     // Strategy 2: Try to resolve from node_modules
+    // Note: resolve the package main export (not /letta.js subpath) because
+    // the package.json "exports" field doesn't expose the subpath directly.
     try {
       const { createRequire } = await import("node:module");
       const require = createRequire(import.meta.url);
-      const resolved = require.resolve("@letta-ai/letta-code/letta.js");
+      const resolved = require.resolve("@letta-ai/letta-code");
       if (existsSync(resolved)) {
         return resolved;
       }


### PR DESCRIPTION
## Summary

- Fix `ERR_PACKAGE_PATH_NOT_EXPORTED` when the SDK tries to find the letta-code CLI binary
- `require.resolve("@letta-ai/letta-code/letta.js")` fails because the package's `exports` field doesn't expose the `/letta.js` subpath — only the main `"."` export (which maps to `./letta.js`)
- Changed to `require.resolve("@letta-ai/letta-code")` which resolves the main export correctly
- Added test that verifies the main export resolves and that the subpath does not

👾 Generated with [Letta Code](https://letta.com)