### PR TITLE
feat: support remote app-server auth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ const legacyLocalClient = new LettaCodeClient({
 const remoteClient = new LettaCodeClient({
   backend: "remote",
   url: "http://127.0.0.1:4500",
+  // Required when the app-server is bound to a non-loopback interface with
+  // --ws-auth capability-token.
+  authToken: process.env.LETTA_APP_SERVER_TOKEN,
 });
 
 // Cloud remains a typed placeholder in this release. Construction succeeds,
@@ -98,6 +101,7 @@ and SDK-defined external tools.
 const client = new LettaCodeClient({
   backend: "remote",
   url: "http://127.0.0.1:4500",
+  authToken: process.env.LETTA_APP_SERVER_TOKEN,
   requestTimeoutMs: 120_000,
 });
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/letta-ai/letta-code-sdk"
   },
   "dependencies": {
-    "@letta-ai/letta-code": "0.27.12"
+    "@letta-ai/letta-code": "0.27.13"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -457,6 +457,9 @@ export class AppServerSession implements LettaCodeSession {
 
     this.client = createAppServerClient({
       url,
+      ...(this.remoteOptions.authToken !== undefined
+        ? { authToken: this.remoteOptions.authToken }
+        : {}),
       ...(this.remoteOptions.WebSocket
         ? { WebSocket: this.remoteOptions.WebSocket as AppServerSocketConstructor }
         : {}),

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -31,7 +31,10 @@ class FakeAppServerSocket {
   sent: unknown[] = [];
   private listeners = new Map<string, Set<Listener>>();
 
-  constructor(readonly url: string) {
+  constructor(
+    readonly url: string,
+    readonly options?: { headers?: Record<string, string> },
+  ) {
     FakeAppServerSocket.instances.push(this);
     queueMicrotask(() => {
       this.readyState = 1;
@@ -406,6 +409,30 @@ describe("LettaCodeClient", () => {
     expect(remoteClient.backend).toBe("remote");
     expect(cloudClient.backend).toBe("cloud");
     expect(cloudClient.environment).toEqual({ name: "LettaDevelopers" });
+  });
+
+  test("passes remote auth tokens to app-server websocket upgrades", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaCodeClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      authToken: " super-secret-token\n",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.createSession("agent-123");
+    try {
+      await session.initialize();
+
+      expect(fakeControlSocket().options).toEqual({
+        headers: { Authorization: "Bearer super-secret-token" },
+      });
+      expect(fakeStreamSocket().options).toEqual({
+        headers: { Authorization: "Bearer super-secret-token" },
+      });
+    } finally {
+      session.close();
+    }
   });
 
   test("throws a clear placeholder error when non-local backends are used", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,14 @@ export interface LettaCodeSocketLike {
   once?(type: string, listener: (event: unknown) => void): void;
 }
 
-export type LettaCodeSocketConstructor = new (url: string) => LettaCodeSocketLike;
+export interface LettaCodeSocketOptions {
+  headers?: Record<string, string>;
+}
+
+export type LettaCodeSocketConstructor = new (
+  url: string,
+  options?: LettaCodeSocketOptions,
+) => LettaCodeSocketLike;
 
 // ═══════════════════════════════════════════════════════════════
 // MESSAGE CONTENT TYPES (for multimodal support)
@@ -300,6 +307,8 @@ export interface LettaCodeRemoteClientOptions {
   backend: "remote";
   /** URL of the user-managed app-server / websocket endpoint. */
   url: string;
+  /** Optional capability token sent as Authorization: Bearer <token> during websocket upgrade. */
+  authToken?: string;
   /** Optional WebSocket constructor for non-browser runtimes and tests. */
   WebSocket?: LettaCodeSocketConstructor;
   /** Timeout for app-server request/turn correlation. Defaults to app-server client default. */


### PR DESCRIPTION
## Summary
- Bump `@letta-ai/letta-code` to `0.27.13` for the app-server websocket auth client support from letta-ai/letta-code#3008 / LET-9244.
- Add `authToken` to the SDK `backend: "remote"` options and forward it to `createAppServerClient` so remote app-server websocket upgrades send `Authorization: Bearer <token>`.
- Document the `authToken` option in the remote backend examples and add a regression test that both control and stream sockets receive the header.

## Linear
- LET-9236
- LET-9244

## Test plan
- `bun test src/tests/client.test.ts`
- `bun run check`
- `bun test`
- `bun run build`

👾 Generated with [Letta Code](https://letta.com)