### PR TITLE
fix: accumulate tool_call_message arguments across streaming chunks

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -266,6 +266,39 @@ export class Session implements AsyncDisposable {
       accumulatedArgs: string;
     }>();
 
+    const mergeToolArgs = (existing: string, incoming: string): string => {
+      if (!incoming) return existing;
+      if (!existing) return incoming;
+      if (incoming === existing) return existing;
+
+      // Handle cumulative chunking where the latest chunk already includes prior text.
+      if (incoming.startsWith(existing)) return incoming;
+      if (existing.endsWith(incoming)) return existing;
+
+      // Handle delta chunking where each chunk is an append.
+      return `${existing}${incoming}`;
+    };
+
+    const extractToolCall = (wireMsgAny: Record<string, unknown>) => {
+      const toolCalls = wireMsgAny.tool_calls as Array<{
+        name?: string;
+        arguments?: string;
+        tool_call_id?: string;
+      }> | undefined;
+      const toolCall = wireMsgAny.tool_call as {
+        name?: string;
+        arguments?: string;
+        tool_call_id?: string;
+      } | undefined;
+      const tc = toolCalls?.[0] || toolCall;
+      if (!tc?.tool_call_id) return null;
+      return {
+        id: tc.tool_call_id,
+        name: tc.name ?? "?",
+        args: tc.arguments ?? "",
+      };
+    };
+
     const flushPendingToolCalls = () => {
       for (const [, pending] of pendingToolCalls) {
         // Patch the accumulated arguments into the wire message before transforming
@@ -286,10 +319,15 @@ export class Session implements AsyncDisposable {
     };
 
     for await (const wireMsg of this.transport.messages()) {
+      const wireMsgAny = wireMsg as unknown as Record<string, unknown>;
+
       if (wireMsg.type === "control_request") {
+        // Ensure tool rows/args are visible before any runtime approval callback.
+        if (pendingToolCalls.size > 0) {
+          flushPendingToolCalls();
+        }
         const handled = await this.handleControlRequest(wireMsg as ControlRequest);
         if (!handled) {
-          const wireMsgAny = wireMsg as unknown as Record<string, unknown>;
           sessionLog("pump", `DROPPED unsupported control_request: subtype=${(wireMsgAny.request as Record<string, unknown>)?.subtype || "N/A"}`);
         }
         continue;
@@ -315,28 +353,26 @@ export class Session implements AsyncDisposable {
       // Accumulate tool_call_message arguments across streaming chunks.
       // The CLI sends partial args in each chunk; we concatenate and flush
       // the complete message when a different type arrives.
-      const wireMsgAny = wireMsg as unknown as Record<string, unknown>;
       const messageType = wireMsgAny.message_type as string | undefined;
 
       if (wireMsg.type === "message" && (messageType === "tool_call_message" || messageType === "approval_request_message")) {
-        const toolCalls = wireMsgAny.tool_calls as Array<{ name: string; arguments: string; tool_call_id: string }> | undefined;
-        const toolCall = wireMsgAny.tool_call as { name: string; arguments: string; tool_call_id: string } | undefined;
-        const tc = toolCalls?.[0] || toolCall;
-        const tcId = tc?.tool_call_id;
-
-        if (tcId) {
-          const existing = pendingToolCalls.get(tcId);
+        const toolCall = extractToolCall(wireMsgAny);
+        if (toolCall) {
+          const existing = pendingToolCalls.get(toolCall.id);
           if (existing) {
             // Same tool_call_id: accumulate arguments
-            existing.accumulatedArgs += tc.arguments || "";
-            sessionLog("pump", `tool_call args accumulated for ${tcId}: +${(tc.arguments || "").length} chars`);
+            existing.accumulatedArgs = mergeToolArgs(
+              existing.accumulatedArgs,
+              toolCall.args
+            );
+            sessionLog("pump", `tool_call args accumulated for ${toolCall.id}: +${toolCall.args.length} chars`);
           } else {
             // New tool_call_id: buffer it
-            pendingToolCalls.set(tcId, {
+            pendingToolCalls.set(toolCall.id, {
               wireMsg,
-              accumulatedArgs: tc.arguments || "",
+              accumulatedArgs: toolCall.args,
             });
-            sessionLog("pump", `tool_call buffered: ${tc.name || "?"} id=${tcId}`);
+            sessionLog("pump", `tool_call buffered: ${toolCall.name} id=${toolCall.id}`);
           }
           continue;
         }

--- a/src/tests/tool-call-args-accumulation.test.ts
+++ b/src/tests/tool-call-args-accumulation.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, mock, test } from "bun:test";
+import { Session } from "../session.js";
+import type { WireMessage } from "../types.js";
+
+type FakeTransport = {
+  messages: () => AsyncGenerator<WireMessage>;
+  write: (msg: unknown) => Promise<void>;
+};
+
+function makeFakeTransport(messages: WireMessage[]) {
+  const writes: unknown[] = [];
+  const transport: FakeTransport = {
+    async *messages() {
+      for (const msg of messages) {
+        yield msg;
+      }
+    },
+    async write(msg: unknown) {
+      writes.push(msg);
+    },
+  };
+  return { transport, writes };
+}
+
+function toolChunk(
+  toolCallId: string,
+  args: string,
+  uuid: string,
+  messageType: "tool_call_message" | "approval_request_message" = "tool_call_message"
+): WireMessage {
+  return {
+    type: "message",
+    message_type: messageType,
+    uuid,
+    tool_call: {
+      name: "Bash",
+      arguments: args,
+      tool_call_id: toolCallId,
+    },
+  } as unknown as WireMessage;
+}
+
+function reasoningChunk(uuid: string, text = "done"): WireMessage {
+  return {
+    type: "message",
+    message_type: "reasoning_message",
+    uuid,
+    reasoning: text,
+  } as unknown as WireMessage;
+}
+
+function canUseToolRequest(requestId: string): WireMessage {
+  return {
+    type: "control_request",
+    request_id: requestId,
+    request: {
+      subtype: "can_use_tool",
+      tool_name: "Bash",
+      input: { command: "echo hi" },
+    },
+  } as unknown as WireMessage;
+}
+
+function queuedMessages(session: Session) {
+  return ((session as unknown as { streamQueue: unknown[] }).streamQueue ??
+    []) as Array<Record<string, unknown>>;
+}
+
+describe("tool call argument accumulation", () => {
+  test("accumulates delta chunks and parses final tool input", async () => {
+    const { transport } = makeFakeTransport([
+      toolChunk("tc-1", '{"command":"echo', "msg-1"),
+      toolChunk("tc-1", ' hi"}', "msg-1"),
+      reasoningChunk("msg-2"),
+    ]);
+
+    const session = new Session({ agentId: "agent-test" });
+    (session as unknown as { transport: FakeTransport }).transport = transport;
+
+    await (session as unknown as { runBackgroundPump: () => Promise<void> })
+      .runBackgroundPump();
+
+    const msgs = queuedMessages(session);
+    const toolMsg = msgs.find((m) => m.type === "tool_call");
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg?.toolInput).toEqual({ command: "echo hi" });
+  });
+
+  test("flushes pending tool call before control_request callback runs", async () => {
+    const queueSizesSeenByCallback: number[] = [];
+
+    const canUseTool = mock(() => {
+      queueSizesSeenByCallback.push(
+        queuedMessages(session).filter((m) => m.type === "tool_call").length
+      );
+      return {
+        behavior: "allow" as const,
+        updatedInput: null,
+        updatedPermissions: [],
+      };
+    });
+
+    const { transport, writes } = makeFakeTransport([
+      toolChunk("tc-2", '{"command":"echo', "msg-3"),
+      toolChunk("tc-2", ' hi"}', "msg-3"),
+      canUseToolRequest("can-use-1"),
+      reasoningChunk("msg-4"),
+    ]);
+
+    const session = new Session({
+      agentId: "agent-test",
+      canUseTool,
+    });
+    (session as unknown as { transport: FakeTransport }).transport = transport;
+
+    await (session as unknown as { runBackgroundPump: () => Promise<void> })
+      .runBackgroundPump();
+
+    expect(canUseTool).toHaveBeenCalledTimes(1);
+    expect(queueSizesSeenByCallback[0]).toBe(1);
+    expect(
+      writes.some((w) => {
+        const wire = w as {
+          type?: string;
+          response?: { request_id?: string; subtype?: string };
+        };
+        return (
+          wire.type === "control_response" &&
+          wire.response?.request_id === "can-use-1" &&
+          wire.response?.subtype === "success"
+        );
+      })
+    ).toBe(true);
+  });
+
+  test("handles cumulative chunks without duplicating prior arguments", async () => {
+    const { transport } = makeFakeTransport([
+      toolChunk("tc-3", '{"command":"ec', "msg-5"),
+      toolChunk("tc-3", '{"command":"echo hi"}', "msg-5"),
+      reasoningChunk("msg-6"),
+    ]);
+
+    const session = new Session({ agentId: "agent-test" });
+    (session as unknown as { transport: FakeTransport }).transport = transport;
+
+    await (session as unknown as { runBackgroundPump: () => Promise<void> })
+      .runBackgroundPump();
+
+    const msgs = queuedMessages(session);
+    const toolMsg = msgs.find((m) => m.type === "tool_call");
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg?.toolInput).toEqual({ command: "echo hi" });
+  });
+});


### PR DESCRIPTION
## Summary
- **Bug**: `SDKToolCallMessage.toolInput` was always `{}` (empty object) for tool calls streamed from the CLI
- **Root cause**: The CLI streams `tool_call_message` in chunks with partial `arguments`. The SDK's `transformMessage()` parsed each chunk independently -- `JSON.parse("{}")` on the first chunk yielded `{}`, and subsequent chunks with partial JSON either threw or produced `{ raw: "..." }`
- **Fix**: The background pump now buffers `tool_call_message` chunks by `tool_call_id`, concatenating `arguments` across chunks. The complete message is flushed and transformed when a different message type arrives (e.g., `tool_return_message`, `assistant_message`) or the pump ends

### Before
```
{ type: "tool_call", toolName: "web_search", toolInput: {} }
```

### After
```
{ type: "tool_call", toolName: "web_search", toolInput: { query: "Prime Intellect AI news" } }
```

## Impact
Any SDK consumer that reads `toolInput` now gets the actual arguments. This was discovered while building tool call display in [lettabot](https://github.com/letta-ai/lettabot) -- the display needed to show what arguments tools were called with, but `toolInput` was always empty.

## Test plan
- [x] All 121 existing tests pass (`bun test`)
- [x] Type-check clean (`bun run check`)
- [x] Manual test: linked into lettabot via `npm link`, confirmed `toolInput` now populated for web_search, conversation_search, Bash, and other tools

Written by Cameron and Letta Code

"The best way to predict the future is to invent it." -- Alan Kay