### PR TITLE
test: add regression coverage for approval_request_message stream mapping

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -12,6 +12,7 @@ import type {
   SDKInitMessage,
   SDKAssistantMessage,
   SDKResultMessage,
+  MessageWire,
   WireMessage,
   ControlRequest,
   CanUseToolControlRequest,
@@ -669,7 +670,7 @@ export class Session implements AsyncDisposable {
   /**
    * Transform wire message to SDK message
    */
-  private transformMessage(wireMsg: WireMessage): SDKMessage | null {
+  private transformMessage(wireMsg: WireMessage | MessageWire): SDKMessage | null {
     // Init message
     if (wireMsg.type === "system" && "subtype" in wireMsg && wireMsg.subtype === "init") {
       const msg = wireMsg as WireMessage & {


### PR DESCRIPTION
## Summary
- add regression tests in `src/session.test.ts` for `approval_request_message` mapping to SDK `tool_call`
- add coverage for malformed tool arguments fallback (`{ raw: ... }`)
- remove brittle test-cast approach by widening internal `transformMessage` input to accept `MessageWire` (the real stream payload envelope)

## Why
PR #38 fixed runtime handling for approval request messages, but there was no direct test coverage to prevent regressions.

## Validation
- `bun test src/session.test.ts`
- `bun run check`
