### PR TITLE
feat: expose error and retry messages to SDK consumers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ export type {
   SDKReasoningMessage,
   SDKResultMessage,
   SDKStreamEventMessage,
+  SDKErrorMessage,
+  SDKRetryMessage,
   SkillSource,
   SleeptimeOptions,
   SleeptimeTrigger,

--- a/src/session.ts
+++ b/src/session.ts
@@ -726,6 +726,44 @@ export class Session implements AsyncDisposable {
       };
     }
 
+    // Error message — carries the actual error detail from the CLI.
+    // The subsequent type=result only has the opaque string "error";
+    // this message has the human-readable description and API error.
+    if (wireMsg.type === "error") {
+      const msg = wireMsg as WireMessage & {
+        message: string;
+        stop_reason: string;
+        run_id?: string;
+        api_error?: Record<string, unknown>;
+      };
+      return {
+        type: "error" as const,
+        message: msg.message,
+        stopReason: msg.stop_reason,
+        runId: msg.run_id,
+        apiError: msg.api_error,
+      };
+    }
+
+    // Retry message — the CLI is retrying after a transient failure.
+    if (wireMsg.type === "retry") {
+      const msg = wireMsg as WireMessage & {
+        reason: string;
+        attempt: number;
+        max_attempts: number;
+        delay_ms: number;
+        run_id?: string;
+      };
+      return {
+        type: "retry" as const,
+        reason: msg.reason,
+        attempt: msg.attempt,
+        maxAttempts: msg.max_attempts,
+        delayMs: msg.delay_ms,
+        runId: msg.run_id,
+      };
+    }
+
     // Skip other message types (system_message, user_message, etc.)
     return null;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -473,6 +473,41 @@ export interface SDKStreamEventMessage {
   uuid: string;
 }
 
+/**
+ * Error message from the CLI — carries the actual error detail that
+ * would otherwise be lost (the subsequent `type=result` only has
+ * the opaque string "error" as its error field).
+ */
+export interface SDKErrorMessage {
+  type: "error";
+  /** Human-readable error description from the CLI */
+  message: string;
+  /** Why the run stopped (e.g. "error", "llm_api_error", "max_steps") */
+  stopReason: string;
+  /** Run that produced the error, if available */
+  runId?: string;
+  /** Nested Letta API error when the error originated server-side */
+  apiError?: Record<string, unknown>;
+}
+
+/**
+ * Retry message — the CLI is retrying after a transient failure.
+ * Emitted before each retry attempt so consumers can log / display progress.
+ */
+export interface SDKRetryMessage {
+  type: "retry";
+  /** The stop reason that triggered the retry */
+  reason: string;
+  /** Current attempt number (1-based) */
+  attempt: number;
+  /** Maximum attempts before giving up */
+  maxAttempts: number;
+  /** Delay in ms before the next attempt */
+  delayMs: number;
+  /** Run that triggered the retry, if available */
+  runId?: string;
+}
+
 /** Union of all SDK message types */
 export type SDKMessage =
   | SDKInitMessage
@@ -481,7 +516,9 @@ export type SDKMessage =
   | SDKToolResultMessage
   | SDKReasoningMessage
   | SDKResultMessage
-  | SDKStreamEventMessage;
+  | SDKStreamEventMessage
+  | SDKErrorMessage
+  | SDKRetryMessage;
 
 // ═══════════════════════════════════════════════════════════════
 // EXTERNAL TOOL PROTOCOL TYPES


### PR DESCRIPTION
## Summary

- Add `SDKErrorMessage` and `SDKRetryMessage` types to the SDK message union
- Handle `type=error` and `type=retry` wire messages in `transformMessage()` instead of silently dropping them
- Export both new types from the SDK entry point

Previously, when the Letta API returned errors (rate limiting, auth failures, etc.), the SDK dropped the `type=error` wire message that contained the actual error detail (`message`, `stop_reason`, `api_error`). Consumers only saw the subsequent `type=result` with the opaque string `"error"` as both its `error` and `stopReason` fields. Similarly, `type=retry` messages with attempt counts and backoff timing were silently discarded.

Now both message types flow through to consumers, enabling meaningful error display instead of "Agent run failed: error [error]".

## Test plan

- [x] `bun test` -- 47/47 pass
- [x] `bun run build` -- clean
- [x] Tested end-to-end against a 429 rate-limit error on lettabot (Telegram channel). Error message now surfaces actual API error detail to the bot's stream loop.

Written by Cameron and Letta Code

"There are two ways of constructing a software design: One way is to make it so simple that there are obviously no deficiencies, and the other way is to make it so complicated that there are no obvious deficiencies." -- C.A.R. Hoare