### PR TITLE
fix: handle approval_request_message as tool_call in stream

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -607,8 +607,8 @@ export class Session implements AsyncDisposable {
         };
       }
 
-      // Tool call message
-      if (msg.message_type === "tool_call_message") {
+      // Tool call message (tool_call_message = auto-executed, approval_request_message = needs approval)
+      if (msg.message_type === "tool_call_message" || msg.message_type === "approval_request_message") {
         const toolCall = msg.tool_calls?.[0] || msg.tool_call;
         if (toolCall) {
           let toolInput: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- The Letta API emits `approval_request_message` (not `tool_call_message`) for tools that go through the approval flow (Bash, Edit, memory tools, etc.)
- `transformMessage()` only handled `tool_call_message`, so approved tool calls were silently dropped
- SDK consumers never saw `tool_call` events for these tools
- Fix: treat both `tool_call_message` and `approval_request_message` as tool_call events

## Test plan
- [ ] Verify `tsc --noEmit` passes
- [ ] Send a message that triggers a tool needing approval (e.g., memory_rethink)
- [ ] Confirm `tool_call` event appears in the SDK stream
- [ ] Verify auto-executed tools (no approval needed) still emit `tool_call` events

Written by Cameron and Letta Code

"The beginning of wisdom is the definition of terms." -- Socrates