### PR TITLE
feat: add LettaCodeClient backend interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,27 +16,42 @@ npm install @letta-ai/letta-code-sdk
 
 ## Quick start
 
-### One-shot prompt
+### Client creation
 
 ```ts
-import { prompt } from "@letta-ai/letta-code-sdk";
+import { LettaCodeClient } from "@letta-ai/letta-code-sdk";
 
-const result = await prompt("What is 2 + 2?");
-console.log(result.result);
+// Local: embedded Letta Code harness, stdio wire. This spawns/manages a
+// subprocess; it is not the same as `remote` + a localhost URL.
+const localClient = new LettaCodeClient({ backend: "local" });
+
+// Remote/cloud are typed placeholders in this release. Construction succeeds,
+// but using them will throw until the transports are implemented.
+const remoteClient = new LettaCodeClient({
+  backend: "remote",
+  url: "wss://up698.railway.com/9123",
+});
+
+const client = new LettaCodeClient({
+  backend: "cloud",
+  environment: { name: "Cameron's MacMini" }, // optional default
+});
 ```
 
 ### Persistent agent with multi-turn conversations
 
 ```ts
-import { createAgent, resumeSession } from "@letta-ai/letta-code-sdk";
+import { LettaCodeClient } from "@letta-ai/letta-code-sdk";
 
-const agentId = await createAgent({
+const client = new LettaCodeClient({ backend: "local" });
+
+const agentId = await client.createAgent({
   persona: "You are a helpful coding assistant for TypeScript projects.",
 });
 
 // SDK-created agents have MemFS enabled by default and include the
 // origin:letta-code tag. Set memfs: false to explicitly opt out.
-await using session = resumeSession(agentId);
+await using session = client.resumeSession(agentId);
 
 await session.send("Find and fix the bug in auth.ts");
 for await (const msg of session.stream()) {
@@ -50,6 +65,18 @@ for await (const msg of session.stream()) {
 ```
 
 By default, `resumeSession(agentId)` continues the agent’s default conversation. To start a fresh thread, use `createSession(agentId)` (see docs).
+
+For cloud/remote backends, `environment` is session-scoped and can override the
+client's default execution target once those backends are implemented:
+
+```ts
+await using session = client.resumeSession(agentId, {
+  environment: { name: "LettaDevelopers" },
+});
+```
+
+The legacy top-level helpers (`createAgent`, `createSession`, `resumeSession`,
+and `prompt`) remain available and use the local subprocess backend.
 
 
 ### Remote environments (ACK-only dispatch)

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,194 @@
+import { Session } from "./session.js";
+import type {
+  CreateAgentOptions,
+  CreateSessionOptions,
+  LettaCodeBackend,
+  LettaCodeClientOptions,
+  LettaCodeClientSessionOptions,
+  LettaCodeEnvironment,
+  SDKResultMessage,
+  SendMessage,
+} from "./types.js";
+import {
+  validateCreateAgentOptions,
+  validateCreateSessionOptions,
+} from "./validation.js";
+
+const VALID_BACKENDS = new Set<LettaCodeBackend>([
+  "local",
+  "remote",
+  "cloud",
+]);
+
+function isLettaCodeBackend(value: string): value is LettaCodeBackend {
+  return VALID_BACKENDS.has(value as LettaCodeBackend);
+}
+
+function getOptionsEnvironment(
+  options: LettaCodeClientOptions,
+): LettaCodeEnvironment | undefined {
+  if ("environment" in options) {
+    return options.environment;
+  }
+  return undefined;
+}
+
+function stripEnvironment(
+  options: LettaCodeClientSessionOptions,
+): CreateSessionOptions {
+  const sessionOptions = { ...options };
+  delete sessionOptions.environment;
+  return sessionOptions;
+}
+
+function hasCreateAgentEnvironment(options: CreateAgentOptions): boolean {
+  return "environment" in (options as Record<string, unknown>);
+}
+
+/**
+ * Top-level Letta Code SDK client.
+ *
+ * `backend` selects how the SDK reaches or runs the Letta Code harness.
+ * The only implemented backend today is `local`, which spawns the bundled
+ * Letta Code CLI subprocess and speaks the existing stdio JSON protocol.
+ * `remote` and `cloud` are typed placeholders for the upcoming app-server /
+ * constellation-backed transports.
+ */
+export class LettaCodeClient {
+  readonly backend: LettaCodeBackend;
+  readonly environment: LettaCodeEnvironment | undefined;
+
+  constructor(options: LettaCodeClientOptions = {}) {
+    const backend = options.backend ?? "local";
+    if (!isLettaCodeBackend(backend)) {
+      throw new Error(
+        `Invalid Letta Code backend '${String(backend)}'. Valid values: local, remote, cloud.`,
+      );
+    }
+
+    this.backend = backend;
+    this.environment = getOptionsEnvironment(options);
+
+    if (this.backend === "local" && this.environment !== undefined) {
+      throw new Error(
+        "LettaCodeClient environment is only valid for remote/cloud backends.",
+      );
+    }
+  }
+
+  /**
+   * Create a new Letta Code agent with a default conversation.
+   *
+   * Environment/device selection is intentionally not part of the agent payload;
+   * it belongs to the client/session execution context.
+   */
+  async createAgent(options: CreateAgentOptions = {}): Promise<string> {
+    this.assertLocalBackend("createAgent");
+    if (hasCreateAgentEnvironment(options)) {
+      throw new Error(
+        "createAgent() does not accept environment. Set a client default or pass environment to resumeSession()/createSession().",
+      );
+    }
+
+    validateCreateAgentOptions(options);
+    const session = new Session({ ...options, createOnly: true });
+    const initMsg = await session.initialize();
+    session.close();
+    return initMsg.agentId;
+  }
+
+  /**
+   * Create a new conversation/session.
+   *
+   * Without an agent id, this uses the default/LRU agent, matching the legacy
+   * top-level createSession() helper.
+   */
+  createSession(
+    agentIdOrOptions?: string | LettaCodeClientSessionOptions,
+    options: LettaCodeClientSessionOptions = {},
+  ): Session {
+    const agentId =
+      typeof agentIdOrOptions === "string" ? agentIdOrOptions : undefined;
+    const resolvedOptions =
+      typeof agentIdOrOptions === "string" ? options : (agentIdOrOptions ?? {});
+
+    this.assertSessionBackend("createSession", resolvedOptions);
+    const sessionOptions = stripEnvironment(resolvedOptions);
+    validateCreateSessionOptions(sessionOptions);
+
+    if (agentId) {
+      return new Session({ ...sessionOptions, agentId, newConversation: true });
+    }
+    return new Session({ ...sessionOptions, newConversation: true });
+  }
+
+  /**
+   * Resume an existing agent default conversation or a specific conversation.
+   *
+   * `options.environment` overrides the client's default execution target for
+   * remote/cloud backends once those transports are implemented.
+   */
+  resumeSession(
+    id: string,
+    options: LettaCodeClientSessionOptions = {},
+  ): Session {
+    this.assertSessionBackend("resumeSession", options);
+    const sessionOptions = stripEnvironment(options);
+    validateCreateSessionOptions(sessionOptions);
+
+    if (id.startsWith("conv-")) {
+      return new Session({ ...sessionOptions, conversationId: id });
+    }
+    return new Session({
+      ...sessionOptions,
+      agentId: id,
+      defaultConversation: true,
+    });
+  }
+
+  /** One-shot prompt convenience helper using a new conversation. */
+  async prompt(
+    message: SendMessage,
+    agentId?: string,
+    options: LettaCodeClientSessionOptions = {},
+  ): Promise<SDKResultMessage> {
+    const session = agentId
+      ? this.createSession(agentId, options)
+      : this.createSession(options);
+
+    try {
+      return await session.runTurn(message);
+    } finally {
+      session.close();
+    }
+  }
+
+  private assertLocalBackend(action: string): void {
+    if (this.backend === "local") {
+      return;
+    }
+
+    throw new Error(
+      `LettaCodeClient backend '${this.backend}' is not implemented yet. ${action} currently supports backend 'local' only.`,
+    );
+  }
+
+  private assertSessionBackend(
+    action: string,
+    options: LettaCodeClientSessionOptions,
+  ): void {
+    const effectiveEnvironment = options.environment ?? this.environment;
+    if (this.backend === "local") {
+      if (effectiveEnvironment !== undefined) {
+        throw new Error(
+          `${action}() environment overrides are only valid for remote/cloud backends.`,
+        );
+      }
+      return;
+    }
+
+    throw new Error(
+      `LettaCodeClient backend '${this.backend}' is not implemented yet. ${action} currently supports backend 'local' only.`,
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,11 @@
  *
  * @example
  * ```typescript
- * import { createAgent, createSession, resumeSession, prompt } from '@letta-ai/letta-code-sdk';
+ * import { LettaCodeClient, createAgent, createSession, resumeSession, prompt } from '@letta-ai/letta-code-sdk';
+ *
+ * const client = new LettaCodeClient({ backend: 'local' });
+ * const agentId = await client.createAgent();
+ * const clientSession = client.resumeSession(agentId);
  *
  * // Start session with default agent + new conversation (like `letta`)
  * const session = createSession();
@@ -36,6 +40,13 @@ import { validateCreateSessionOptions, validateCreateAgentOptions } from "./vali
 export type {
   CreateSessionOptions,
   CreateAgentOptions,
+  LettaCodeBackend,
+  LettaCodeEnvironment,
+  LettaCodeLocalClientOptions,
+  LettaCodeRemoteClientOptions,
+  LettaCodeCloudClientOptions,
+  LettaCodeClientOptions,
+  LettaCodeClientSessionOptions,
   SDKMessage,
   SDKInitMessage,
   SDKAssistantMessage,
@@ -84,6 +95,7 @@ export type {
 } from "./types.js";
 
 export { Session } from "./session.js";
+export { LettaCodeClient } from "./client.js";
 
 export {
   RemoteAgent,

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { LettaCodeClient, Session } from "../index.js";
+
+describe("LettaCodeClient", () => {
+  test("defaults to the implemented local backend", () => {
+    const client = new LettaCodeClient();
+
+    expect(client.backend).toBe("local");
+    expect(client.environment).toBeUndefined();
+  });
+
+  test("creates local sessions without starting the subprocess until use", () => {
+    const client = new LettaCodeClient({ backend: "local" });
+    const session = client.resumeSession("agent-123");
+
+    try {
+      expect(session).toBeInstanceOf(Session);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("rejects environment overrides on local sessions", () => {
+    const client = new LettaCodeClient({ backend: "local" });
+
+    expect(() =>
+      client.resumeSession("agent-123", { environment: "work-laptop" }),
+    ).toThrow("environment overrides are only valid for remote/cloud backends");
+  });
+
+  test("keeps remote and cloud backend construction as typed placeholders", () => {
+    const remoteClient = new LettaCodeClient({
+      backend: "remote",
+      url: "wss://example.com/ws",
+    });
+    const cloudClient = new LettaCodeClient({
+      backend: "cloud",
+      environment: { name: "LettaDevelopers" },
+    });
+
+    expect(remoteClient.backend).toBe("remote");
+    expect(cloudClient.backend).toBe("cloud");
+    expect(cloudClient.environment).toEqual({ name: "LettaDevelopers" });
+  });
+
+  test("throws a clear placeholder error when non-local backends are used", () => {
+    const client = new LettaCodeClient({
+      backend: "cloud",
+      environment: "LettaDevelopers",
+    });
+
+    expect(() => client.resumeSession("agent-123")).toThrow(
+      "backend 'cloud' is not implemented yet",
+    );
+  });
+
+  test("keeps environment out of createAgent payloads", async () => {
+    const client = new LettaCodeClient({ backend: "local" });
+
+    await expect(
+      client.createAgent({ environment: "work-laptop" } as never),
+    ).rejects.toThrow("createAgent() does not accept environment");
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,55 @@ export interface AgentTool<TParams, TResult> {
 export type AnyAgentTool = AgentTool<any, unknown>;
 
 // ═══════════════════════════════════════════════════════════════
+// TOP-LEVEL CLIENT TYPES
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * How the SDK reaches or runs the Letta Code harness.
+ *
+ * - local: spawn/manage a local Letta Code subprocess and speak stdio.
+ * - remote: connect to a user-managed app-server. Placeholder for now.
+ * - cloud: connect through Letta Cloud/Constellation. Placeholder for now.
+ */
+export type LettaCodeBackend = "local" | "remote" | "cloud";
+
+/**
+ * Stable execution target for remote/cloud runtimes.
+ *
+ * Strings are treated as human-readable environment names. Object forms allow
+ * callers to avoid relying on names as unique identifiers once backend support
+ * is implemented.
+ */
+export type LettaCodeEnvironment = string | { name: string } | { id: string };
+
+export interface LettaCodeLocalClientOptions {
+  backend?: "local";
+}
+
+export interface LettaCodeRemoteClientOptions {
+  backend: "remote";
+  /** URL of the user-managed app-server / websocket endpoint. */
+  url: string;
+  /** Optional default execution target, overridable at session creation. */
+  environment?: LettaCodeEnvironment;
+}
+
+export interface LettaCodeCloudClientOptions {
+  backend: "cloud";
+  /** Optional API key override. Defaults to LETTA_API_KEY / existing auth. */
+  apiKey?: string;
+  /** Optional API base URL override. Defaults to Letta Cloud. */
+  apiBaseUrl?: string;
+  /** Optional default execution target, overridable at session creation. */
+  environment?: LettaCodeEnvironment;
+}
+
+export type LettaCodeClientOptions =
+  | LettaCodeLocalClientOptions
+  | LettaCodeRemoteClientOptions
+  | LettaCodeCloudClientOptions;
+
+// ═══════════════════════════════════════════════════════════════
 // SESSION OPTIONS
 // ═══════════════════════════════════════════════════════════════
 
@@ -401,6 +450,16 @@ export interface CreateSessionOptions {
    * Maps to the CLI --memfs-startup flag.
    */
   memfsStartup?: "blocking" | "background" | "skip";
+}
+
+/**
+ * Session options accepted by LettaCodeClient methods.
+ *
+ * `environment` is a remote/cloud execution-target override. It is deliberately
+ * session-scoped rather than part of createAgent() options.
+ */
+export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
+  environment?: LettaCodeEnvironment;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Introduce the client-first `LettaCodeClient` public surface.
- Keep legacy top-level helpers unchanged on the local subprocess backend.
- Add typed `local` / `remote` / `cloud` backend options, with remote/cloud initially guarded behind clear placeholder errors.
- Keep `environment` scoped to client/session execution context rather than agent creation payloads.

## Stack
- Base: #140 / LET-9236 (`@letta-ai/letta-code` 0.27.11)
- This PR: LET-9239
- Next: LET-9237 remote backend
- Next: LET-9238 cloud backend

Linear: LET-9239

## Test plan
- `bun run check`
- `bun test`