### PR TITLE
feat: add remote environment dispatch helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,34 @@ for await (const msg of session.stream()) {
 
 By default, `resumeSession(agentId)` continues the agent’s default conversation. To start a fresh thread, use `createSession(agentId)` (see docs).
 
+
+### Remote environments (ACK-only dispatch)
+
+The SDK can also address a Letta Code remote environment through the Cloud
+remote-environment API. Treat the agent and conversation as the stable actor;
+treat the remote as an execution target that may be online or offline.
+
+```ts
+import { createRemoteAgent } from "@letta-ai/letta-code-sdk";
+
+const agent = createRemoteAgent({
+  apiKey: process.env.LETTA_API_KEY,
+  agentId: "agent-123",
+  conversationId: "conv-456",
+  target: { deviceId: "work-laptop" },
+  fallback: "fail_if_unavailable",
+});
+
+const dispatch = await agent.tell("Pull main, run tests, and summarize failures.");
+console.log(dispatch.connectionId, dispatch.clientMessageId);
+```
+
+Remote dispatch currently acknowledges that the message reached the selected
+Letta Code environment. It does **not** yet stream the final answer through this
+SDK surface. The API is intentionally shaped around stable targets (`deviceId`,
+`environmentId`, `lastUsed`) instead of making application code depend on the
+current ephemeral `connectionId`.
+
 ## Session configuration
 
 The SDK surfaces the same runtime controls as Letta Code CLI for skills, reminders, and sleeptime:

--- a/examples/remote-environments/README.md
+++ b/examples/remote-environments/README.md
@@ -1,0 +1,79 @@
+# Remote Environment Examples
+
+These examples show the remote-agent programming model added in this branch:
+keep the agent/conversation as the stable actor, then target a Letta Code remote
+environment for the turn.
+
+Remote dispatch is currently **ACK-only**. The call confirms that Cloud accepted
+and forwarded the message to the selected online Letta Code environment. It does
+not yet stream the final assistant answer through the SDK.
+
+## Prerequisites
+
+1. Start an online remote environment, for example with `letta server` on the
+   machine you want to target.
+2. Create or choose a Letta agent.
+3. Export the IDs used by the scripts:
+
+```bash
+export LETTA_API_KEY="sk-..."
+export LETTA_AGENT_ID="agent-..."
+
+# Optional. Defaults to the agent's default conversation when omitted.
+export LETTA_CONVERSATION_ID="conv-..."
+
+# Preferred stable target selector.
+export LETTA_REMOTE_DEVICE_ID="device-..."
+
+# Optional if you are using a non-production Cloud API.
+export LETTA_BASE_URL="https://api.letta.com"
+```
+
+If you do not know the remote device ID yet, run:
+
+```bash
+bun examples/remote-environments/list-and-send.ts --list-only
+```
+
+## High-level actor wrapper
+
+Use `createRemoteAgent()` when your application already knows which agent,
+conversation, and environment it wants to target:
+
+```bash
+bun examples/remote-environments/send-to-device.ts \
+  "Pull main, run tests, and summarize failures."
+```
+
+This uses a stable `deviceId` and lets the SDK resolve the current ephemeral
+`connectionId`.
+
+## Last-used environment
+
+If the agent/conversation has a recorded last remote environment, target it with:
+
+```bash
+bun examples/remote-environments/send-to-last-used.ts \
+  "Continue the task on the machine I used last time."
+```
+
+The script falls back to any online environment if the last-used one is offline.
+
+## Lower-level client flow
+
+Use `RemoteEnvironmentClient` directly when you want to list environments, choose
+a target in your own UI, and then dispatch:
+
+```bash
+bun examples/remote-environments/list-and-send.ts \
+  "Run pwd and tell me which repo you are in."
+```
+
+Selectors supported by the helper:
+
+```bash
+export LETTA_REMOTE_DEVICE_ID="device-..."        # stable, preferred
+export LETTA_REMOTE_ENVIRONMENT_ID="env-..."     # stable Cloud environment row
+export LETTA_REMOTE_CONNECTION_NAME="Work Mac"   # user-facing, must be unique
+export LETTA_REMOTE_CONNECTION_ID="conn-..."     # low-level, ephemeral
+```

--- a/examples/remote-environments/list-and-send.ts
+++ b/examples/remote-environments/list-and-send.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+
+/**
+ * Lower-level RemoteEnvironmentClient example.
+ *
+ * Lists remote environments, chooses a target from environment variables, and
+ * dispatches one ACK-only message.
+ *
+ * Required:
+ *   LETTA_API_KEY
+ *   LETTA_AGENT_ID
+ *
+ * Optional selectors, checked in this order:
+ *   LETTA_REMOTE_DEVICE_ID
+ *   LETTA_REMOTE_ENVIRONMENT_ID
+ *   LETTA_REMOTE_CONNECTION_NAME
+ *   LETTA_REMOTE_CONNECTION_ID
+ *
+ * If no selector is provided, the script uses the first online environment.
+ *
+ * Run:
+ *   bun examples/remote-environments/list-and-send.ts --list-only
+ *   bun examples/remote-environments/list-and-send.ts "Run pwd and summarize the repo."
+ */
+
+import {
+  RemoteEnvironmentClient,
+  type RemoteEnvironmentConnection,
+  type RemoteEnvironmentTarget,
+} from '../../src/index.js';
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function targetFromEnv(onlineEnvironments: RemoteEnvironmentConnection[]): RemoteEnvironmentTarget {
+  if (process.env.LETTA_REMOTE_DEVICE_ID) {
+    return { deviceId: process.env.LETTA_REMOTE_DEVICE_ID };
+  }
+  if (process.env.LETTA_REMOTE_ENVIRONMENT_ID) {
+    return { environmentId: process.env.LETTA_REMOTE_ENVIRONMENT_ID };
+  }
+  if (process.env.LETTA_REMOTE_CONNECTION_NAME) {
+    return { connectionName: process.env.LETTA_REMOTE_CONNECTION_NAME };
+  }
+  if (process.env.LETTA_REMOTE_CONNECTION_ID) {
+    return { connectionId: process.env.LETTA_REMOTE_CONNECTION_ID };
+  }
+
+  const firstOnline = onlineEnvironments.find((environment) => environment.connectionId);
+  if (!firstOnline?.connectionId) {
+    throw new Error('No online remote environments found. Start `letta server` first.');
+  }
+
+  return { connectionId: firstOnline.connectionId };
+}
+
+function describeTarget(target: RemoteEnvironmentTarget): string {
+  if ('deviceId' in target) return `deviceId=${target.deviceId}`;
+  if ('environmentId' in target) return `environmentId=${target.environmentId}`;
+  if ('connectionName' in target) return `connectionName=${target.connectionName}`;
+  if ('connectionId' in target) return `connectionId=${target.connectionId}`;
+  return 'lastUsed=true';
+}
+
+const listOnly = process.argv.includes('--list-only');
+const input = process.argv
+  .slice(2)
+  .filter((arg) => arg !== '--list-only')
+  .join(' ') || 'Run pwd and summarize the current working directory.';
+
+const client = new RemoteEnvironmentClient({
+  apiKey: requiredEnv('LETTA_API_KEY'),
+  baseUrl: process.env.LETTA_BASE_URL,
+});
+
+const { connections } = await client.listEnvironments();
+const rows = connections.map((environment) => ({
+  id: environment.id,
+  deviceId: environment.deviceId,
+  connectionName: environment.connectionName,
+  connectionId: environment.connectionId ?? '(offline)',
+  online: Boolean(environment.connectionId),
+  lastSeenAt: new Date(environment.lastSeenAt).toISOString(),
+}));
+
+console.table(rows);
+
+if (listOnly) {
+  process.exit(0);
+}
+
+const target = targetFromEnv(connections);
+console.log(`Dispatching to ${describeTarget(target)}...`);
+
+const dispatch = await client.sendMessage({
+  agentId: requiredEnv('LETTA_AGENT_ID'),
+  conversationId: process.env.LETTA_CONVERSATION_ID,
+  target,
+  input,
+});
+
+console.log('\nMessage dispatched.');
+console.log(`connectionId: ${dispatch.connectionId}`);
+console.log(`clientMessageId: ${dispatch.clientMessageId}`);
+console.log(`ack: ${dispatch.message}`);

--- a/examples/remote-environments/send-to-device.ts
+++ b/examples/remote-environments/send-to-device.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env bun
+
+/**
+ * Send one ACK-only message to a Letta Code remote by stable device ID.
+ *
+ * Required:
+ *   LETTA_API_KEY
+ *   LETTA_AGENT_ID
+ *   LETTA_REMOTE_DEVICE_ID
+ *
+ * Optional:
+ *   LETTA_CONVERSATION_ID (defaults to the agent's default conversation)
+ *   LETTA_BASE_URL        (defaults to https://api.letta.com)
+ *
+ * Run:
+ *   bun examples/remote-environments/send-to-device.ts "Run tests and summarize failures."
+ */
+
+import { createRemoteAgent } from '../../src/index.js';
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+const input = process.argv.slice(2).join(' ') || 'Say hello from this remote environment.';
+
+const remoteAgent = createRemoteAgent({
+  apiKey: requiredEnv('LETTA_API_KEY'),
+  baseUrl: process.env.LETTA_BASE_URL,
+  agentId: requiredEnv('LETTA_AGENT_ID'),
+  conversationId: process.env.LETTA_CONVERSATION_ID,
+  target: { deviceId: requiredEnv('LETTA_REMOTE_DEVICE_ID') },
+  fallback: 'fail_if_unavailable',
+});
+
+const dispatch = await remoteAgent.tell(input);
+
+console.log('Message dispatched to remote environment.');
+console.log(`connectionId: ${dispatch.connectionId}`);
+console.log(`clientMessageId: ${dispatch.clientMessageId}`);
+console.log(`ack: ${dispatch.message}`);
+console.log('\nThis SDK helper is ACK-only today; watch the remote Letta Code session for the response.');

--- a/examples/remote-environments/send-to-last-used.ts
+++ b/examples/remote-environments/send-to-last-used.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+
+/**
+ * Send one ACK-only message to the last environment used by this
+ * agent/conversation, with a fallback to any online environment.
+ *
+ * Required:
+ *   LETTA_API_KEY
+ *   LETTA_AGENT_ID
+ *
+ * Optional:
+ *   LETTA_CONVERSATION_ID (defaults to the agent's default conversation)
+ *   LETTA_BASE_URL        (defaults to https://api.letta.com)
+ *
+ * Run:
+ *   bun examples/remote-environments/send-to-last-used.ts "Continue where we left off."
+ */
+
+import { createRemoteAgent } from '../../src/index.js';
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+const input = process.argv.slice(2).join(' ') || 'Continue the previous remote task and summarize current status.';
+
+const remoteAgent = createRemoteAgent({
+  apiKey: requiredEnv('LETTA_API_KEY'),
+  baseUrl: process.env.LETTA_BASE_URL,
+  agentId: requiredEnv('LETTA_AGENT_ID'),
+  conversationId: process.env.LETTA_CONVERSATION_ID,
+  target: { lastUsed: true },
+  fallback: 'any_online',
+});
+
+const target = await remoteAgent.resolveTarget();
+console.log('Resolved remote target:');
+console.log(`connectionId: ${target.connectionId}`);
+if (target.environment) {
+  console.log(`deviceId: ${target.environment.deviceId}`);
+  console.log(`connectionName: ${target.environment.connectionName}`);
+}
+
+const dispatch = await remoteAgent.tell(input);
+console.log('\nMessage dispatched.');
+console.log(`clientMessageId: ${dispatch.clientMessageId}`);
+console.log(`ack: ${dispatch.message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,26 @@ export type {
 
 export { Session } from "./session.js";
 
+export {
+  RemoteAgent,
+  RemoteEnvironmentClient,
+  createRemoteAgent,
+} from "./remote.js";
+
+export type {
+  RemoteAgentOptions,
+  RemoteEnvironmentClientOptions,
+  RemoteEnvironmentConnection,
+  RemoteEnvironmentFallback,
+  RemoteEnvironmentListResult,
+  RemoteEnvironmentTarget,
+  RemoteMessageDispatchResult,
+  RemoteRuntimeLastEnvironment,
+  ResolvedRemoteEnvironment,
+  ResolveRemoteEnvironmentOptions,
+  SendRemoteMessageOptions,
+} from "./remote.js";
+
 export { extractStreamTextDelta } from "./stream-events.js";
 
 // Tool helpers

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,0 +1,403 @@
+import type { MessageContentItem, SendMessage, TextContent } from "./types.js";
+
+export type RemoteEnvironmentTarget =
+  | { connectionId: string }
+  | { environmentId: string }
+  | { deviceId: string }
+  | { connectionName: string }
+  | { lastUsed: true };
+
+export type RemoteEnvironmentFallback = "fail_if_unavailable" | "any_online";
+
+export interface RemoteEnvironmentClientOptions {
+  /** Letta API base URL. Defaults to https://api.letta.com. */
+  baseUrl?: string;
+  /** Bearer token / API key. Defaults to process.env.LETTA_API_KEY when present. */
+  apiKey?: string;
+  /** Additional headers, e.g. x-project-id. */
+  headers?: Record<string, string>;
+  /** Custom fetch implementation for tests or non-standard runtimes. */
+  fetch?: typeof fetch;
+}
+
+export interface RemoteEnvironmentConnection {
+  id: string;
+  connectionId: string | null;
+  deviceId: string;
+  connectionName: string;
+  organizationId: string;
+  userId?: string;
+  apiKeyOwner?: string;
+  podId: string | null;
+  connectedAt: number | null;
+  lastHeartbeat: number | null;
+  lastSeenAt: number;
+  firstSeenAt: number;
+  currentMode?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RemoteEnvironmentListResult {
+  connections: RemoteEnvironmentConnection[];
+  hasNextPage: boolean;
+}
+
+export interface RemoteRuntimeLastEnvironment {
+  environmentId: string | null;
+  deviceId: string;
+  connectionName: string;
+  metadata: Record<string, unknown> | null;
+  status: "online" | "offline" | "unreachable";
+  isOnline: boolean;
+  lastSeenAt: number | null;
+  lastUsedAt: number;
+  source: "environment" | "sandbox" | "unknown";
+}
+
+export interface ResolvedRemoteEnvironment {
+  connectionId: string;
+  environment?: RemoteEnvironmentConnection;
+  target: RemoteEnvironmentTarget;
+}
+
+export interface ResolveRemoteEnvironmentOptions {
+  agentId?: string;
+  conversationId?: string | null;
+  fallback?: RemoteEnvironmentFallback;
+}
+
+export interface RemoteMessageDispatchResult {
+  success: boolean;
+  message: string;
+  connectionId: string;
+  environment?: RemoteEnvironmentConnection;
+  clientMessageId: string;
+}
+
+export interface SendRemoteMessageOptions extends ResolveRemoteEnvironmentOptions {
+  clientMessageId?: string;
+}
+
+export interface RemoteAgentOptions extends RemoteEnvironmentClientOptions {
+  agentId: string;
+  conversationId?: string | null;
+  target: RemoteEnvironmentTarget;
+  fallback?: RemoteEnvironmentFallback;
+}
+
+type RemoteUserMessage = {
+  role: "user";
+  content: string | TextContent[];
+  client_message_id: string;
+  otid?: string;
+};
+
+type RemoteFetch = typeof fetch;
+
+function getDefaultApiKey(): string | undefined {
+  if (typeof process === "undefined") {
+    return undefined;
+  }
+  return process.env.LETTA_API_KEY;
+}
+
+function createHeaders(options: RemoteEnvironmentClientOptions): Record<string, string> {
+  const apiKey = options.apiKey ?? getDefaultApiKey();
+  return {
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    ...(options.headers ?? {}),
+  };
+}
+
+function getFetch(options: RemoteEnvironmentClientOptions): RemoteFetch {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  if (!fetchImpl) {
+    throw new Error("Remote environments require a fetch implementation");
+  }
+  return fetchImpl.bind(globalThis) as RemoteFetch;
+}
+
+function normalizeBaseUrl(baseUrl?: string): string {
+  return (baseUrl ?? "https://api.letta.com").replace(/\/$/, "");
+}
+
+function isTextContent(item: MessageContentItem): item is TextContent {
+  return item.type === "text";
+}
+
+function toRemoteUserMessage(
+  input: SendMessage,
+  clientMessageId: string,
+): RemoteUserMessage {
+  if (typeof input === "string") {
+    return {
+      role: "user",
+      content: input,
+      client_message_id: clientMessageId,
+      otid: clientMessageId,
+    };
+  }
+
+  const textParts = input.filter(isTextContent);
+  if (textParts.length !== input.length) {
+    throw new Error(
+      "Remote environment messages currently support text content only",
+    );
+  }
+
+  return {
+    role: "user",
+    content: textParts,
+    client_message_id: clientMessageId,
+    otid: clientMessageId,
+  };
+}
+
+function generateClientMessageId(): string {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function ensureOnline(
+  environment: RemoteEnvironmentConnection,
+  target: RemoteEnvironmentTarget,
+): ResolvedRemoteEnvironment {
+  if (!environment.connectionId) {
+    const label =
+      "deviceId" in target
+        ? target.deviceId
+        : "environmentId" in target
+          ? target.environmentId
+          : "connectionName" in target
+            ? target.connectionName
+            : environment.deviceId;
+    throw new Error(`Remote environment is offline: ${label}`);
+  }
+
+  return {
+    connectionId: environment.connectionId,
+    environment,
+    target,
+  };
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  const body = text ? JSON.parse(text) : null;
+
+  if (!response.ok) {
+    const message =
+      body && typeof body === "object" && "message" in body
+        ? String((body as { message: unknown }).message)
+        : response.statusText;
+    throw new Error(`Letta API request failed (${response.status}): ${message}`);
+  }
+
+  return body as T;
+}
+
+/**
+ * Small Cloud API helper for remote Letta Code environments.
+ *
+ * This wraps the currently public environment dispatch primitives. Message
+ * sends are ACK-only: use the returned clientMessageId/run events elsewhere
+ * for live UI once the Cloud remote streaming API is exposed.
+ */
+export class RemoteEnvironmentClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: RemoteFetch;
+
+  constructor(private readonly options: RemoteEnvironmentClientOptions = {}) {
+    this.baseUrl = normalizeBaseUrl(options.baseUrl);
+    this.fetchImpl = getFetch(options);
+  }
+
+  async listEnvironments(query: { onlineOnly?: boolean } = {}): Promise<RemoteEnvironmentListResult> {
+    const url = new URL(`${this.baseUrl}/v1/environments`);
+    if (query.onlineOnly !== undefined) {
+      url.searchParams.set("onlineOnly", String(query.onlineOnly));
+    }
+
+    const response = await this.fetchImpl(url, {
+      headers: createHeaders(this.options),
+    });
+    return parseJsonResponse<RemoteEnvironmentListResult>(response);
+  }
+
+  async getEnvironmentByDeviceId(deviceId: string): Promise<RemoteEnvironmentConnection> {
+    const response = await this.fetchImpl(
+      `${this.baseUrl}/v1/environments/${encodeURIComponent(deviceId)}`,
+      { headers: createHeaders(this.options) },
+    );
+    return parseJsonResponse<RemoteEnvironmentConnection>(response);
+  }
+
+  async getLastEnvironment(params: {
+    agentId: string;
+    conversationId: string;
+  }): Promise<RemoteRuntimeLastEnvironment> {
+    const response = await this.fetchImpl(
+      `${this.baseUrl}/v1/environments/runtimes/${encodeURIComponent(params.agentId)}/${encodeURIComponent(params.conversationId)}/last`,
+      { headers: createHeaders(this.options) },
+    );
+    return parseJsonResponse<RemoteRuntimeLastEnvironment>(response);
+  }
+
+  async resolveEnvironment(
+    target: RemoteEnvironmentTarget,
+    options: ResolveRemoteEnvironmentOptions = {},
+  ): Promise<ResolvedRemoteEnvironment> {
+    if ("connectionId" in target) {
+      return { connectionId: target.connectionId, target };
+    }
+
+    try {
+      if ("deviceId" in target) {
+        return ensureOnline(await this.getEnvironmentByDeviceId(target.deviceId), target);
+      }
+
+      if ("lastUsed" in target) {
+        if (!options.agentId) {
+          throw new Error("agentId is required to resolve last used environment");
+        }
+        const conversationId = options.conversationId ?? "default";
+        const last = await this.getLastEnvironment({
+          agentId: options.agentId,
+          conversationId,
+        });
+        return ensureOnline(await this.getEnvironmentByDeviceId(last.deviceId), target);
+      }
+
+      const { connections } = await this.listEnvironments();
+      if ("environmentId" in target) {
+        const match = connections.find((env) => env.id === target.environmentId);
+        if (!match) {
+          throw new Error(`Remote environment not found: ${target.environmentId}`);
+        }
+        return ensureOnline(match, target);
+      }
+
+      const matches = connections.filter(
+        (env) => env.connectionName === target.connectionName,
+      );
+      if (matches.length === 0) {
+        throw new Error(`Remote environment not found: ${target.connectionName}`);
+      }
+      if (matches.length > 1) {
+        throw new Error(
+          `Remote environment name is ambiguous: ${target.connectionName}`,
+        );
+      }
+      const match = matches[0];
+      if (!match) {
+        throw new Error(`Remote environment not found: ${target.connectionName}`);
+      }
+      return ensureOnline(match, target);
+    } catch (error) {
+      if (options.fallback !== "any_online") {
+        throw error;
+      }
+
+      const { connections } = await this.listEnvironments({ onlineOnly: true });
+      const fallback = connections.find((env) => env.connectionId !== null);
+      if (!fallback?.connectionId) {
+        throw error;
+      }
+
+      return {
+        connectionId: fallback.connectionId,
+        environment: fallback,
+        target,
+      };
+    }
+  }
+
+  async sendMessage(params: {
+    agentId: string;
+    conversationId?: string | null;
+    target: RemoteEnvironmentTarget;
+    input: SendMessage;
+    options?: SendRemoteMessageOptions;
+  }): Promise<RemoteMessageDispatchResult> {
+    const clientMessageId =
+      params.options?.clientMessageId ?? generateClientMessageId();
+    const resolved = await this.resolveEnvironment(params.target, {
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+      fallback: params.options?.fallback,
+    });
+
+    const body = {
+      messages: [toRemoteUserMessage(params.input, clientMessageId)],
+      agentId: params.agentId,
+      conversationId: params.conversationId ?? "default",
+    };
+
+    const response = await this.fetchImpl(
+      `${this.baseUrl}/v1/environments/${encodeURIComponent(resolved.connectionId)}/messages`,
+      {
+        method: "POST",
+        headers: {
+          ...createHeaders(this.options),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    const result = await parseJsonResponse<{ success: boolean; message: string }>(
+      response,
+    );
+
+    return {
+      ...result,
+      connectionId: resolved.connectionId,
+      environment: resolved.environment,
+      clientMessageId,
+    };
+  }
+}
+
+/**
+ * Actor-style convenience wrapper for dispatching turns to a remote environment.
+ *
+ * Today this is a fire-and-forget `tell()` abstraction over the Cloud
+ * environment dispatch endpoint. It intentionally does not pretend to stream a
+ * final answer until Cloud exposes a stable remote run/event API for SDKs.
+ */
+export class RemoteAgent {
+  private readonly client: RemoteEnvironmentClient;
+
+  constructor(private readonly options: RemoteAgentOptions) {
+    this.client = new RemoteEnvironmentClient(options);
+  }
+
+  async tell(
+    input: SendMessage,
+    options: SendRemoteMessageOptions = {},
+  ): Promise<RemoteMessageDispatchResult> {
+    return this.client.sendMessage({
+      agentId: this.options.agentId,
+      conversationId: this.options.conversationId,
+      target: this.options.target,
+      input,
+      options: {
+        fallback: this.options.fallback,
+        ...options,
+      },
+    });
+  }
+
+  async resolveTarget(): Promise<ResolvedRemoteEnvironment> {
+    return this.client.resolveEnvironment(this.options.target, {
+      agentId: this.options.agentId,
+      conversationId: this.options.conversationId,
+      fallback: this.options.fallback,
+    });
+  }
+}
+
+export function createRemoteAgent(options: RemoteAgentOptions): RemoteAgent {
+  return new RemoteAgent(options);
+}

--- a/src/tests/remote.test.ts
+++ b/src/tests/remote.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import {
+  RemoteAgent,
+  RemoteEnvironmentClient,
+  createRemoteAgent,
+} from "../remote.js";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+type FetchInput = Parameters<typeof fetch>[0];
+
+function createFetchMock(
+  handler: (input: FetchInput | URL, init?: RequestInit) => Response,
+): typeof fetch {
+  return ((input: FetchInput | URL, init?: RequestInit) =>
+    Promise.resolve(handler(input, init))) as typeof fetch;
+}
+
+function urlOf(input: FetchInput | URL): string {
+  return input instanceof URL ? input.toString() : String(input);
+}
+
+const onlineEnvironment = {
+  id: "env-1",
+  connectionId: "conn-1",
+  deviceId: "device-1",
+  connectionName: "work-laptop",
+  organizationId: "org-1",
+  podId: "pod-1",
+  connectedAt: 1,
+  lastHeartbeat: 2,
+  lastSeenAt: 3,
+  firstSeenAt: 0,
+};
+
+describe("RemoteEnvironmentClient", () => {
+  test("resolves a stable device id and dispatches an ACK-only remote message", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchMock = createFetchMock((input, init) => {
+      const url = urlOf(input);
+      requests.push({ url, init });
+
+      if (url === "https://api.test/v1/environments/device-1") {
+        return jsonResponse(onlineEnvironment);
+      }
+
+      if (url === "https://api.test/v1/environments/conn-1/messages") {
+        return jsonResponse({ success: true, message: "Message sent to environment" });
+      }
+
+      return jsonResponse({ message: "not found" }, { status: 404 });
+    });
+
+    const client = new RemoteEnvironmentClient({
+      baseUrl: "https://api.test/",
+      apiKey: "sk-test",
+      fetch: fetchMock,
+    });
+
+    const result = await client.sendMessage({
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      target: { deviceId: "device-1" },
+      input: "Run the tests",
+      options: { clientMessageId: "client-msg-1" },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      connectionId: "conn-1",
+      clientMessageId: "client-msg-1",
+    });
+
+    const dispatchRequest = requests[1];
+    expect(dispatchRequest).toBeDefined();
+    expect(dispatchRequest!.init?.method).toBe("POST");
+    expect(dispatchRequest!.init?.headers).toMatchObject({
+      Authorization: "Bearer sk-test",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(dispatchRequest!.init?.body))).toEqual({
+      messages: [
+        {
+          role: "user",
+          content: "Run the tests",
+          client_message_id: "client-msg-1",
+          otid: "client-msg-1",
+        },
+      ],
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    });
+  });
+
+  test("rejects ambiguous connection names instead of guessing", async () => {
+    const fetchMock = createFetchMock(() =>
+      jsonResponse({
+        connections: [
+          onlineEnvironment,
+          { ...onlineEnvironment, id: "env-2", connectionId: "conn-2" },
+        ],
+        hasNextPage: false,
+      }),
+    );
+    const client = new RemoteEnvironmentClient({
+      baseUrl: "https://api.test",
+      fetch: fetchMock,
+    });
+
+    await expect(
+      client.resolveEnvironment({ connectionName: "work-laptop" }),
+    ).rejects.toThrow("Remote environment name is ambiguous");
+  });
+
+  test("can fall back to any online environment when preferred target is unavailable", async () => {
+    const requests: string[] = [];
+    const fetchMock = createFetchMock((input) => {
+      const url = urlOf(input);
+      requests.push(url);
+
+      if (url === "https://api.test/v1/environments/offline-device") {
+        return jsonResponse({ ...onlineEnvironment, connectionId: null });
+      }
+
+      return jsonResponse({
+        connections: [onlineEnvironment],
+        hasNextPage: false,
+      });
+    });
+    const client = new RemoteEnvironmentClient({
+      baseUrl: "https://api.test",
+      fetch: fetchMock,
+    });
+
+    const resolved = await client.resolveEnvironment(
+      { deviceId: "offline-device" },
+      { fallback: "any_online" },
+    );
+
+    expect(resolved.connectionId).toBe("conn-1");
+    expect(requests.at(-1)).toBe("https://api.test/v1/environments?onlineOnly=true");
+  });
+
+  test("rejects image content until the environment endpoint supports it", async () => {
+    const client = new RemoteEnvironmentClient({
+      fetch: createFetchMock(() => jsonResponse(onlineEnvironment)),
+    });
+
+    await expect(
+      client.sendMessage({
+        agentId: "agent-1",
+        target: { connectionId: "conn-1" },
+        input: [
+          { type: "text", text: "What is in this image?" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "abc",
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow("text content only");
+  });
+});
+
+describe("RemoteAgent", () => {
+  test("createRemoteAgent returns the actor-style remote wrapper", () => {
+    const agent = createRemoteAgent({
+      agentId: "agent-1",
+      target: { connectionId: "conn-1" },
+    });
+
+    expect(agent).toBeInstanceOf(RemoteAgent);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a small remote-environment layer to the SDK so application code can treat the agent and conversation as the stable actor while targeting a Letta Code remote environment for execution.

The new `RemoteEnvironmentClient` wraps the existing Cloud environment dispatch primitives: it can list environments, resolve stable selectors such as `deviceId`, `environmentId`, `connectionName`, or `lastUsed`, and then dispatch a user message to the currently online `connectionId`. `RemoteAgent` / `createRemoteAgent` provide the actor-style convenience wrapper discussed in the Slack thread.

This intentionally keeps the current behavior honest: remote sends are ACK-only. They confirm dispatch to the selected environment, but they do not claim to stream the final agent response through this SDK surface yet. The README calls out that limit and the API is shaped so a future remote run/event transport can slot in without forcing users to depend on ephemeral connection IDs.

The PR now also includes runnable examples under `examples/remote-environments/` for the high-level stable device target, last-used environment fallback, and lower-level list-and-send client flow.

## Validation

- `bun run check`
- `bun test`
- `bun run build`
- `bun build examples/remote-environments/send-to-device.ts examples/remote-environments/send-to-last-used.ts examples/remote-environments/list-and-send.ts --target=bun --outdir /tmp/letta-code-sdk-example-build`

## Notes

The implementation rejects image content for remote dispatch for now because the current environment message contract only accepts text content parts. It also refuses ambiguous connection names instead of guessing.

👾 Generated with [Letta Code](https://letta.com)
