### PR TITLE
fix: add --new flag when creating agent with memory blocks

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -219,6 +219,11 @@ export class SubprocessTransport {
     } else if (this.options.createOnly) {
       // createAgent() - explicitly create new agent
       args.push("--new-agent");
+    } else if (this.options.memory !== undefined && !this.options.agentId) {
+      // createSession() with memory blocks requires new agent + new conversation
+      // Memory blocks can only be set during agent creation with --new-agent
+      args.push("--new-agent");
+      args.push("--new");  // Also create the initial conversation
     } else if (this.options.newConversation) {
       // createSession() without agentId - LRU agent + new conversation
       args.push("--new");


### PR DESCRIPTION
## Problem

When calling `createSession()` with memory blocks but no agent ID, the SDK generates CLI args:
```
--new -m model --memory-blocks [...]
```

This fails with error:
```
Error: --memory-blocks can only be used together with --new to provide initial memory blocks.
```

The CLI requires `--new-agent` to create a new agent when memory blocks are specified, but the SDK only adds `--new`.

## Solution

Add both `--new-agent` (to create the agent) and `--new` (to create the initial conversation) when memory blocks are present.

## Changes

**File:** `src/transport.ts`

Adds a check for memory blocks that generates both flags:
```typescript
} else if (this.options.memory !== undefined && !this.options.agentId) {
  args.push("--new-agent");
  args.push("--new");
}
```

## Test Case

**Before:**
```typescript
createSession(undefined, {
  model: 'gpt-4',
  memory: [{ label: 'persona', value: 'I am helpful' }]
});
// ❌ Error
```

**After:**
```typescript
createSession(undefined, {
  model: 'gpt-4',
  memory: [{ label: 'persona', value: 'I am helpful' }]
});
// ✅ Works - creates agent + conversation with memory blocks
```