### PR TITLE
feat: add memfs option to createAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ import { createAgent, resumeSession } from "@letta-ai/letta-code-sdk";
 
 const agentId = await createAgent({
   persona: "You are a helpful coding assistant for TypeScript projects.",
+  memfs: true, // Enable git-backed memory filesystem for this new agent
 });
 
 await using session = resumeSession(agentId);

--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -30,6 +30,7 @@ describe("transport args", () => {
     permissionMode?: "default" | "acceptEdits" | "plan" | "bypassPermissions";
     allowedTools?: string[];
     disallowedTools?: string[];
+    memfs?: boolean;
   } = {}): string[] {
     const transport = new SubprocessTransport(options);
     // Access private helper for deterministic argument testing.
@@ -65,5 +66,15 @@ describe("transport args", () => {
     expect(args).toContain("Read,Bash");
     expect(args).toContain("--disallowedTools");
     expect(args).toContain("EnterPlanMode,ExitPlanMode");
+  });
+
+  test("memfs true forwards --memfs", () => {
+    const args = buildArgsFor({ memfs: true });
+    expect(args).toContain("--memfs");
+  });
+
+  test("memfs false/undefined does not forward --memfs", () => {
+    expect(buildArgsFor({ memfs: false })).not.toContain("--memfs");
+    expect(buildArgsFor({})).not.toContain("--memfs");
   });
 });

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -367,6 +367,11 @@ export class SubprocessTransport {
       args.push("--tags", this.options.tags.join(","));
     }
 
+    // Memory filesystem
+    if (this.options.memfs) {
+      args.push("--memfs");
+    }
+
     return args;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,6 +211,9 @@ export interface InternalSessionOptions {
   // Tags (only for new agents)
   tags?: string[];
 
+  // Memory filesystem (only for new agents)
+  memfs?: boolean;
+
   // Permissions
   allowedTools?: string[];
   disallowedTools?: string[];
@@ -318,6 +321,12 @@ export interface CreateAgentOptions {
 
   /** Tags to organize and categorize the agent */
   tags?: string[];
+
+  /**
+   * Enable git-backed memory filesystem for this newly created agent.
+   * Maps to Letta Code CLI `--memfs` during agent creation.
+   */
+  memfs?: boolean;
 }
 
 // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add `memfs?: boolean` to `CreateAgentOptions` and internal session options so SDK callers can opt into memfs at agent creation time
- forward `memfs: true` to the CLI by appending `--memfs` in transport arg construction
- add transport tests for memfs arg forwarding and update README example to show `createAgent({ memfs: true })`

## Test plan
- [x] `bun test --cwd /Users/sarahwooders/repos/letta-code-sdk`
- [x] `bun run --cwd /Users/sarahwooders/repos/letta-code-sdk check`

👾 Generated with [Letta Code](https://letta.com)