### PR TITLE
fix: Fix public session API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,12 @@ const agentId = await client.createAgent({
   persona: "You are a helpful coding assistant.",
 });
 
-await using session = client.createSession(agentId, { cwd: process.cwd() });
-const result = await session.runTurn("Summarize this repository.");
-console.log(result.result);
+await using session = client.createSession(agentId);
+
+await session.send("Summarize this repository.");
+for await (const msg of session.stream()) {
+  if (msg.type === "assistant") console.log(msg.content);
+}
 ```
 
 
@@ -132,12 +135,15 @@ const agentId = await client.createAgent({
 });
 
 await using session = client.resumeSession(agentId, {
-  cwd: process.cwd(),
+  // Paths are resolved inside the remote environment, not on the caller machine.
+  cwd: "/workspace/project",
   permissionMode: "bypassPermissions",
 });
 
-const result = await session.runTurn("Summarize this repository.");
-console.log(result.result);
+await session.send("Summarize this repository.");
+for await (const msg of session.stream()) {
+  if (msg.type === "assistant") console.log(msg.content);
+}
 ```
 
 You can set a default `environment` on the client or override it per session:
@@ -164,9 +170,11 @@ custom upgrade headers.
 ## Session configuration
 
 App-server and Cloud sessions use the remote/listener protocol for runtime
-controls that can be applied to an existing agent, including `model`,
-toolset preference, sleeptime trigger settings, `cwd`, and `permissionMode`.
-MemFS is enabled for SDK-created agents and is not configurable through SDK options.
+settings that are applied when the session starts, including `model`,
+sleeptime trigger settings, `cwd`, and `permissionMode`. A broader runtime
+controls surface for changing settings on an active session is intentionally
+left to a later typed design. MemFS is enabled for SDK-created agents and is
+not configurable through SDK options.
 CLI-only flags such as `skillSources`, `systemInfoReminder`,
 `sleeptime.behavior`, and partial-message toggles are rejected on
 app-server/Cloud sessions until those controls are wired through the remote
@@ -179,7 +187,9 @@ const client = new LettaCodeClient({ backend: "local" });
 
 const session = client.resumeSession("agent-123", {
   model: "anthropic/claude-sonnet-4",
-  cwd: process.cwd(),
+  // For local sessions this may be a local path; for remote/Cloud sessions,
+  // use a path inside the selected runtime environment.
+  cwd: "/workspace/project",
   permissionMode: "bypassPermissions",
   sleeptime: {
     trigger: "step-count", // off | step-count | compaction-event

--- a/src/client.ts
+++ b/src/client.ts
@@ -63,6 +63,10 @@ function looksLikeConversationId(id: string): boolean {
   return id.startsWith("conv-") || id.startsWith("local-conv-");
 }
 
+type TurnSession = LettaCodeSession & {
+  runTurn(message: SendMessage): Promise<SDKResultMessage>;
+};
+
 /**
  * Top-level Letta Code SDK client.
  *
@@ -325,7 +329,7 @@ export class LettaCodeClient {
       : this.createSession(options);
 
     try {
-      return await session.runTurn(message);
+      return await (session as TurnSession).runTurn(message);
     } finally {
       session.close();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,9 @@ import type {
   CreateSessionOptions,
   CreateAgentOptions,
   LettaCodeSession,
+  SDKInitMessage,
   SDKResultMessage,
+  SendMessage,
 } from "./types.js";
 import { validateCreateSessionOptions, validateCreateAgentOptions } from "./validation.js";
 
@@ -204,8 +206,7 @@ export function resumeSession(
  *
  * - Without agentId: uses default agent (like `letta -p`), new conversation
  * - With agentId: uses specific agent, new conversation
- * - Uses `session.runTurn()` under the hood, including bounded SDK-managed
- *   approval-conflict recovery (default 1 attempt)
+ * - Uses a short-lived session and returns the final turn result.
  *
  * @example
  * ```typescript
@@ -213,6 +214,14 @@ export function resumeSession(
  * const result = await prompt('What is the capital of France?', agentId);  // specific agent
  * ```
  */
+type TurnSession = LettaCodeSession & {
+  runTurn(message: SendMessage): Promise<SDKResultMessage>;
+};
+
+type InitializableSession = LettaCodeSession & {
+  initialize(): Promise<SDKInitMessage>;
+};
+
 export async function prompt(
   message: string,
   agentId?: string
@@ -223,7 +232,7 @@ export async function prompt(
     : createSession();
 
   try {
-    return await session.runTurn(message);
+    return await (session as TurnSession).runTurn(message);
   } finally {
     session.close();
   }
@@ -242,7 +251,7 @@ import type { ListMessagesOptions, ListMessagesResult } from "./types.js";
  * closes the subprocess.  Useful for prefetching conversation histories before
  * opening a full session (e.g. desktop sidebar warm-up).
  *
- * Routing follows the same semantics as session.listMessages():
+ * Routing follows the same agent/conversation semantics as session history:
  * - Pass a conv-xxx conversationId to read a specific conversation.
  * - Omit conversationId to read the agent's default conversation.
  *
@@ -271,7 +280,7 @@ export async function listMessagesDirect(
   const session = new LettaCodeClient().resumeSession(agentId, {
     permissionMode: "bypassPermissions",
   });
-  await session.initialize();
+  await (session as InitializableSession).initialize();
   try {
     return await session.listMessages(options);
   } finally {

--- a/src/tests/advanced-session.ts
+++ b/src/tests/advanced-session.ts
@@ -1,0 +1,24 @@
+import type {
+  BootstrapStateOptions,
+  BootstrapStateResult,
+  LettaCodeSession,
+  RecoverPendingApprovalsOptions,
+  RecoverPendingApprovalsResult,
+  SDKInitMessage,
+  SDKResultMessage,
+  SendMessage,
+} from "../types.js";
+
+export type AdvancedSession = LettaCodeSession & {
+  initialize(): Promise<SDKInitMessage>;
+  runTurn(message: SendMessage): Promise<SDKResultMessage>;
+  recoverPendingApprovals(
+    options?: RecoverPendingApprovalsOptions,
+  ): Promise<RecoverPendingApprovalsResult>;
+  updateToolset(toolsetPreference: string): Promise<void>;
+  bootstrapState(options?: BootstrapStateOptions): Promise<BootstrapStateResult>;
+};
+
+export function asAdvanced(session: LettaCodeSession): AdvancedSession {
+  return session as AdvancedSession;
+}

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { LettaCodeClient, Session } from "../index.js";
+import { asAdvanced } from "./advanced-session.js";
 
 type Listener = (event: unknown) => void;
 type FetchInput = Parameters<typeof fetch>[0];
@@ -384,7 +385,7 @@ describe("LettaCodeClient", () => {
 
     try {
       expect(session).toBeInstanceOf(Session);
-      await expect(session.updateToolset("developer")).rejects.toThrow(
+      await expect(asAdvanced(session).updateToolset("developer")).rejects.toThrow(
         "Local stdio sessions do not support updateToolset",
       );
     } finally {
@@ -427,7 +428,7 @@ describe("LettaCodeClient", () => {
 
     const session = client.createSession("agent-123", { cwd: "/tmp/project" });
     try {
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       expect(init.agentId).toBe("agent-123");
       expect(init.conversationId).toBe("conv-created");
 
@@ -463,7 +464,7 @@ describe("LettaCodeClient", () => {
       ],
     });
     try {
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       expect(init.tools).toEqual(["Bash", "Read"]);
       expect(fakeControlSocket().sent[0]).toMatchObject({
         type: "runtime_start",
@@ -505,7 +506,7 @@ describe("LettaCodeClient", () => {
 
     const session = client.createSession("agent-123");
     try {
-      await session.initialize();
+      await asAdvanced(session).initialize();
 
       expect(fakeControlSocket().options).toEqual({
         headers: { Authorization: "Bearer super-secret-token" },
@@ -540,11 +541,11 @@ describe("LettaCodeClient", () => {
 
     const session = client.createSession("agent-123", { cwd: "/tmp/project" });
     try {
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       expect(init.agentId).toBe("agent-123");
       expect(init.conversationId).toBe("conv-created");
 
-      const result = await session.runTurn("hello");
+      const result = await asAdvanced(session).runTurn("hello");
       expect(result.success).toBe(true);
       expect(result.result).toBe("hello from app-server");
       expect(result.runIds).toEqual(["run-1"]);
@@ -594,7 +595,7 @@ describe("LettaCodeClient", () => {
     });
 
     try {
-      await session.initialize();
+      await asAdvanced(session).initialize();
       fakeControlSocket().serverMessage({
         type: "control_request",
         request_id: "approval-1",
@@ -648,7 +649,7 @@ describe("LettaCodeClient", () => {
 
     const session = client.createSession("agent-123");
     try {
-      await session.initialize();
+      await asAdvanced(session).initialize();
       await session.send("this will time out");
       const messages: unknown[] = [];
       for await (const message of session.stream()) {
@@ -681,7 +682,7 @@ describe("LettaCodeClient", () => {
 
     const session = client.createSession("agent-123");
     try {
-      await session.initialize();
+      await asAdvanced(session).initialize();
       const messages: unknown[] = [];
       await session.send("use a tool");
       for await (const message of session.stream()) {
@@ -722,8 +723,8 @@ describe("LettaCodeClient", () => {
 
     const session = client.createSession("agent-123");
     try {
-      await session.initialize();
-      const result = await session.runTurn("use a tool");
+      await asAdvanced(session).initialize();
+      const result = await asAdvanced(session).runTurn("use a tool");
 
       expect(result).toMatchObject({
         type: "result",
@@ -776,7 +777,7 @@ describe("LettaCodeClient", () => {
 
     const session = client.resumeSession("conv-abc");
     try {
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       expect(init.agentId).toBe("agent-from-conversation");
       expect(init.conversationId).toBe("conv-abc");
       expect(fakeControlSocket().sent[0]).toMatchObject({
@@ -803,7 +804,7 @@ describe("LettaCodeClient", () => {
 
     const session = client.resumeSession("local-conv-63");
     try {
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       expect(init.agentId).toBe("agent-from-conversation");
       expect(init.conversationId).toBe("local-conv-63");
       expect(fakeControlSocket().sent[0]).toMatchObject({
@@ -849,7 +850,7 @@ describe("LettaCodeClient", () => {
     });
 
     try {
-      await session.initialize();
+      await asAdvanced(session).initialize();
       expect(fakeControlSocket().sent[0]).toMatchObject({
         type: "runtime_start",
         external_tools: [
@@ -902,7 +903,7 @@ describe("LettaCodeClient", () => {
     });
 
     try {
-      await session.initialize();
+      await asAdvanced(session).initialize();
       expect(fakeControlSocket().sent).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -926,14 +927,14 @@ describe("LettaCodeClient", () => {
         query: { limit: 2, order: "desc" },
       });
 
-      await session.updateToolset("developer");
+      await asAdvanced(session).updateToolset("developer");
       expect(fakeControlSocket().sent.at(-1)).toMatchObject({
         type: "update_toolset",
         runtime: { agent_id: "agent-123", conversation_id: "default" },
         toolset_preference: "developer",
       });
 
-      await expect(session.recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
+      await expect(asAdvanced(session).recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
         recovered: true,
         unsupported: false,
       });

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { LettaCodeClient } from "../index.js";
+import { asAdvanced } from "./advanced-session.js";
 
 type Listener = (event: unknown) => void;
 type FetchInput = Parameters<typeof fetch>[0];
@@ -483,14 +484,14 @@ describe("CloudEnvironmentSession", () => {
     });
 
     const session = client.resumeSession("agent-1");
-    await expect(session.initialize()).rejects.toThrow(
+    await expect(asAdvanced(session).initialize()).rejects.toThrow(
       "Cloud backend requires an environment target until managed Cloud sandboxes land",
     );
 
-    await expect(client.createSession("agent-1").initialize()).rejects.toThrow(
+    await expect(asAdvanced(client.createSession("agent-1")).initialize()).rejects.toThrow(
       "Cloud backend requires an environment target until managed Cloud sandboxes land",
     );
-    await expect(client.resumeSession("conv-1").initialize()).rejects.toThrow(
+    await expect(asAdvanced(client.resumeSession("conv-1")).initialize()).rejects.toThrow(
       "Cloud backend requires an environment target until managed Cloud sandboxes land",
     );
 
@@ -517,7 +518,7 @@ describe("CloudEnvironmentSession", () => {
       permissionMode: "bypassPermissions",
       sleeptime: { trigger: "step-count", stepCount: 3 },
     });
-    const init = await session.initialize();
+    const init = await asAdvanced(session).initialize();
 
     expect(init).toMatchObject({
       type: "init",
@@ -558,14 +559,14 @@ describe("CloudEnvironmentSession", () => {
     }));
     expect(controlSocket.sent.some((command) => command.type === "change_device_state")).toBe(false);
 
-    await session.updateToolset("developer");
+    await asAdvanced(session).updateToolset("developer");
     expect(controlSocket.sent).toContainEqual(expect.objectContaining({
       type: "update_toolset",
       runtime: { agent_id: "agent-1", conversation_id: "default" },
       toolset_preference: "developer",
     }));
 
-    await expect(session.recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
+    await expect(asAdvanced(session).recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
       recovered: true,
       unsupported: false,
     });
@@ -577,7 +578,7 @@ describe("CloudEnvironmentSession", () => {
       request_id: expect.any(String),
     }));
 
-    const result = await session.runTurn("hello");
+    const result = await asAdvanced(session).runTurn("hello");
     expect(result).toMatchObject({
       type: "result",
       success: true,
@@ -616,7 +617,7 @@ describe("CloudEnvironmentSession", () => {
     });
 
     const session = client.resumeSession("agent-1");
-    await session.initialize();
+    await asAdvanced(session).initialize();
 
     expect(requests.some((request) => new URL(request.url).pathname.includes("/sandboxes"))).toBe(false);
     const socketUrl = new URL(FakeCloudSocket.instances[0]!.url);
@@ -646,7 +647,7 @@ describe("CloudEnvironmentSession", () => {
 
     const session = client.resumeSession("agent-1");
     try {
-      const result = await session.runTurn("hello");
+      const result = await asAdvanced(session).runTurn("hello");
       expect(result).toMatchObject({
         success: true,
         result: "hello once",
@@ -676,8 +677,8 @@ describe("CloudEnvironmentSession", () => {
 
     const session = client.resumeSession("agent-1");
     try {
-      await session.initialize();
-      await expect(session.recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
+      await asAdvanced(session).initialize();
+      await expect(asAdvanced(session).recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
         recovered: false,
         unsupported: false,
         detail: "sync failed",
@@ -702,7 +703,7 @@ describe("CloudEnvironmentSession", () => {
 
     const session = client.resumeSession("agent-1");
     try {
-      await session.initialize();
+      await asAdvanced(session).initialize();
       const controlSocket = FakeCloudSocket.socket("control")!;
       const streamSocket = FakeCloudSocket.socket("stream")!;
       const syncCount = controlSocket.sent.filter((command) => command.type === "sync").length;
@@ -849,7 +850,7 @@ describe("CloudEnvironmentSession", () => {
 
     const session = client.resumeSession("conv-1");
     try {
-      const state = await session.bootstrapState({ limit: 3 });
+      const state = await asAdvanced(session).bootstrapState({ limit: 3 });
       expect(state).toMatchObject({
         agentId: "agent-from-conv",
         conversationId: "conv-1",
@@ -890,7 +891,7 @@ describe("CloudEnvironmentSession", () => {
     });
 
     const session = client.resumeSession("agent-1");
-    await session.initialize();
+    await asAdvanced(session).initialize();
 
     const environmentRequest = requests.find((request) => new URL(request.url).pathname === "/v1/environments");
     expect(requests.some((request) => new URL(request.url).pathname.includes("/sandboxes"))).toBe(false);
@@ -978,7 +979,7 @@ describe("CloudEnvironmentSession", () => {
       },
     });
 
-    const result = await session.runTurn("run pwd");
+    const result = await asAdvanced(session).runTurn("run pwd");
 
     expect(result).toMatchObject({ success: true, result: "approved" });
     expect(decisions).toEqual([{ toolName: "Bash", input: { command: "pwd" } }]);
@@ -1044,7 +1045,7 @@ describe("CloudEnvironmentSession", () => {
     });
 
     try {
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       expect(init.tools).toBeUndefined();
 
       const controlSocket = FakeCloudSocket.socket("control")!;
@@ -1169,7 +1170,7 @@ describe("CloudEnvironmentSession", () => {
     });
 
     const session = client.resumeSession("agent-1");
-    const result = await session.runTurn("trigger failure");
+    const result = await asAdvanced(session).runTurn("trigger failure");
 
     expect(result).toMatchObject({
       type: "result",
@@ -1200,7 +1201,7 @@ describe("CloudEnvironmentSession", () => {
     });
 
     const session = client.resumeSession("agent-1");
-    const result = await session.runTurn("trigger delayed failure");
+    const result = await asAdvanced(session).runTurn("trigger delayed failure");
 
     expect(result).toMatchObject({
       type: "result",

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { createSession, resumeSession } from "../index.js";
+import { asAdvanced } from "./advanced-session.js";
 import type {
   SDKMessage,
   SDKResultMessage,
@@ -305,7 +306,7 @@ describeLive("live integration: letta-code-sdk", () => {
       });
       openedSessions.push(session);
 
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       seededConversationId = init.conversationId;
 
       expect(init.type).toBe("init");
@@ -335,7 +336,7 @@ describeLive("live integration: letta-code-sdk", () => {
       });
       openedSessions.push(session);
 
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       expect(init.conversationId).toBe(conversationId);
 
       await writeFixture("resume_conversation_init", init);
@@ -353,7 +354,7 @@ describeLive("live integration: letta-code-sdk", () => {
       });
       openedSessions.push(session);
 
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       const nonce = Math.random().toString(36).slice(2, 8);
       const prompt = `Reply with exactly this text and nothing else: SDK_LIVE_OK_${nonce}`;
 
@@ -383,7 +384,7 @@ describeLive("live integration: letta-code-sdk", () => {
       });
       openedSessions.push(session);
 
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       const prompt =
         "Produce 40 short bullet points about test observability. One bullet per line.";
 
@@ -428,7 +429,7 @@ describeLive("live integration: letta-code-sdk", () => {
       });
       openedSessions.push(session);
 
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
 
       await collectTurn(
         session,
@@ -495,7 +496,7 @@ describeLive("live integration: letta-code-sdk", () => {
       });
       openedSessions.push(session);
 
-      const init = await session.initialize();
+      const init = await asAdvanced(session).initialize();
       const prompt =
         "Write a medium-length response with at least 30 numbered lines describing integration test anti-patterns.";
 
@@ -549,7 +550,7 @@ describeLive("live integration: letta-code-sdk", () => {
       });
       openedSessions.push(session);
 
-      await session.initialize();
+      await asAdvanced(session).initialize();
 
       const attempts: Array<{ prompt: string; messages: SDKMessage[] }> = [];
       const prompts = [
@@ -616,12 +617,12 @@ describeLive("live integration: letta-code-sdk", () => {
         });
         openedSessions.push(session);
 
-        const init = await session.initialize();
+        const init = await asAdvanced(session).initialize();
         expect(init.agentId).toBe(stuckAgentId);
         log(`Session initialized for stuck agent, conversationId: ${init.conversationId}`);
 
         // Attempt recovery - the agent has a pending approval from a Bash tool call
-        const recovery = await session.recoverPendingApprovals({ timeoutMs: 30000 });
+        const recovery = await asAdvanced(session).recoverPendingApprovals({ timeoutMs: 30000 });
         log("Recovery result:", recovery);
 
         // The recovery should either succeed (recovered=true) or report that
@@ -650,7 +651,7 @@ describeLive("live integration: letta-code-sdk", () => {
               stopReason: result.stopReason,
               errorCode: result.errorCode,
             });
-            const followupRecovery = await session.recoverPendingApprovals({ timeoutMs: 30000 });
+            const followupRecovery = await asAdvanced(session).recoverPendingApprovals({ timeoutMs: 30000 });
             log("Post-recovery approval cleanup result", followupRecovery);
           } else if (result.success) {
             log("Post-recovery turn succeeded");

--- a/src/tests/public-session-types.test.ts
+++ b/src/tests/public-session-types.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import type { LettaCodeSession } from "../types.js";
+
+type AssertTrue<T extends true> = T;
+type AssertFalse<T extends false> = T;
+type HasKey<K extends PropertyKey> = K extends keyof LettaCodeSession ? true : false;
+
+type _HasSend = AssertTrue<HasKey<"send">>;
+type _HasStream = AssertTrue<HasKey<"stream">>;
+type _HasListMessages = AssertTrue<HasKey<"listMessages">>;
+type _HasClose = AssertTrue<HasKey<"close">>;
+type _NoInitialize = AssertFalse<HasKey<"initialize">>;
+type _NoRunTurn = AssertFalse<HasKey<"runTurn">>;
+type _NoRecoverPendingApprovals = AssertFalse<HasKey<"recoverPendingApprovals">>;
+type _NoUpdateToolset = AssertFalse<HasKey<"updateToolset">>;
+type _NoBootstrapState = AssertFalse<HasKey<"bootstrapState">>;
+
+describe("public LettaCodeSession type", () => {
+  test("keeps the canonical public session surface", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -510,17 +510,9 @@ export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
 }
 
 export interface LettaCodeSession extends AsyncDisposable {
-  initialize(): Promise<SDKInitMessage>;
   send(message: SendMessage): Promise<void>;
-  runTurn(message: SendMessage, options?: RunTurnOptions): Promise<SDKResultMessage>;
   stream(): AsyncGenerator<SDKMessage>;
-  recoverPendingApprovals(
-    options?: RecoverPendingApprovalsOptions,
-  ): Promise<RecoverPendingApprovalsResult>;
-  /** Update the active remote/listener toolset preference for this session. */
-  updateToolset(toolsetPreference: string): Promise<void>;
   listMessages(options?: ListMessagesOptions): Promise<ListMessagesResult>;
-  bootstrapState(options?: BootstrapStateOptions): Promise<BootstrapStateResult>;
   close(): void;
   readonly agentId: string | null;
   readonly sessionId: string | null;


### PR DESCRIPTION
## Summary
- Narrow `LettaCodeSession` to the intended public surface: `send`, `stream`, `listMessages`, `close`, and readonly IDs
- Keep lifecycle/control/bootstrap helpers available only through internal/test capability casts, punting the controls API to a later typed design
- Update README examples to use `send` + `stream` and avoid misleading caller-local `process.cwd()` for remote/Cloud sessions
- Add a compile-time public session surface test

## Tests
- `bun run check`
- `bun test src/tests/client.test.ts src/tests/cloud-session.test.ts src/tests/public-session-types.test.ts`
- `bun test`

Parallel cleanup PR off `main`, separate from #148.