### PR TITLE
feat: expose stop_reason on SDKResultMessage

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -408,12 +408,14 @@ export class Session implements AsyncDisposable {
         duration_ms: number;
         total_cost_usd?: number;
         conversation_id: string;
+        stop_reason?: string;
       };
       return {
         type: "result",
         success: msg.subtype === "success",
         result: msg.result,
         error: msg.subtype !== "success" ? msg.subtype : undefined,
+        stopReason: msg.stop_reason,
         durationMs: msg.duration_ms,
         totalCostUsd: msg.total_cost_usd,
         conversationId: msg.conversation_id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -279,6 +279,7 @@ export interface SDKResultMessage {
   success: boolean;
   result?: string;
   error?: string;
+  stopReason?: string;
   durationMs: number;
   totalCostUsd?: number;
   conversationId: string | null;


### PR DESCRIPTION
## Summary

The wire result message from the CLI includes a `stop_reason` field (e.g. `"requires_approval"`) but `transformMessage()` was silently dropping it. Consumers see `success=false, error="error"` with no way to distinguish approval-blocked runs from generic errors.

### Changes

- Add `stopReason?: string` to `SDKResultMessage` type in `types.ts`
- Pass `stop_reason` through in `session.ts` `transformMessage()`

### Motivation

When lettabot's agent gets stuck on a pending approval (HITL flow), the SDK returns `{ success: false, error: "error" }`. Without `stopReason`, lettabot can't detect this is an approval issue and attempt recovery. With it:

```typescript
if (result.stopReason === 'requires_approval') {
  // Detect and recover from stuck approvals
}
```

Related: SDK issue #25

## Test plan

- [x] `bun run build` passes
- [x] 22 tests pass
- [x] 3 lines added, no breaking changes