### PR TITLE
Handle control approvals without stream consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ for await (const msg of session.stream()) {
 
 By default, `resumeSession(agentId)` continues the agent’s default conversation. To start a fresh thread, use `createSession(agentId)` (see docs).
 
+### Stream buffering
+
+If you do not consume `session.stream()`, the SDK buffers up to `messageQueueSize` messages (default `1000`). When the queue is full, the oldest messages are dropped and a warning is logged with the running `droppedMessageCount`. Configure this via `createSession()`/`createAgent()` options.
+
 ## Links
 
 - Docs: https://docs.letta.com/letta-code-sdk

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,9 @@ export interface InternalSessionOptions {
   permissionMode?: PermissionMode;
   canUseTool?: CanUseToolCallback;
 
+  // Stream message queue settings
+  messageQueueSize?: number;
+
   // Process settings
   cwd?: string;
 }
@@ -178,11 +181,14 @@ export interface CreateSessionOptions {
   /** Permission mode */
   permissionMode?: PermissionMode;
 
-  /** Working directory for the CLI process */
-  cwd?: string;
-
   /** Custom permission callback - called when tool needs approval */
   canUseTool?: CanUseToolCallback;
+
+  /** Max queued SDK messages when stream is not consumed */
+  messageQueueSize?: number;
+
+  /** Working directory for the CLI process */
+  cwd?: string;
 }
 
 /**
@@ -223,11 +229,14 @@ export interface CreateAgentOptions {
   /** Permission mode */
   permissionMode?: PermissionMode;
 
-  /** Working directory for the CLI process */
-  cwd?: string;
-
   /** Custom permission callback - called when tool needs approval */
   canUseTool?: CanUseToolCallback;
+
+  /** Max queued SDK messages when stream is not consumed */
+  messageQueueSize?: number;
+
+  /** Working directory for the CLI process */
+  cwd?: string;
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -47,6 +47,16 @@ function validateSystemPromptPreset(preset: string): void {
 }
 
 /**
+ * Validate message queue size value.
+ */
+function validateMessageQueueSize(size: number | undefined): void {
+  if (size === undefined) return;
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new Error("messageQueueSize must be a positive integer");
+  }
+}
+
+/**
  * Validate CreateSessionOptions (used by createSession and resumeSession).
  */
 export function validateCreateSessionOptions(options: CreateSessionOptions): void {
@@ -54,6 +64,8 @@ export function validateCreateSessionOptions(options: CreateSessionOptions): voi
   if (options.systemPrompt !== undefined) {
     validateSystemPromptPreset(options.systemPrompt);
   }
+
+  validateMessageQueueSize(options.messageQueueSize);
 }
 
 /**
@@ -104,4 +116,6 @@ export function validateCreateAgentOptions(options: CreateAgentOptions): void {
     }
     // If not a preset, it's a custom string - no validation needed
   }
+
+  validateMessageQueueSize(options.messageQueueSize);
 }


### PR DESCRIPTION
Fix SDK approvals when stream isn't consumed; add bounded message queue with eviction logging; restore init messages in stream and add regression tests.