### PR TITLE
chore: bump @letta-ai/letta-code to 0.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/letta-ai/letta-code-sdk"
   },
   "dependencies": {
-    "@letta-ai/letta-code": "0.15.3"
+    "@letta-ai/letta-code": "0.15.4"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary
- bump SDK dependency `@letta-ai/letta-code` from `0.15.3` to `0.15.4`
- align `package.json` with the lockfile resolution already on `0.15.4`

## Validation
- `bun test`
- `bun run check`
