### PR TITLE
Default SDK-created agents to MemFS with origin tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ import { createAgent, resumeSession } from "@letta-ai/letta-code-sdk";
 
 const agentId = await createAgent({
   persona: "You are a helpful coding assistant for TypeScript projects.",
-  memfs: true, // Enable git-backed memory filesystem for this new agent
 });
 
+// SDK-created agents have MemFS enabled by default and include the
+// origin:letta-code tag. Set memfs: false to explicitly opt out.
 await using session = resumeSession(agentId);
 
 await session.send("Find and fix the bug in auth.ts");

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,15 +102,20 @@ export {
  *
  * @example
  * ```typescript
- * // Create agent with default settings
+ * // Create agent with default settings. SDK-created agents get MemFS
+ * // enabled by default and are tagged with origin:letta-code.
  * const agentId = await createAgent();
  *
  * // Create agent with custom memory
  * const agentId = await createAgent({
  *   memory: ['persona', 'project'],
  *   persona: 'You are a helpful coding assistant',
- *   model: 'claude-sonnet-4'
+ *   model: 'claude-sonnet-4',
+ *   tags: ['project:docs'] // origin:letta-code is added automatically
  * });
+ *
+ * // Explicitly opt out of MemFS
+ * const agentId = await createAgent({ memfs: false });
  *
  * // Then resume the default conversation:
  * const session = resumeSession(agentId);

--- a/src/tests/transport-args.test.ts
+++ b/src/tests/transport-args.test.ts
@@ -234,6 +234,34 @@ describe("buildCliArgs — tools and tags", () => {
     expect(args[idx + 1]).toBe("production,v2");
   });
 
+  test("createOnly adds SDK origin tag", () => {
+    const args = buildCliArgs({ createOnly: true });
+    const idx = args.indexOf("--tags");
+    expect(args[idx + 1]).toBe("origin:letta-code");
+  });
+
+  test("createOnly preserves user tags and adds SDK origin tag", () => {
+    const args = buildCliArgs({ createOnly: true, tags: ["production", "v2"] });
+    const idx = args.indexOf("--tags");
+    const tags = args[idx + 1]!.split(",");
+    expect(tags).toEqual([
+      "production",
+      "v2",
+      "origin:letta-code",
+    ]);
+  });
+
+  test("createOnly does not duplicate SDK origin tag", () => {
+    const args = buildCliArgs({
+      createOnly: true,
+      tags: ["origin:letta-code", "production", "origin:letta-code"],
+    });
+    const idx = args.indexOf("--tags");
+    const tags = args[idx + 1]!.split(",");
+    expect(tags).toEqual(["origin:letta-code", "production"]);
+    expect(tags.filter((tag) => tag === "origin:letta-code")).toHaveLength(1);
+  });
+
   test("empty tags array → no --tags flag", () => {
     const args = buildCliArgs({ tags: [] });
     expect(args).not.toContain("--tags");
@@ -257,9 +285,21 @@ describe("buildCliArgs — memfs", () => {
     expect(args).not.toContain("--memfs");
   });
 
-  test("memfs undefined → neither flag", () => {
+  test("memfs undefined → neither flag when not creating an agent", () => {
     const args = buildCliArgs({});
     expect(args).not.toContain("--memfs");
     expect(args).not.toContain("--no-memfs");
+  });
+
+  test("createOnly defaults memfs to enabled", () => {
+    const args = buildCliArgs({ createOnly: true });
+    expect(args).toContain("--memfs");
+    expect(args).not.toContain("--no-memfs");
+  });
+
+  test("createOnly preserves explicit memfs opt-out", () => {
+    const args = buildCliArgs({ createOnly: true, memfs: false });
+    expect(args).toContain("--no-memfs");
+    expect(args).not.toContain("--memfs");
   });
 });

--- a/src/tests/transport.test.ts
+++ b/src/tests/transport.test.ts
@@ -30,6 +30,8 @@ describe("transport args", () => {
     permissionMode?: "default" | "acceptEdits" | "plan" | "bypassPermissions";
     allowedTools?: string[];
     disallowedTools?: string[];
+    createOnly?: boolean;
+    tags?: string[];
     memfs?: boolean;
     skillSources?: Array<"bundled" | "global" | "agent" | "project">;
     systemInfoReminder?: boolean;
@@ -86,9 +88,36 @@ describe("transport args", () => {
     expect(args).not.toContain("--memfs");
   });
 
-  test("memfs undefined does not forward memfs flags", () => {
+  test("memfs undefined does not forward memfs flags when not creating", () => {
     expect(buildArgsFor({})).not.toContain("--memfs");
     expect(buildArgsFor({})).not.toContain("--no-memfs");
+  });
+
+  test("createOnly defaults memfs to enabled", () => {
+    const args = buildArgsFor({ createOnly: true });
+    expect(args).toContain("--memfs");
+    expect(args).not.toContain("--no-memfs");
+  });
+
+  test("createOnly preserves explicit memfs opt-out", () => {
+    const args = buildArgsFor({ createOnly: true, memfs: false });
+    expect(args).toContain("--no-memfs");
+    expect(args).not.toContain("--memfs");
+  });
+
+  test("createOnly adds origin tag without dropping user tags", () => {
+    const args = buildArgsFor({ createOnly: true, tags: ["production"] });
+    const idx = args.indexOf("--tags");
+    expect(args[idx + 1]).toBe("production,origin:letta-code");
+  });
+
+  test("createOnly does not duplicate origin tag", () => {
+    const args = buildArgsFor({
+      createOnly: true,
+      tags: ["origin:letta-code", "production", "origin:letta-code"],
+    });
+    const idx = args.indexOf("--tags");
+    expect(args[idx + 1]).toBe("origin:letta-code,production");
   });
 
   test("empty skillSources forwards --no-skills", () => {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -13,6 +13,31 @@ function sdkLog(tag: string, ...args: unknown[]) {
   if (process.env.DEBUG_SDK) console.error(`[SDK-Transport] [${tag}]`, ...args);
 }
 
+const SDK_AGENT_ORIGIN_TAG = "origin:letta-code";
+
+function shouldApplyNewAgentDefaults(options: InternalSessionOptions): boolean {
+  return options.createOnly === true;
+}
+
+function includeSdkAgentOriginTag(tags: string[] | undefined): string[] {
+  const normalizedTags: string[] = [];
+  let hasOriginTag = false;
+
+  for (const tag of tags ?? []) {
+    if (tag === SDK_AGENT_ORIGIN_TAG) {
+      if (hasOriginTag) continue;
+      hasOriginTag = true;
+    }
+    normalizedTags.push(tag);
+  }
+
+  if (!hasOriginTag) {
+    normalizedTags.push(SDK_AGENT_ORIGIN_TAG);
+  }
+
+  return normalizedTags;
+}
+
 /**
  * Build the CLI argument array for a given set of session options.
  *
@@ -26,6 +51,7 @@ export function buildCliArgs(options: InternalSessionOptions): string[] {
     "--input-format",
     "stream-json",
   ];
+  const applyNewAgentDefaults = shouldApplyNewAgentDefaults(options);
 
   // Conversation and agent handling
   if (options.conversationId) {
@@ -144,12 +170,18 @@ export function buildCliArgs(options: InternalSessionOptions): string[] {
   }
 
   // Tags
-  if (options.tags && options.tags.length > 0) {
-    args.push("--tags", options.tags.join(","));
+  const tags = applyNewAgentDefaults
+    ? includeSdkAgentOriginTag(options.tags)
+    : options.tags;
+  if (tags && tags.length > 0) {
+    args.push("--tags", tags.join(","));
   }
 
   // Memory filesystem enable/disable
-  if (options.memfs === true) {
+  if (
+    options.memfs === true ||
+    (applyNewAgentDefaults && options.memfs === undefined)
+  ) {
     args.push("--memfs");
   } else if (options.memfs === false) {
     args.push("--no-memfs");

--- a/src/types.ts
+++ b/src/types.ts
@@ -456,12 +456,15 @@ export interface CreateAgentOptions {
    */
   tools?: AnyAgentTool[];
 
-  /** Tags to organize and categorize the agent */
+  /**
+   * Tags to organize and categorize the agent.
+   * SDK-created agents are also tagged with `origin:letta-code` if missing.
+   */
   tags?: string[];
 
   /**
    * Enable git-backed memory filesystem for this newly created agent.
-   * Maps to Letta Code CLI `--memfs` during agent creation.
+   * Defaults to enabled; set false to explicitly opt out during creation.
    */
   memfs?: boolean;
 


### PR DESCRIPTION
## Summary
- In `src/transport.ts`, apply agent-creation defaults on the `createOnly` path so new SDK-created agents pass `--memfs` unless `memfs: false` requests `--no-memfs`.
- Add `origin:letta-code` to SDK-created agent tags while preserving caller tags and keeping the origin tag unique.
- Update `CreateAgentOptions`/README documentation and focused transport argument tests for the new defaults.

## Test plan
- [x] `bun test src/tests/transport-args.test.ts src/tests/transport.test.ts`
- [x] `bun run check`
- [x] `bun test`
- [x] `bun run build`

Attribution: Work requested via Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974).

👾 Generated with [Letta Code](https://letta.com)