### PR TITLE
feat(types): re-export DiffPreview types from protocol

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,10 @@ export type {
   CanUseToolResponse,
   CanUseToolResponseAllow,
   CanUseToolResponseDeny,
+  // Diff preview types (for approval UI rendering)
+  DiffPreview,
+  DiffHunk,
+  DiffHunkLine,
   // Configuration types
   SystemPromptPresetConfig,
   CreateBlock,


### PR DESCRIPTION
Add DiffPreview, DiffHunk, and DiffHunkLine to the public type re-exports so SDK consumers can type-check approval UI rendering against diff preview payloads.

Requires @letta-ai/letta-code >= next release with feat/diff-preview-protocol changes.

🐾 Generated with [Letta Code](https://letta.com)