### PR TITLE
chore(deps): bump letta-code to 0.26.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/letta-ai/letta-code-sdk"
   },
   "dependencies": {
-    "@letta-ai/letta-code": "0.16.9"
+    "@letta-ai/letta-code": "0.26.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/tests/headless-skills-reminder-contract.test.ts
+++ b/src/tests/headless-skills-reminder-contract.test.ts
@@ -7,8 +7,21 @@ function extractBidirectionalModeSegment(source: string): string {
   const start = source.indexOf("async function runBidirectionalMode(");
   expect(start).toBeGreaterThan(-1);
 
-  const end = source.indexOf("process.exit(0);", start);
-  expect(end).toBeGreaterThan(start);
+  const bodyStart = source.indexOf("{", start);
+  expect(bodyStart).toBeGreaterThan(start);
+
+  let depth = 0;
+  let end = -1;
+  for (let i = bodyStart; i < source.length; i += 1) {
+    const char = source[i];
+    if (char === "{") depth += 1;
+    if (char === "}") depth -= 1;
+    if (depth === 0) {
+      end = i + 1;
+      break;
+    }
+  }
+  expect(end).toBeGreaterThan(bodyStart);
 
   return source.slice(start, end);
 }


### PR DESCRIPTION
## Summary
- Bump `@letta-ai/letta-code` from `0.16.9` to the latest published version, `0.26.2`.
- Tighten the bundled CLI contract test so it extracts only the `runBidirectionalMode` function body for the newer CLI bundle shape.

## Test plan
- [x] `bun test`
- [x] `bun run check`
- [x] `bun run build`

👾 Generated with [Letta Code](https://letta.com)