### PR TITLE
chore: bump @letta-ai/letta-code to 0.16.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/letta-ai/letta-code-sdk"
   },
   "dependencies": {
-    "@letta-ai/letta-code": "0.16.4"
+    "@letta-ai/letta-code": "0.16.6"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary
- bump `@letta-ai/letta-code` from `0.16.4` to `0.16.6`

## Validation
- `bun install --lockfile-only` resolves successfully against `0.16.6`
- `bun run check` passes