### PR TITLE
feat: Add SDK-managed sandbox lifecycle for Constellation agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,11 @@ const remoteClient = new LettaCodeClient({
   authToken: process.env.LETTA_APP_SERVER_TOKEN,
 });
 
-// Cloud: control an explicit Letta Cloud remote environment over the
-// Remote Client websocket protocol. SDK-managed sandboxes are a fast follow.
+// Cloud: create or resume Cloud-hosted agents and run turns in an
+// SDK-managed sandbox by default.
 const client = new LettaCodeClient({
   backend: "cloud",
   apiKey: process.env.LETTA_API_KEY,
-  environment: { connectionId: process.env.LETTA_ENVIRONMENT_CONNECTION_ID! },
 });
 ```
 
@@ -70,8 +69,9 @@ for await (const msg of session.stream()) {
 
 By default, `resumeSession(agentId)` continues the agent’s default conversation. To start a fresh thread, use `createSession(agentId)` (see docs). App-server sessions require an explicit agent id; default/LRU local-agent selection (`createSession()` with no agent id) remains available through the legacy local stdio fallback.
 
-For cloud backends, `environment` is session-scoped and can override the
-client default. Remote app-server URLs already select their runtime:
+For cloud backends, omitting `environment` lets the SDK create and manage a
+Cloud sandbox for the session. `environment` is still session-scoped and can
+override the client default when you want to use a specific remote runtime:
 
 ```ts
 await using session = client.resumeSession(agentId, {
@@ -114,19 +114,24 @@ for await (const msg of session.stream()) {
 ### Letta Cloud backend
 
 Use `backend: "cloud"` to create or resume Cloud-hosted agents while running
-turns in an explicit Letta Cloud remote environment. The current SDK requires
-callers to supply `environment`; SDK-managed Cloud sandbox lifecycle is not yet
-available. Once connected, the SDK uses the Remote Client
-websocket protocol for
-`sync`, `input/create_message`, streaming deltas, approval responses, model
-updates, toolset updates, cwd/mode device-state updates, and heartbeats.
+turns through the Remote Client websocket protocol. If no `environment` is
+provided, the SDK creates an agent-scoped Cloud sandbox, waits for its remote
+environment connection, refreshes its TTL while the session is active, and
+best-effort terminates it on close. Once connected, the SDK uses the Remote
+Client protocol for `sync`, `input/create_message`, streaming deltas, approval
+responses, model updates, toolset updates, cwd/mode device-state updates, and
+heartbeats.
 
 ```ts
 const client = new LettaCodeClient({
   backend: "cloud",
   apiKey: process.env.LETTA_API_KEY,
-  // Required until SDK-managed Cloud sandboxes land.
-  environment: { connectionId: process.env.LETTA_ENVIRONMENT_CONNECTION_ID! },
+  sandbox: {
+    // Optional: defaults to Cloud's 5-minute refresh TTL.
+    ttlMinutes: 5,
+    // Optional: defaults true. Set false for concurrent same-agent sessions.
+    terminateOnClose: true,
+  },
 });
 
 const agentId = await client.createAgent({
@@ -146,7 +151,8 @@ for await (const msg of session.stream()) {
 }
 ```
 
-You can set a default `environment` on the client or override it per session:
+You can still set a default `environment` on the client or override it per
+session to use an existing remote runtime instead of an SDK-managed sandbox:
 
 ```ts
 const client = new LettaCodeClient({
@@ -160,8 +166,11 @@ await using session = client.resumeSession(agentId, {
 });
 ```
 
-SDK-managed Cloud sandbox lifecycle is not yet exposed by this SDK path. Passing
-legacy `sandbox` options fails fast; pass an explicit `environment` instead.
+`environment` and `sandbox` are mutually exclusive. Managed sandbox refresh and
+termination use Cloud's agent-scoped sandbox routes, which operate on the latest
+active sandbox for an agent; set `sandbox.terminateOnClose: false` when multiple
+SDK sessions may run concurrently against the same agent and rely on TTL cleanup
+instead.
 
 By default, websocket authentication uses `Authorization` headers. Set
 `webSocketAuth: "query"` for browser-style websocket clients that cannot send

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ const agentId = await client.createAgent({
   persona: "You are a helpful coding assistant for TypeScript projects.",
 });
 
-// SDK-created agents always use MemFS and include the origin:letta-code tag.
 await using session = client.resumeSession(agentId);
 
 await session.send("Find and fix the bug in auth.ts");
@@ -67,7 +66,8 @@ for await (const msg of session.stream()) {
 }
 ```
 
-By default, `resumeSession(agentId)` continues the agent’s default conversation. To start a fresh thread, use `createSession(agentId)` (see docs). App-server sessions require an explicit agent id; default/LRU local-agent selection (`createSession()` with no agent id) remains available through the legacy local stdio fallback.
+By default, `resumeSession(agentId)` continues the agent’s default conversation.
+Use `createSession(agentId)` when you want to start a fresh thread.
 
 For cloud backends, omitting `environment` lets the SDK create and manage a
 Cloud sandbox for the session. `environment` is still session-scoped and can
@@ -115,12 +115,8 @@ for await (const msg of session.stream()) {
 
 Use `backend: "cloud"` to create or resume Cloud-hosted agents while running
 turns through the Remote Client websocket protocol. If no `environment` is
-provided, the SDK creates an agent-scoped Cloud sandbox, waits for its remote
-environment connection, refreshes its TTL while the session is active, and
-best-effort terminates it on close. Once connected, the SDK uses the Remote
-Client protocol for `sync`, `input/create_message`, streaming deltas, approval
-responses, model updates, toolset updates, cwd/mode device-state updates, and
-heartbeats.
+provided, the SDK creates an agent-scoped Cloud sandbox, waits for it to come
+online, refreshes it while the session is active, and cleans it up on close.
 
 ```ts
 const client = new LettaCodeClient({
@@ -180,16 +176,9 @@ custom upgrade headers.
 
 ## Session configuration
 
-App-server and Cloud sessions use the remote/listener protocol for runtime
-settings that are applied when the session starts, including `model`,
-sleeptime trigger settings, `cwd`, and `permissionMode`. A broader runtime
-controls surface for changing settings on an active session is intentionally
-left to a later typed design. MemFS is enabled for SDK-created agents and is
-not configurable through SDK options.
-CLI-only flags such as `skillSources`, `systemInfoReminder`,
-`sleeptime.behavior`, and partial-message toggles are rejected on
-app-server/Cloud sessions until those controls are wired through the remote
-protocol.
+Session options let you set runtime defaults before a session starts, including
+`model`, `cwd`, `permissionMode`, and sleeptime triggers. For remote and Cloud
+sessions, `cwd` must be a path inside the selected runtime environment.
 
 ```ts
 import { LettaCodeClient } from "@letta-ai/letta-code-sdk";

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ const remoteClient = new LettaCodeClient({
   authToken: process.env.LETTA_APP_SERVER_TOKEN,
 });
 
-// Cloud: create or resume Cloud-hosted agents and run turns in an
-// SDK-managed sandbox by default.
+// Constellation: create or resume agents whose state lives in Letta's
+// agent cloud, with an SDK-managed sandbox by default.
 const client = new LettaCodeClient({
   backend: "cloud",
   apiKey: process.env.LETTA_API_KEY,
@@ -69,8 +69,8 @@ for await (const msg of session.stream()) {
 By default, `resumeSession(agentId)` continues the agent’s default conversation.
 Use `createSession(agentId)` when you want to start a fresh thread.
 
-For cloud backends, omitting `environment` lets the SDK create and manage a
-Cloud sandbox for the session. `environment` is still session-scoped and can
+For Constellation agents, omitting `environment` lets the SDK create and manage
+a sandbox for the session. `environment` is still session-scoped and can
 override the client default when you want to use a specific remote runtime:
 
 ```ts
@@ -111,19 +111,19 @@ for await (const msg of session.stream()) {
 ```
 
 
-### Letta Cloud backend
+### Constellation
 
-Use `backend: "cloud"` to create or resume Cloud-hosted agents while running
-turns through the Remote Client websocket protocol. If no `environment` is
-provided, the SDK creates an agent-scoped Cloud sandbox, waits for it to come
-online, refreshes it while the session is active, and cleans it up on close.
+Use `backend: "cloud"` to create or resume agents hosted on Constellation. If
+no `environment` is provided, the SDK creates an agent-scoped sandbox, waits for
+it to come online, refreshes it while the session is active, and cleans it up on
+close.
 
 ```ts
 const client = new LettaCodeClient({
   backend: "cloud",
   apiKey: process.env.LETTA_API_KEY,
   sandbox: {
-    // Optional: defaults to Cloud's 5-minute refresh TTL.
+    // Optional: defaults to a 5-minute refresh TTL.
     ttlMinutes: 5,
     // Optional: defaults true. Set false for concurrent same-agent sessions.
     terminateOnClose: true,
@@ -145,9 +145,9 @@ for await (const msg of session.stream()) {
 }
 ```
 
-If you pass `cwd` for a Cloud session, use a path that exists inside the selected
-remote environment or managed sandbox. Local paths such as `process.cwd()` are
-not mapped into Cloud sandboxes automatically.
+If you pass `cwd` for a Constellation session, use a path that exists inside the
+selected remote environment or managed sandbox. Local paths such as
+`process.cwd()` are not mapped into managed sandboxes automatically.
 
 You can still set a default `environment` on the client or override it per
 session to use an existing remote runtime instead of an SDK-managed sandbox:
@@ -165,10 +165,9 @@ await using session = client.resumeSession(agentId, {
 ```
 
 `environment` and `sandbox` are mutually exclusive. Managed sandbox refresh and
-termination use Cloud's agent-scoped sandbox routes, which operate on the latest
-active sandbox for an agent; set `sandbox.terminateOnClose: false` when multiple
-SDK sessions may run concurrently against the same agent and rely on TTL cleanup
-instead.
+termination operate on the latest active sandbox for an agent; set
+`sandbox.terminateOnClose: false` when multiple SDK sessions may run
+concurrently against the same agent and rely on TTL cleanup instead.
 
 By default, websocket authentication uses `Authorization` headers. Set
 `webSocketAuth: "query"` for browser-style websocket clients that cannot send
@@ -177,8 +176,9 @@ custom upgrade headers.
 ## Session configuration
 
 Session options let you set runtime defaults before a session starts, including
-`model`, `cwd`, `permissionMode`, and sleeptime triggers. For remote and Cloud
-sessions, `cwd` must be a path inside the selected runtime environment.
+`model`, `cwd`, `permissionMode`, and sleeptime triggers. For remote and
+Constellation sessions, `cwd` must be a path inside the selected runtime
+environment.
 
 ```ts
 import { LettaCodeClient } from "@letta-ai/letta-code-sdk";
@@ -187,8 +187,8 @@ const client = new LettaCodeClient({ backend: "local" });
 
 const session = client.resumeSession("agent-123", {
   model: "anthropic/claude-sonnet-4",
-  // For local sessions this may be a local path; for remote/Cloud sessions,
-  // use a path inside the selected runtime environment.
+  // For local sessions this may be a local path; for remote/Constellation
+  // sessions, use a path inside the selected runtime environment.
   cwd: "/workspace/project",
   permissionMode: "bypassPermissions",
   sleeptime: {

--- a/README.md
+++ b/README.md
@@ -140,8 +140,6 @@ const agentId = await client.createAgent({
 });
 
 await using session = client.resumeSession(agentId, {
-  // Paths are resolved inside the remote environment, not on the caller machine.
-  cwd: "/workspace/project",
   permissionMode: "bypassPermissions",
 });
 
@@ -150,6 +148,10 @@ for await (const msg of session.stream()) {
   if (msg.type === "assistant") console.log(msg.content);
 }
 ```
+
+If you pass `cwd` for a Cloud session, use a path that exists inside the selected
+remote environment or managed sandbox. Local paths such as `process.cwd()` are
+not mapped into Cloud sandboxes automatically.
 
 You can still set a default `environment` on the client or override it per
 session to use an existing remote runtime instead of an SDK-managed sandbox:

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -172,7 +172,7 @@ export function assertRemoteSessionOptionsSupported(
     throw new Error(`App-server ${action}() does not yet support sleeptime.behavior overrides.`);
   }
   if ((options as { memfsStartup?: unknown }).memfsStartup !== undefined) {
-    throw new Error(`App-server ${action}() does not use memfsStartup; app-server owns its startup synchronization.`);
+    throw new Error(`App-server ${action}() does not support memfsStartup.`);
   }
   if (options.includePartialMessages !== undefined) {
     throw new Error(`App-server ${action}() streams app-server deltas directly and does not support includePartialMessages.`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,11 +47,12 @@ function getOptionsEnvironment(
   return undefined;
 }
 
-function stripEnvironment(
+function stripCloudExecutionOptions(
   options: LettaCodeClientSessionOptions,
 ): CreateSessionOptions {
   const sessionOptions = { ...options };
   delete sessionOptions.environment;
+  delete sessionOptions.sandbox;
   return sessionOptions;
 }
 
@@ -103,6 +104,9 @@ export class LettaCodeClient {
       throw new Error(
         "LettaCodeClient environment is only valid for the cloud backend; remote url selects the app-server runtime.",
       );
+    }
+    if (this.backend !== "cloud" && (options as { sandbox?: unknown }).sandbox !== undefined) {
+      throw new Error("LettaCodeClient sandbox options are only valid for cloud backends.");
     }
 
     if (this.backend === "local") {
@@ -206,7 +210,7 @@ export class LettaCodeClient {
       typeof agentIdOrOptions === "string" ? options : (agentIdOrOptions ?? {});
 
     this.assertSessionBackend("createSession", resolvedOptions);
-    const sessionOptions = stripEnvironment(resolvedOptions);
+    const sessionOptions = stripCloudExecutionOptions(resolvedOptions);
     validateCreateSessionOptions(sessionOptions);
 
     if (this.backend === "remote") {
@@ -260,7 +264,7 @@ export class LettaCodeClient {
     options: LettaCodeClientSessionOptions = {},
   ): LettaCodeSession {
     this.assertSessionBackend("resumeSession", options);
-    const sessionOptions = stripEnvironment(options);
+    const sessionOptions = stripCloudExecutionOptions(options);
     validateCreateSessionOptions(sessionOptions);
 
     if (this.backend === "remote") {
@@ -356,6 +360,9 @@ export class LettaCodeClient {
           `${action}() environment overrides are only valid for cloud backends.`,
         );
       }
+      if (options.sandbox !== undefined) {
+        throw new Error(`${action}() sandbox options are only valid for cloud backends.`);
+      }
       if (!this.useLegacyLocalStdio()) {
         assertRemoteSessionOptionsSupported(action, options);
       }
@@ -368,10 +375,20 @@ export class LettaCodeClient {
           `${action}() environment overrides are only valid for cloud backends; remote url selects the app-server runtime.`,
         );
       }
+      if (options.sandbox !== undefined) {
+        throw new Error(`${action}() sandbox options are only valid for cloud backends; remote url selects the app-server runtime.`);
+      }
       assertRemoteSessionOptionsSupported(action, options);
       return;
     }
     if (this.backend === "cloud") {
+      const cloudOptions = this.cloudOptions();
+      if (cloudOptions.environment !== undefined && options.sandbox !== undefined) {
+        throw new Error(`Cloud backend ${action}() cannot specify sandbox options when the client has a default environment.`);
+      }
+      if (cloudOptions.sandbox !== undefined && options.environment !== undefined) {
+        throw new Error(`Cloud backend ${action}() cannot specify an environment when the client has default sandbox options.`);
+      }
       assertCloudSessionOptionsSupported(action, options);
       return;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -75,8 +75,8 @@ type TurnSession = LettaCodeSession & {
  * `local` spawns an SDK-owned Letta Code app-server and speaks the websocket
  * protocol by default, with an explicit stdio fallback for legacy flows.
  * `remote` connects to a user-managed Letta Code app-server websocket endpoint.
- * `cloud` connects to an explicit Letta Cloud remote environment and controls
- * it over the Remote Client websocket protocol.
+ * `cloud` uses agents hosted on Constellation, with an explicit remote
+ * environment or SDK-managed sandbox.
  */
 export class LettaCodeClient {
   readonly backend: LettaCodeBackend;
@@ -97,16 +97,16 @@ export class LettaCodeClient {
 
     if (this.backend === "local" && this.environment !== undefined) {
       throw new Error(
-        "LettaCodeClient environment is only valid for cloud backends.",
+        'LettaCodeClient environment is only valid with backend: "cloud".',
       );
     }
     if (this.backend === "remote" && this.environment !== undefined) {
       throw new Error(
-        "LettaCodeClient environment is only valid for the cloud backend; remote url selects the app-server runtime.",
+        'LettaCodeClient environment is only valid with backend: "cloud"; remote url selects the app-server runtime.',
       );
     }
     if (this.backend !== "cloud" && (options as { sandbox?: unknown }).sandbox !== undefined) {
-      throw new Error("LettaCodeClient sandbox options are only valid for cloud backends.");
+      throw new Error('LettaCodeClient sandbox options are only valid with backend: "cloud".');
     }
 
     if (this.backend === "local") {
@@ -229,7 +229,7 @@ export class LettaCodeClient {
     if (this.backend === "cloud") {
       if (!agentId) {
         throw new Error(
-          "Cloud backend createSession() requires an agent id. Call createAgent() first or pass an agent id.",
+          "Constellation createSession() requires an agent id. Call createAgent() first or pass an agent id.",
         );
       }
       return new CloudEnvironmentSession(this.cloudOptions(), {
@@ -257,7 +257,7 @@ export class LettaCodeClient {
    * Resume an existing agent default conversation or a specific conversation.
    *
    * `options.environment` overrides the client's default execution target for
-   * cloud backends. Remote app-server URLs already select the runtime.
+   * Constellation sessions. Remote app-server URLs already select the runtime.
    */
   resumeSession(
     id: string,
@@ -357,11 +357,11 @@ export class LettaCodeClient {
     if (this.backend === "local") {
       if (effectiveEnvironment !== undefined) {
         throw new Error(
-          `${action}() environment overrides are only valid for cloud backends.`,
+          `${action}() environment overrides are only valid with backend: "cloud".`,
         );
       }
       if (options.sandbox !== undefined) {
-        throw new Error(`${action}() sandbox options are only valid for cloud backends.`);
+        throw new Error(`${action}() sandbox options are only valid with backend: "cloud".`);
       }
       if (!this.useLegacyLocalStdio()) {
         assertRemoteSessionOptionsSupported(action, options);
@@ -372,11 +372,11 @@ export class LettaCodeClient {
     if (this.backend === "remote") {
       if (options.environment !== undefined) {
         throw new Error(
-          `${action}() environment overrides are only valid for cloud backends; remote url selects the app-server runtime.`,
+          `${action}() environment overrides are only valid with backend: "cloud"; remote url selects the app-server runtime.`,
         );
       }
       if (options.sandbox !== undefined) {
-        throw new Error(`${action}() sandbox options are only valid for cloud backends; remote url selects the app-server runtime.`);
+        throw new Error(`${action}() sandbox options are only valid with backend: "cloud"; remote url selects the app-server runtime.`);
       }
       assertRemoteSessionOptionsSupported(action, options);
       return;
@@ -384,10 +384,10 @@ export class LettaCodeClient {
     if (this.backend === "cloud") {
       const cloudOptions = this.cloudOptions();
       if (cloudOptions.environment !== undefined && options.sandbox !== undefined) {
-        throw new Error(`Cloud backend ${action}() cannot specify sandbox options when the client has a default environment.`);
+        throw new Error(`Constellation ${action}() cannot specify sandbox options when the client has a default environment.`);
       }
       if (cloudOptions.sandbox !== undefined && options.environment !== undefined) {
-        throw new Error(`Cloud backend ${action}() cannot specify an environment when the client has default sandbox options.`);
+        throw new Error(`Constellation ${action}() cannot specify an environment when the client has default sandbox options.`);
       }
       assertCloudSessionOptionsSupported(action, options);
       return;
@@ -427,7 +427,7 @@ export class LettaCodeClient {
 
   private cloudOptions(): LettaCodeCloudClientOptions {
     if (this.backend !== "cloud") {
-      throw new Error("Cloud options requested for non-cloud backend.");
+      throw new Error('Constellation options requested for non-"cloud" backend.');
     }
     return this.options as LettaCodeCloudClientOptions;
   }

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -654,7 +654,7 @@ export function assertCloudSessionOptionsSupported(
     throw new Error(`Cloud backend ${action}() has not wired sleeptime.behavior to the remote device protocol yet.`);
   }
   if ((options as { memfsStartup?: unknown }).memfsStartup !== undefined) {
-    throw new Error(`Cloud backend ${action}() does not use memfsStartup; remote device startup owns synchronization.`);
+    throw new Error(`Cloud backend ${action}() does not support memfsStartup.`);
   }
   if (options.includePartialMessages !== undefined) {
     throw new Error(`Cloud backend ${action}() streams Remote Client deltas directly; includePartialMessages is not a separate toggle.`);

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -258,7 +258,7 @@ export function validateCloudClientOptions(options: LettaCodeCloudClientOptions)
   validatePositiveInteger(options.appServer?.startupTimeoutMs, "appServer.startupTimeoutMs");
   validateCloudSandboxOptions(options.sandbox, "sandbox");
   if (options.environment !== undefined && options.sandbox !== undefined) {
-    throw new Error("Cloud backend cannot specify both environment and sandbox options.");
+    throw new Error("Constellation sessions cannot specify both environment and sandbox options.");
   }
   if (
     options.webSocketAuth !== undefined &&
@@ -461,7 +461,7 @@ function createCloudStatusWebSocketConstructor(params: {
 
       this.ackIfSequenced(message);
 
-      // Cloud's status gateway can mirror device stream frames to the control
+      // The status gateway can mirror device stream frames to the control
       // subscriber. Drop them at the Cloud transport boundary instead of making
       // shared app-server session code understand Cloud fanout quirks. Do this
       // before idempotency/event tracking so the canonical stream-channel frame
@@ -636,28 +636,28 @@ export function assertCloudSessionOptionsSupported(
 ): void {
   validateCloudSandboxOptions(options.sandbox, "sandbox");
   if (options.environment !== undefined && options.sandbox !== undefined) {
-    throw new Error(`Cloud backend ${action}() cannot specify both environment and sandbox options.`);
+    throw new Error(`Constellation ${action}() cannot specify both environment and sandbox options.`);
   }
   if (options.systemPrompt !== undefined) {
-    throw new Error(`Cloud backend ${action}() cannot rewrite an existing agent's systemPrompt from the SDK adapter yet.`);
+    throw new Error(`Constellation ${action}() cannot rewrite an existing agent's systemPrompt from the SDK adapter yet.`);
   }
   if (options.allowedTools !== undefined || options.disallowedTools !== undefined) {
-    throw new Error(`Cloud backend ${action}() has not wired allowedTools/disallowedTools to the remote device protocol yet.`);
+    throw new Error(`Constellation ${action}() has not wired allowedTools/disallowedTools to the remote device protocol yet.`);
   }
   if (options.skillSources !== undefined) {
-    throw new Error(`Cloud backend ${action}() has not wired skillSources to the remote device protocol yet.`);
+    throw new Error(`Constellation ${action}() has not wired skillSources to the remote device protocol yet.`);
   }
   if (options.systemInfoReminder !== undefined) {
-    throw new Error(`Cloud backend ${action}() has not wired systemInfoReminder to the remote device protocol yet.`);
+    throw new Error(`Constellation ${action}() has not wired systemInfoReminder to the remote device protocol yet.`);
   }
   if (options.sleeptime?.behavior !== undefined) {
-    throw new Error(`Cloud backend ${action}() has not wired sleeptime.behavior to the remote device protocol yet.`);
+    throw new Error(`Constellation ${action}() has not wired sleeptime.behavior to the remote device protocol yet.`);
   }
   if ((options as { memfsStartup?: unknown }).memfsStartup !== undefined) {
-    throw new Error(`Cloud backend ${action}() does not support memfsStartup.`);
+    throw new Error(`Constellation ${action}() does not support memfsStartup.`);
   }
   if (options.includePartialMessages !== undefined) {
-    throw new Error(`Cloud backend ${action}() streams Remote Client deltas directly; includePartialMessages is not a separate toggle.`);
+    throw new Error(`Constellation ${action}() streams Remote Client deltas directly; includePartialMessages is not a separate toggle.`);
   }
 }
 
@@ -816,7 +816,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
 
     if (!agentId || !conversationId) {
       throw new Error(
-        "Cloud backend createSession()/resumeSession() requires an agent id or conversation id.",
+        "Constellation createSession()/resumeSession() requires an agent id or conversation id.",
       );
     }
 
@@ -863,7 +863,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     const sandboxOptions = this.effectiveSandboxOptions();
     if (environment !== undefined) {
       if (sandboxOptions !== undefined) {
-        throw new Error("Cloud backend cannot specify both environment and sandbox options.");
+        throw new Error("Constellation sessions cannot specify both environment and sandbox options.");
       }
       return this.resolveExplicitConnection(environment);
     }

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -31,6 +31,7 @@ import type {
   CreateAgentOptions,
   LettaCodeClientSessionOptions,
   LettaCodeCloudClientOptions,
+  LettaCodeCloudSandboxOptions,
   LettaCodeEnvironment,
   LettaCodeSocketConstructor,
   LettaCodeSocketLike,
@@ -39,6 +40,11 @@ import type {
 const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
 const DEFAULT_TURN_TIMEOUT_MS = 120_000;
 const DEFAULT_PING_INTERVAL_MS = 30_000;
+const DEFAULT_SANDBOX_TTL_MINUTES = 5;
+const MIN_SANDBOX_TTL_MINUTES = 1;
+const MAX_SANDBOX_TTL_MINUTES = 60;
+const DEFAULT_SANDBOX_READY_TIMEOUT_MS = 120_000;
+const DEFAULT_SANDBOX_READY_POLL_INTERVAL_MS = 1_000;
 const SDK_AGENT_ORIGIN = "@letta-ai/letta-code-sdk";
 
 type FetchLike = typeof fetch;
@@ -74,6 +80,36 @@ type CloudConversation = Record<string, unknown> & {
   id?: string;
   agent_id?: string;
 };
+
+type CloudAgentSandbox = Record<string, unknown> & {
+  sandboxId?: string;
+  deviceId?: string;
+  connectionName?: string;
+};
+
+type CloudAgentSandboxRefresh = Record<string, unknown> & {
+  success?: boolean;
+  sandboxId?: string;
+  ttlMinutes?: number;
+};
+
+type ManagedCloudSandbox = {
+  agentId: string;
+  sandboxId: string;
+  deviceId: string;
+  connectionName: string;
+  ttlMinutes: number;
+  readyTimeoutMs: number;
+  readyPollIntervalMs: number;
+  refreshIntervalMs: number;
+  terminateOnClose: boolean;
+};
+
+type ResolvedCloudConnection = {
+  connectionId: string;
+};
+
+class CloudManagedSandboxOwnershipError extends Error {}
 
 type CloudSessionMode = Extract<RuntimeSessionMode, { kind: "session" }>;
 
@@ -179,14 +215,50 @@ function validatePositiveInteger(value: number | undefined, name: string): void 
   }
 }
 
+function validateIntegerRange(
+  value: number | undefined,
+  name: string,
+  min: number,
+  max: number,
+): void {
+  if (value === undefined) return;
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`Invalid ${name}. Expected an integer between ${min} and ${max}.`);
+  }
+}
+
+function validateCloudSandboxOptions(
+  options: LettaCodeCloudSandboxOptions | undefined,
+  name: string,
+): void {
+  if (options === undefined) return;
+  if (options === null || typeof options !== "object" || Array.isArray(options)) {
+    throw new Error(`Invalid ${name}. Expected an object.`);
+  }
+  validateIntegerRange(
+    options.ttlMinutes,
+    `${name}.ttlMinutes`,
+    MIN_SANDBOX_TTL_MINUTES,
+    MAX_SANDBOX_TTL_MINUTES,
+  );
+  validatePositiveInteger(options.readyTimeoutMs, `${name}.readyTimeoutMs`);
+  validatePositiveInteger(options.readyPollIntervalMs, `${name}.readyPollIntervalMs`);
+  validatePositiveInteger(options.refreshIntervalMs, `${name}.refreshIntervalMs`);
+  if (
+    options.terminateOnClose !== undefined &&
+    typeof options.terminateOnClose !== "boolean"
+  ) {
+    throw new Error(`Invalid ${name}.terminateOnClose. Expected a boolean.`);
+  }
+}
+
 export function validateCloudClientOptions(options: LettaCodeCloudClientOptions): void {
   validatePositiveInteger(options.requestTimeoutMs, "requestTimeoutMs");
   validatePositiveInteger(options.appServer?.requestTimeoutMs, "appServer.requestTimeoutMs");
   validatePositiveInteger(options.appServer?.startupTimeoutMs, "appServer.startupTimeoutMs");
-  if ((options as { sandbox?: unknown }).sandbox !== undefined) {
-    throw new Error(
-      "Cloud backend SDK-managed sandboxes are not available yet. Specify environment.",
-    );
+  validateCloudSandboxOptions(options.sandbox, "sandbox");
+  if (options.environment !== undefined && options.sandbox !== undefined) {
+    throw new Error("Cloud backend cannot specify both environment and sandbox options.");
   }
   if (
     options.webSocketAuth !== undefined &&
@@ -473,6 +545,43 @@ function isCloudConversation(value: unknown): value is CloudConversation & { id:
   return Boolean(value && typeof value === "object" && typeof (value as CloudConversation).id === "string");
 }
 
+function isCloudAgentSandbox(
+  value: unknown,
+): value is CloudAgentSandbox & { sandboxId: string; deviceId: string; connectionName: string } {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      typeof (value as CloudAgentSandbox).sandboxId === "string" &&
+      typeof (value as CloudAgentSandbox).deviceId === "string" &&
+      typeof (value as CloudAgentSandbox).connectionName === "string",
+  );
+}
+
+function isCloudAgentSandboxRefresh(
+  value: unknown,
+): value is CloudAgentSandboxRefresh & { success: boolean; sandboxId: string; ttlMinutes: number } {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      typeof (value as CloudAgentSandboxRefresh).success === "boolean" &&
+      typeof (value as CloudAgentSandboxRefresh).sandboxId === "string" &&
+      typeof (value as CloudAgentSandboxRefresh).ttlMinutes === "number",
+  );
+}
+
+function isRetryableManagedSandboxResolveError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("Remote environment is offline") ||
+    message.toLowerCase().includes("not found") ||
+    message.includes("(404)")
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function externalToolsByName(tools: AnyAgentTool[] | undefined): Map<string, AnyAgentTool> {
   const result = new Map<string, AnyAgentTool>();
   for (const tool of tools ?? []) {
@@ -525,10 +634,9 @@ export function assertCloudSessionOptionsSupported(
   action: string,
   options: LettaCodeClientSessionOptions,
 ): void {
-  if ((options as { sandbox?: unknown }).sandbox !== undefined) {
-    throw new Error(
-      `Cloud backend ${action}() does not accept SDK-managed sandbox options yet. Specify environment.`,
-    );
+  validateCloudSandboxOptions(options.sandbox, "sandbox");
+  if (options.environment !== undefined && options.sandbox !== undefined) {
+    throw new Error(`Cloud backend ${action}() cannot specify both environment and sandbox options.`);
   }
   if (options.systemPrompt !== undefined) {
     throw new Error(`Cloud backend ${action}() cannot rewrite an existing agent's systemPrompt from the SDK adapter yet.`);
@@ -558,6 +666,9 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   private removeExternalToolHandler: (() => void) | null = null;
   private removeControlRequestHandler: (() => void) | null = null;
   private externalTools = new Map<string, AnyAgentTool>();
+  private managedSandbox: ManagedCloudSandbox | null = null;
+  private sandboxRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  private sandboxRefreshInFlight: Promise<void> | null = null;
   private readonly cloudMode: CloudSessionMode;
 
   constructor(
@@ -574,9 +685,8 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   }
 
   protected override async initializeRuntimeController(): Promise<RuntimeSessionInit> {
-    const environment = this.requireEnvironment();
     const resolved = await this.resolveRuntime();
-    const connection = await this.resolveConnection(resolved.runtime, environment);
+    const connection = await this.resolveConnectionForRuntime(resolved.runtime);
     this.connectionId = connection.connectionId;
 
     const apiKey = getCloudApiKey(this.cloudOptions);
@@ -629,6 +739,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       this.removeControlRequestHandler?.();
       this.removeControlRequestHandler = null;
       client.close();
+      await this.cleanupManagedSandbox();
       throw error;
     }
   }
@@ -670,11 +781,18 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     });
   }
 
+  protected override async beforeTurn(): Promise<void> {
+    const sandbox = this.managedSandbox;
+    if (!sandbox) return;
+    await this.refreshManagedSandbox(sandbox);
+  }
+
   protected override onCoreClose(): void {
     this.removeExternalToolHandler?.();
     this.removeExternalToolHandler = null;
     this.removeControlRequestHandler?.();
     this.removeControlRequestHandler = null;
+    void this.cleanupManagedSandbox();
   }
 
   private async resolveRuntime(): Promise<{ runtime: RuntimeScope }> {
@@ -738,29 +856,205 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     return { id: body.id, agent_id: body.agent_id };
   }
 
-  private async resolveConnection(
+  private async resolveConnectionForRuntime(
     runtime: RuntimeScope,
+  ): Promise<ResolvedCloudConnection> {
+    const environment = this.effectiveEnvironment();
+    const sandboxOptions = this.effectiveSandboxOptions();
+    if (environment !== undefined) {
+      if (sandboxOptions !== undefined) {
+        throw new Error("Cloud backend cannot specify both environment and sandbox options.");
+      }
+      return this.resolveExplicitConnection(environment);
+    }
+    return this.createManagedSandboxConnection(runtime);
+  }
+
+  private async resolveExplicitConnection(
     environment: LettaCodeEnvironment,
   ): Promise<{ connectionId: string }> {
     const target = environmentToRemoteTarget(environment);
-    const client = new RemoteEnvironmentClient({
+    const resolved = await this.remoteEnvironmentClient().resolveEnvironment(target);
+    return { connectionId: resolved.connectionId };
+  }
+
+  private async createManagedSandboxConnection(
+    runtime: RuntimeScope,
+  ): Promise<ResolvedCloudConnection> {
+    const sandbox = await this.createManagedSandbox(runtime.agent_id);
+    this.managedSandbox = sandbox;
+
+    try {
+      await this.refreshManagedSandbox(sandbox);
+      const connection = await this.waitForManagedSandboxConnection(sandbox);
+      this.startManagedSandboxRefresh(sandbox);
+      return { connectionId: connection.connectionId };
+    } catch (error) {
+      await this.cleanupManagedSandbox();
+      throw error;
+    }
+  }
+
+  private async createManagedSandbox(agentId: string): Promise<ManagedCloudSandbox> {
+    const fetchImpl = getFetch(this.cloudOptions.fetch);
+    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+    const response = await fetchImpl(
+      `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/sandboxes`,
+      {
+        method: "POST",
+        headers: cloudHeaders(this.cloudOptions),
+        body: JSON.stringify({}),
+      },
+    );
+    const body = await parseJsonResponse(response);
+    assertOkResponse(response, body, "Cloud create managed sandbox");
+    if (!isCloudAgentSandbox(body)) {
+      throw new Error("Cloud create managed sandbox response did not include sandbox connection details.");
+    }
+
+    const sandboxOptions = this.resolvedSandboxOptions();
+    const ttlMinutes = sandboxOptions.ttlMinutes ?? DEFAULT_SANDBOX_TTL_MINUTES;
+    const readyTimeoutMs = sandboxOptions.readyTimeoutMs
+      ?? DEFAULT_SANDBOX_READY_TIMEOUT_MS;
+    const readyPollIntervalMs = sandboxOptions.readyPollIntervalMs
+      ?? DEFAULT_SANDBOX_READY_POLL_INTERVAL_MS;
+    const defaultRefreshIntervalMs = Math.max(
+      1_000,
+      Math.floor(ttlMinutes * 60_000 * 0.8),
+    );
+
+    return {
+      agentId,
+      sandboxId: body.sandboxId,
+      deviceId: body.deviceId,
+      connectionName: body.connectionName,
+      ttlMinutes,
+      readyTimeoutMs,
+      readyPollIntervalMs,
+      refreshIntervalMs: sandboxOptions.refreshIntervalMs ?? defaultRefreshIntervalMs,
+      terminateOnClose: sandboxOptions.terminateOnClose ?? true,
+    };
+  }
+
+  private async refreshManagedSandbox(sandbox: ManagedCloudSandbox): Promise<void> {
+    if (this.sandboxRefreshInFlight) {
+      await this.sandboxRefreshInFlight;
+      return;
+    }
+
+    this.sandboxRefreshInFlight = this.refreshManagedSandboxOnce(sandbox);
+    try {
+      await this.sandboxRefreshInFlight;
+    } finally {
+      this.sandboxRefreshInFlight = null;
+    }
+  }
+
+  private async refreshManagedSandboxOnce(sandbox: ManagedCloudSandbox): Promise<void> {
+    const fetchImpl = getFetch(this.cloudOptions.fetch);
+    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+    const response = await fetchImpl(
+      `${baseUrl}/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes/refresh`,
+      {
+        method: "POST",
+        headers: cloudHeaders(this.cloudOptions),
+        body: JSON.stringify({ ttlMinutes: sandbox.ttlMinutes }),
+      },
+    );
+    const body = await parseJsonResponse(response);
+    assertOkResponse(response, body, "Cloud refresh managed sandbox");
+    if (!isCloudAgentSandboxRefresh(body) || !body.success) {
+      throw new Error("Cloud refresh managed sandbox response did not confirm refresh.");
+    }
+    if (body.sandboxId !== sandbox.sandboxId) {
+      throw new CloudManagedSandboxOwnershipError(
+        `Cloud managed sandbox ownership changed for agent ${sandbox.agentId}: expected ${sandbox.sandboxId}, got ${body.sandboxId}.`,
+      );
+    }
+  }
+
+  private async terminateManagedSandbox(sandbox: ManagedCloudSandbox): Promise<void> {
+    await this.refreshManagedSandbox(sandbox);
+
+    const fetchImpl = getFetch(this.cloudOptions.fetch);
+    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+    const response = await fetchImpl(
+      `${baseUrl}/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes`,
+      {
+        method: "DELETE",
+        headers: cloudHeaders(this.cloudOptions),
+      },
+    );
+    const body = await parseJsonResponse(response);
+    if (response.status === 404) return;
+    assertOkResponse(response, body, "Cloud terminate managed sandbox");
+  }
+
+  private async waitForManagedSandboxConnection(
+    sandbox: ManagedCloudSandbox,
+  ): Promise<{ connectionId: string }> {
+    const deadline = Date.now() + sandbox.readyTimeoutMs;
+    let lastError: unknown;
+
+    while (true) {
+      try {
+        const resolved = await this.remoteEnvironmentClient().resolveEnvironment({
+          deviceId: sandbox.deviceId,
+        });
+        return { connectionId: resolved.connectionId };
+      } catch (error) {
+        lastError = error;
+        if (!isRetryableManagedSandboxResolveError(error) || Date.now() >= deadline) {
+          break;
+        }
+        const remainingMs = Math.max(0, deadline - Date.now());
+        await sleep(Math.min(sandbox.readyPollIntervalMs, remainingMs));
+      }
+    }
+
+    const detail = lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(
+      `Cloud managed sandbox ${sandbox.sandboxId} did not come online within ${sandbox.readyTimeoutMs}ms: ${detail}`,
+    );
+  }
+
+  private startManagedSandboxRefresh(sandbox: ManagedCloudSandbox): void {
+    this.stopManagedSandboxRefresh();
+    this.sandboxRefreshTimer = setInterval(() => {
+      void this.refreshManagedSandbox(sandbox).catch((error) => {
+        if (error instanceof CloudManagedSandboxOwnershipError) {
+          this.stopManagedSandboxRefresh();
+        }
+      });
+    }, sandbox.refreshIntervalMs);
+    (this.sandboxRefreshTimer as { unref?: () => void }).unref?.();
+  }
+
+  private stopManagedSandboxRefresh(): void {
+    if (!this.sandboxRefreshTimer) return;
+    clearInterval(this.sandboxRefreshTimer);
+    this.sandboxRefreshTimer = null;
+  }
+
+  private async cleanupManagedSandbox(): Promise<void> {
+    this.stopManagedSandboxRefresh();
+    const sandbox = this.managedSandbox;
+    this.managedSandbox = null;
+    if (!sandbox || !sandbox.terminateOnClose) return;
+    try {
+      await this.terminateManagedSandbox(sandbox);
+    } catch {
+      // Best-effort cleanup: Cloud TTL still bounds leaked managed sandboxes.
+    }
+  }
+
+  private remoteEnvironmentClient(): RemoteEnvironmentClient {
+    return new RemoteEnvironmentClient({
       baseUrl: this.cloudOptions.apiBaseUrl,
       apiKey: getCloudApiKey(this.cloudOptions),
       headers: this.cloudOptions.headers,
       fetch: this.cloudOptions.fetch,
     });
-    const resolved = await client.resolveEnvironment(target);
-    return { connectionId: resolved.connectionId };
-  }
-
-  private requireEnvironment(): LettaCodeEnvironment {
-    const environment = this.effectiveEnvironment();
-    if (environment === undefined) {
-      throw new Error(
-        "Cloud backend requires an environment target until managed Cloud sandboxes land. Specify client or session environment.",
-      );
-    }
-    return environment;
   }
 
   private effectiveEnvironment(): LettaCodeEnvironment | undefined {
@@ -768,5 +1062,16 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       ? this.mode.options.environment
       : undefined;
     return modeEnvironment ?? this.cloudOptions.environment;
+  }
+
+  private effectiveSandboxOptions(): LettaCodeCloudSandboxOptions | undefined {
+    const modeSandbox = this.mode.kind === "session"
+      ? this.mode.options.sandbox
+      : undefined;
+    return modeSandbox ?? this.cloudOptions.sandbox;
+  }
+
+  private resolvedSandboxOptions(): LettaCodeCloudSandboxOptions {
+    return this.effectiveSandboxOptions() ?? {};
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,8 +126,7 @@ export {
  *
  * @example
  * ```typescript
- * // Create agent with default settings. SDK-created agents get MemFS
- * // enabled by default and are tagged with origin:letta-code.
+ * // Create agent with default settings.
  * const agentId = await createAgent();
  *
  * // Create agent with custom memory
@@ -135,7 +134,7 @@ export {
  *   memory: ['persona', 'project'],
  *   persona: 'You are a helpful coding assistant',
  *   model: 'claude-sonnet-4',
- *   tags: ['project:docs'] // origin:letta-code is added automatically
+ *   tags: ['project:docs']
  * });
  *
  * // Then resume the default conversation:

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -398,7 +398,7 @@ describe("LettaCodeClient", () => {
 
     expect(() =>
       client.resumeSession("agent-123", { environment: "work-laptop" }),
-    ).toThrow("environment overrides are only valid for cloud backends");
+    ).toThrow('environment overrides are only valid with backend: "cloud"');
   });
 
   test("rejects environment on remote app-server clients", () => {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1273,7 +1273,7 @@ describe("CloudEnvironmentSession", () => {
       backend: "remote",
       url: "ws://app-server.test/ws",
       sandbox: { ttlMinutes: 5 },
-    } as never)).toThrow("sandbox options are only valid for cloud backends");
+    } as never)).toThrow('sandbox options are only valid with backend: "cloud"');
   });
 
   test("reports terminal Cloud loop errors instead of idle success", async () => {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -60,6 +60,48 @@ function createCloudFetchMock(
       return Promise.resolve(jsonResponse({ id: "conv-1", agent_id: "agent-from-conv" }));
     }
 
+    const agentSandboxMatch = /^\/v1\/agents\/([^/]+)\/sandboxes$/.exec(parsed.pathname);
+    if (agentSandboxMatch && method === "POST") {
+      const agentId = decodeURIComponent(agentSandboxMatch[1]!);
+      return Promise.resolve(jsonResponse({
+        sandboxId: `sandbox-${agentId}`,
+        deviceId: `device-${agentId}`,
+        connectionName: `sandbox-${agentId}-session`,
+      }));
+    }
+
+    const agentSandboxRefreshMatch = /^\/v1\/agents\/([^/]+)\/sandboxes\/refresh$/.exec(parsed.pathname);
+    if (agentSandboxRefreshMatch && method === "POST") {
+      const agentId = decodeURIComponent(agentSandboxRefreshMatch[1]!);
+      const body = bodyOf(init) as { ttlMinutes?: number } | undefined;
+      return Promise.resolve(jsonResponse({
+        success: true,
+        sandboxId: `sandbox-${agentId}`,
+        ttlMinutes: body?.ttlMinutes ?? 5,
+      }));
+    }
+
+    if (agentSandboxMatch && method === "DELETE") {
+      return Promise.resolve(jsonResponse({ success: true, message: "terminated" }));
+    }
+
+    const managedEnvironmentMatch = /^\/v1\/environments\/device-(.+)$/.exec(parsed.pathname);
+    if (managedEnvironmentMatch && method === "GET") {
+      const agentId = decodeURIComponent(managedEnvironmentMatch[1]!);
+      return Promise.resolve(jsonResponse({
+        id: `env-${agentId}`,
+        connectionId: `conn-${agentId}`,
+        deviceId: `device-${agentId}`,
+        connectionName: `sandbox-${agentId}-session`,
+        organizationId: "org-test",
+        podId: null,
+        connectedAt: 1,
+        lastHeartbeat: 1,
+        lastSeenAt: 1,
+        firstSeenAt: 1,
+      }));
+    }
+
     if (parsed.pathname === "/v1/environments" && method === "GET") {
       return Promise.resolve(jsonResponse({
         connections: environmentConnections ?? [
@@ -471,7 +513,7 @@ function resetFakeAppServer(): void {
 }
 
 describe("CloudEnvironmentSession", () => {
-  test("requires an explicit environment while SDK-managed Cloud sandboxes are unavailable", async () => {
+  test("creates, refreshes, and cleans up a managed Cloud sandbox when no environment is specified", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const client = new LettaCodeClient({
@@ -481,22 +523,83 @@ describe("CloudEnvironmentSession", () => {
       fetch: createCloudFetchMock(requests),
       WebSocket: FakeCloudSocket,
       requestTimeoutMs: 1_000,
+      sandbox: { ttlMinutes: 2 },
     });
 
     const session = client.resumeSession("agent-1");
-    await expect(asAdvanced(session).initialize()).rejects.toThrow(
-      "Cloud backend requires an environment target until managed Cloud sandboxes land",
-    );
+    try {
+      const init = await asAdvanced(session).initialize();
+      expect(init).toMatchObject({
+        type: "init",
+        agentId: "agent-1",
+        conversationId: "default",
+      });
 
-    await expect(asAdvanced(client.createSession("agent-1")).initialize()).rejects.toThrow(
-      "Cloud backend requires an environment target until managed Cloud sandboxes land",
-    );
-    await expect(asAdvanced(client.resumeSession("conv-1")).initialize()).rejects.toThrow(
-      "Cloud backend requires an environment target until managed Cloud sandboxes land",
-    );
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "POST",
+        url: "https://api.test/v1/agents/agent-1/sandboxes",
+        body: {},
+      }));
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "POST",
+        url: "https://api.test/v1/agents/agent-1/sandboxes/refresh",
+        body: { ttlMinutes: 2 },
+      }));
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "GET",
+        url: "https://api.test/v1/environments/device-agent-1",
+      }));
 
-    expect(requests).toHaveLength(0);
-    expect(FakeCloudSocket.instances).toHaveLength(0);
+      const controlSocket = FakeCloudSocket.socket("control")!;
+      expect(new URL(controlSocket.url).pathname).toBe("/v1/environments/conn-agent-1/status/ws");
+
+      const result = await asAdvanced(session).runTurn("hello");
+      expect(result).toMatchObject({ success: true, result: "hello from cloud" });
+      expect(requests.filter((request) =>
+        new URL(request.url).pathname === "/v1/agents/agent-1/sandboxes/refresh"
+      )).toHaveLength(2);
+    } finally {
+      session.close();
+    }
+
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(requests.filter((request) =>
+      new URL(request.url).pathname === "/v1/agents/agent-1/sandboxes/refresh"
+    )).toHaveLength(3);
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "DELETE",
+      url: "https://api.test/v1/agents/agent-1/sandboxes",
+    }));
+  });
+
+  test("can leave managed Cloud sandbox cleanup to TTL", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaCodeClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { terminateOnClose: false },
+    });
+
+    const session = client.resumeSession("agent-1");
+    await asAdvanced(session).initialize();
+    session.close();
+
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(requests.some((request) =>
+      new URL(request.url).pathname === "/v1/agents/agent-1/sandboxes" &&
+        request.method === "DELETE"
+    )).toBe(false);
   });
 
   test("uses an explicit environment before using the Remote Client websocket", async () => {
@@ -1122,26 +1225,16 @@ describe("CloudEnvironmentSession", () => {
     }
   });
 
-  test("rejects SDK-managed sandbox options until Cloud sandbox support lands", () => {
-    const client = new LettaCodeClient({
+  test("validates managed Cloud sandbox options and environment exclusivity", () => {
+    expect(() => new LettaCodeClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
       fetch: createCloudFetchMock([]),
       WebSocket: FakeCloudSocket,
       environment: { connectionId: "conn-explicit" },
-    });
-
-    expect(() => client.resumeSession("agent-1", {
-      sandbox: { lifecycle: "ephemeral" },
-    } as never)).toThrow(
-      "does not accept SDK-managed sandbox options yet",
-    );
-    expect(() => client.createSession("agent-1", {
-      sandbox: { lifecycle: "ephemeral" },
-    } as never)).toThrow(
-      "does not accept SDK-managed sandbox options yet",
-    );
+      sandbox: { ttlMinutes: 5 },
+    })).toThrow("cannot specify both environment and sandbox options");
 
     expect(() => new LettaCodeClient({
       backend: "cloud",
@@ -1149,10 +1242,38 @@ describe("CloudEnvironmentSession", () => {
       apiKey: "sk-test",
       fetch: createCloudFetchMock([]),
       WebSocket: FakeCloudSocket,
-      sandbox: { lifecycle: "ephemeral" },
-    } as never)).toThrow(
-      "Cloud backend SDK-managed sandboxes are not available yet",
-    );
+      sandbox: { ttlMinutes: 61 },
+    })).toThrow("Invalid sandbox.ttlMinutes");
+
+    const clientWithEnvironment = new LettaCodeClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock([]),
+      WebSocket: FakeCloudSocket,
+      environment: { connectionId: "conn-explicit" },
+    });
+    expect(() => clientWithEnvironment.resumeSession("agent-1", {
+      sandbox: { ttlMinutes: 5 },
+    })).toThrow("cannot specify sandbox options when the client has a default environment");
+
+    const clientWithSandbox = new LettaCodeClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock([]),
+      WebSocket: FakeCloudSocket,
+      sandbox: { ttlMinutes: 5 },
+    });
+    expect(() => clientWithSandbox.resumeSession("agent-1", {
+      environment: { connectionId: "conn-explicit" },
+    })).toThrow("cannot specify an environment when the client has default sandbox options");
+
+    expect(() => new LettaCodeClient({
+      backend: "remote",
+      url: "ws://app-server.test/ws",
+      sandbox: { ttlMinutes: 5 },
+    } as never)).toThrow("sandbox options are only valid for cloud backends");
   });
 
   test("reports terminal Cloud loop errors instead of idle success", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -598,10 +598,7 @@ export interface CreateAgentOptions {
    */
   tools?: AnyAgentTool[];
 
-  /**
-   * Tags to organize and categorize the agent.
-   * SDK-created agents are also tagged with `origin:letta-code` if missing.
-   */
+  /** Tags to organize and categorize the agent. */
   tags?: string[];
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,6 +319,25 @@ export interface LettaCodeRemoteClientOptions {
   requestTimeoutMs?: number;
 }
 
+export interface LettaCodeCloudSandboxOptions {
+  /**
+   * TTL to request when refreshing an SDK-managed Cloud sandbox. Defaults to 5
+   * minutes, matching the Cloud API default. Valid range: 1-60.
+   */
+  ttlMinutes?: number;
+  /** Timeout waiting for a newly created sandbox environment to come online. */
+  readyTimeoutMs?: number;
+  /** Poll interval while waiting for a newly created sandbox environment. */
+  readyPollIntervalMs?: number;
+  /** Interval for proactive TTL refreshes while the session is open. */
+  refreshIntervalMs?: number;
+  /**
+   * Best-effort terminate the SDK-managed sandbox on session close. Defaults to
+   * true. Set false when multiple SDK sessions may race on the same agent.
+   */
+  terminateOnClose?: boolean;
+}
+
 export interface LettaCodeCloudClientOptions {
   backend: "cloud";
   /** Optional API key override. Defaults to LETTA_API_KEY / existing auth. */
@@ -345,8 +364,13 @@ export interface LettaCodeCloudClientOptions {
    * Omit to let the SDK spawn a bundled local app-server authenticated to Cloud.
    */
   appServer?: LettaCodeLocalAppServerOptions;
-  /** Execution target for direct Cloud sessions; required here or per session. */
+  /**
+   * Execution target for direct Cloud sessions. If omitted, the SDK creates and
+   * owns a Cloud sandbox for the session.
+   */
   environment?: LettaCodeEnvironment;
+  /** Options for SDK-managed Cloud sandboxes when environment is omitted. */
+  sandbox?: LettaCodeCloudSandboxOptions;
 }
 
 export type LettaCodeClientOptions =
@@ -507,6 +531,8 @@ export interface CreateSessionOptions {
  */
 export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
   environment?: LettaCodeEnvironment;
+  /** Per-session SDK-managed Cloud sandbox options when environment is omitted. */
+  sandbox?: LettaCodeCloudSandboxOptions;
 }
 
 export interface LettaCodeSession extends AsyncDisposable {

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,7 +263,8 @@ export type AnyAgentTool = AgentTool<any, unknown>;
  *
  * - local: spawn/manage a local Letta Code app-server over loopback websockets.
  * - remote: connect to a user-managed app-server over websockets.
- * - cloud: connect to an explicit Letta Cloud remote environment over the Remote Client websocket.
+ * - cloud: use agents hosted on Constellation, with an explicit remote
+ *   environment or SDK-managed sandbox.
  */
 export type LettaCodeBackend = "local" | "remote" | "cloud";
 
@@ -321,7 +322,7 @@ export interface LettaCodeRemoteClientOptions {
 
 export interface LettaCodeCloudSandboxOptions {
   /**
-   * TTL to request when refreshing an SDK-managed Cloud sandbox. Defaults to 5
+   * TTL to request when refreshing an SDK-managed sandbox. Defaults to 5
    * minutes, matching the Cloud API default. Valid range: 1-60.
    */
   ttlMinutes?: number;
@@ -342,7 +343,7 @@ export interface LettaCodeCloudClientOptions {
   backend: "cloud";
   /** Optional API key override. Defaults to LETTA_API_KEY / existing auth. */
   apiKey?: string;
-  /** Optional API base URL override. Defaults to Letta Cloud. */
+  /** Optional API base URL override. Defaults to the Letta API. */
   apiBaseUrl?: string;
   /** Optional extra HTTP headers for Cloud API requests. */
   headers?: Record<string, string>;
@@ -365,11 +366,11 @@ export interface LettaCodeCloudClientOptions {
    */
   appServer?: LettaCodeLocalAppServerOptions;
   /**
-   * Execution target for direct Cloud sessions. If omitted, the SDK creates and
-   * owns a Cloud sandbox for the session.
+   * Execution target for Constellation sessions. If omitted, the SDK creates
+   * and owns a sandbox for the session.
    */
   environment?: LettaCodeEnvironment;
-  /** Options for SDK-managed Cloud sandboxes when environment is omitted. */
+  /** Options for SDK-managed sandboxes when environment is omitted. */
   sandbox?: LettaCodeCloudSandboxOptions;
 }
 
@@ -531,7 +532,7 @@ export interface CreateSessionOptions {
  */
 export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
   environment?: LettaCodeEnvironment;
-  /** Per-session SDK-managed Cloud sandbox options when environment is omitted. */
+  /** Per-session SDK-managed sandbox options when environment is omitted. */
   sandbox?: LettaCodeCloudSandboxOptions;
 }
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -59,7 +59,7 @@ function validateApprovalRecoveryOptions(options: CreateSessionOptions): void {
 function validateRemovedSessionOptions(options: CreateSessionOptions): void {
   if ((options as { memfsStartup?: unknown }).memfsStartup !== undefined) {
     throw new Error(
-      "memfsStartup is not supported by the SDK. SDK-managed agents use the harness default MemFS behavior.",
+      "memfsStartup is not supported by the SDK.",
     );
   }
 }


### PR DESCRIPTION
## Summary

Constellation sessions now work out of the box without callers manually choosing an environment. If `environment` is omitted, the SDK creates and manages a sandbox for the session.

```ts
import { LettaCodeClient } from "@letta-ai/letta-code-sdk";

const client = new LettaCodeClient({
  backend: "cloud",
  apiKey: process.env.LETTA_API_KEY,
});

await using session = client.resumeSession(agentId, {
  permissionMode: "bypassPermissions",
});

await session.send("Summarize this repository.");
for await (const msg of session.stream()) {
  if (msg.type === "assistant") console.log(msg.content);
}
```

If you pass `cwd` for a Constellation session, use a path that exists inside the selected remote environment or managed sandbox. Local paths such as `process.cwd()` are not mapped into managed sandboxes automatically.

Explicit environments still work for callers that want to bring their own runtime:

```ts
const client = new LettaCodeClient({
  backend: "cloud",
  apiKey: process.env.LETTA_API_KEY,
  environment: { connectionId: process.env.LETTA_ENVIRONMENT_CONNECTION_ID! },
});
```

## Managed sandbox lifecycle

When the SDK owns the sandbox, session startup now follows this flow:

```text
create sandbox
  → refresh TTL
  → wait for returned device to come online
  → connect Remote Client websocket
  → start runtime
  → refresh TTL while active
  → best-effort cleanup on close
```

In SDK terms:

```ts
const client = new LettaCodeClient({
  backend: "cloud",
  apiKey: process.env.LETTA_API_KEY,
  sandbox: {
    // TTL requested whenever the SDK refreshes the sandbox.
    ttlMinutes: 5,

    // How long to wait for the new sandbox device to become reachable.
    readyTimeoutMs: 120_000,
    readyPollIntervalMs: 1_000,

    // Optional override for proactive background refreshes.
    refreshIntervalMs: 240_000,

    // Defaults to true. Set false when multiple sessions may share an agent.
    terminateOnClose: true,
  },
});
```

The SDK refreshes the sandbox before each turn and on a background interval while the session is open. On close, it stops refreshing and best-effort terminates the sandbox. If cleanup fails, the sandbox TTL still bounds the lifetime.

## Concurrent sessions

Sandbox cleanup is agent-scoped, so callers that may run multiple SDK sessions against the same agent can leave cleanup to TTL:

```ts
const client = new LettaCodeClient({
  backend: "cloud",
  apiKey: process.env.LETTA_API_KEY,
  sandbox: {
    terminateOnClose: false,
  },
});
```

## Guardrails

`environment` and `sandbox` are mutually exclusive:

```ts
// ✅ SDK-managed sandbox
new LettaCodeClient({
  backend: "cloud",
  apiKey: process.env.LETTA_API_KEY,
  sandbox: { ttlMinutes: 5 },
});

// ✅ Caller-managed environment
new LettaCodeClient({
  backend: "cloud",
  apiKey: process.env.LETTA_API_KEY,
  environment: { connectionId: "conn-123" },
});

// ❌ Ambiguous ownership
new LettaCodeClient({
  backend: "cloud",
  apiKey: process.env.LETTA_API_KEY,
  environment: { connectionId: "conn-123" },
  sandbox: { ttlMinutes: 5 },
});
```

`sandbox` options are only valid when `backend: "cloud"`.

## Testing

```bash
bun run check
bun test src/tests/cloud-session.test.ts src/tests/client.test.ts src/tests/public-session-types.test.ts
bun test
```
