### PR TITLE
chore: bump sdk to 0.1.2 and letta-code to 0.16.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/letta-code-sdk",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "SDK for programmatic control of Letta Code CLI",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bump `@letta-ai/letta-code-sdk` version from `0.1.1` to `0.1.2`
- bump `@letta-ai/letta-code` dependency from `0.16.0` to `0.16.4`

## Why
- SDK main now includes `session.listMessages()` and control-response waiter plumbing merged in #48
- `@letta-ai/letta-code@0.16.4` includes the matching headless `list_messages` support needed by SDK consumers

## Validation
- `bun run check`
- `bun test src/tests/list-messages.test.ts`
- `bun test src/tests/transport-args.test.ts`
