### PR TITLE
chore: rename npm package to Letta Agent SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Letta Agent SDK
 
-[![npm](https://img.shields.io/npm/v/@letta-ai/letta-code-sdk.svg?style=flat-square)](https://www.npmjs.com/package/@letta-ai/letta-code-sdk) [![Discord](https://img.shields.io/badge/discord-join-blue?style=flat-square&logo=discord)](https://discord.gg/letta)
+[![npm](https://img.shields.io/npm/v/@letta-ai/letta-agent-sdk.svg?style=flat-square)](https://www.npmjs.com/package/@letta-ai/letta-agent-sdk) [![Discord](https://img.shields.io/badge/discord-join-blue?style=flat-square&logo=discord)](https://discord.gg/letta)
 
 The SDK interface to [**Letta Code**](https://github.com/letta-ai/letta-code). Build agents with persistent memory that learn over time. 
 
 ## Installation
 
 ```bash
-npm install @letta-ai/letta-code-sdk
+npm install @letta-ai/letta-agent-sdk
 ```
 
 ## Quick start
@@ -15,7 +15,7 @@ npm install @letta-ai/letta-code-sdk
 ### Client creation
 
 ```ts
-import { LettaCodeClient } from "@letta-ai/letta-code-sdk";
+import { LettaCodeClient } from "@letta-ai/letta-agent-sdk";
 
 // Local: SDK-owned Letta Code app-server over loopback websockets. The SDK
 // spawns/manages the app-server process for you.
@@ -41,7 +41,7 @@ const client = new LettaCodeClient({
 ### Persistent agent with multi-turn conversations
 
 ```ts
-import { LettaCodeClient } from "@letta-ai/letta-code-sdk";
+import { LettaCodeClient } from "@letta-ai/letta-agent-sdk";
 
 const client = new LettaCodeClient({ backend: "local" });
 
@@ -183,7 +183,7 @@ remote and Constellation sessions, `cwd` must be a path inside the selected
 runtime environment.
 
 ```ts
-import { LettaCodeClient } from "@letta-ai/letta-code-sdk";
+import { LettaCodeClient } from "@letta-ai/letta-agent-sdk";
 
 const client = new LettaCodeClient({ backend: "local" });
 
@@ -232,7 +232,7 @@ const sync = await session.sendCommand(
 
 ## Links
 
-- Docs: https://docs.letta.com/letta-code-sdk
+- Docs: https://docs.letta.com/letta-agent-sdk
 - Examples: [`./examples`](./examples)
 
 ---

--- a/build.ts
+++ b/build.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 /**
- * Build script for Letta Code SDK
+ * Build script for Letta Agent SDK
  * Bundles TypeScript source and generates declarations
  */
 
@@ -16,7 +16,7 @@ const __dirname = dirname(__filename);
 const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8"));
 const version = pkg.version;
 
-console.log(`📦 Building Letta Code SDK v${version}...`);
+console.log(`📦 Building Letta Agent SDK v${version}...`);
 
 // Bundle with Bun
 await Bun.build({

--- a/examples/economics-seminar/README.md
+++ b/examples/economics-seminar/README.md
@@ -1,6 +1,6 @@
 # Economics Seminar
 
-A multi-agent academic seminar simulation built on the Letta Code SDK.
+A multi-agent academic seminar simulation built on the Letta Agent SDK.
 
 An economist agent researches and presents findings, then defends their work against a faculty panel of specialists. Each agent has persistent memory and learns from each seminar.
 
@@ -115,7 +115,7 @@ Each agent maintains memory blocks that persist across seminars:
 After running a seminar, the agents can be "teleported" into other contexts:
 
 ```typescript
-import { resumeSession } from '@letta-ai/letta-code-sdk';
+import { resumeSession } from '@letta-ai/letta-agent-sdk';
 
 // Get agent ID from --status
 const drChen = resumeSession('agent-xxx', { permissionMode: 'bypassPermissions' });

--- a/examples/research-team/README.md
+++ b/examples/research-team/README.md
@@ -1,6 +1,6 @@
 # Research Team Demo
 
-A multi-agent academic research system built on the Letta Code SDK. Demonstrates persistent memory and collaborative agents that learn and improve over time.
+A multi-agent academic research system built on the Letta Agent SDK. Demonstrates persistent memory and collaborative agents that learn and improve over time.
 
 ## Overview
 
@@ -201,7 +201,7 @@ The research team agents you create here can be "teleported" into any context:
 ### How It Works
 
 ```typescript
-import { resumeSession } from '@letta-ai/letta-code-sdk';
+import { resumeSession } from '@letta-ai/letta-agent-sdk';
 
 // Get agent ID from team-state.json or --status
 const researcherAgentId = 'agent-xxx-yyy-zzz';
@@ -224,7 +224,7 @@ await researcher.send('Find recent papers on quantum error correction');
 ```typescript
 // server.ts - Turn your research team into an API
 import express from 'express';
-import { resumeSession } from '@letta-ai/letta-code-sdk';
+import { resumeSession } from '@letta-ai/letta-agent-sdk';
 import { loadTeamState } from './tools/file-store';
 
 const app = express();
@@ -268,7 +268,7 @@ After running the demo, check `--status` for agent IDs, then click the links to:
 
 ### Why This Matters
 
-| Claude Agent SDK | Letta Code SDK |
+| Claude Agent SDK | Letta Agent SDK |
 |------------------|----------------|
 | Agents are ephemeral processes | Agents are persistent entities |
 | Memory via local files | Memory on Letta server |
@@ -348,4 +348,4 @@ Modify the system prompts in each agent file to change behavior:
 
 ## License
 
-Apache-2.0 (same as letta-code-sdk)
+Apache-2.0 (same as letta-agent-sdk)

--- a/examples/research-team/teleport-example.ts
+++ b/examples/research-team/teleport-example.ts
@@ -126,7 +126,7 @@ async function main() {
   
   console.log('Try it yourself:\n');
   console.log('   // In your own code:');
-  console.log('   import { resumeSession } from "@letta-ai/letta-code-sdk";');
+  console.log('   import { resumeSession } from "@letta-ai/letta-agent-sdk";');
   console.log(`   const agent = resumeSession("${teamState.agentIds.researcher}");`);
   console.log('   await agent.send("Your question here");');
   console.log('');

--- a/examples/v2-examples.ts
+++ b/examples/v2-examples.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 /**
- * Letta Code SDK V2 Examples
+ * Letta Agent SDK V2 Examples
  * 
  * Comprehensive tests for all SDK features.
  * 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@letta-ai/letta-code-sdk",
+  "name": "@letta-ai/letta-agent-sdk",
   "version": "0.2.1",
-  "description": "SDK for programmatic control of Letta Code CLI",
+  "description": "SDK for programmatic control of Letta agents",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/letta-ai/letta-code-sdk"
+    "url": "https://github.com/letta-ai/letta-agent-sdk"
   },
   "dependencies": {
     "@letta-ai/letta-code": "0.27.14"

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -801,8 +801,8 @@ export class AppServerSession extends RemoteClientSessionCore {
     const options = this.mode.options;
     const command: Record<string, unknown> = {
       client_info: {
-        name: "@letta-ai/letta-code-sdk",
-        title: "Letta Code SDK",
+        name: "@letta-ai/letta-agent-sdk",
+        title: "Letta Agent SDK",
       },
       recover_approvals: false,
       force_device_status: true,

--- a/src/client.ts
+++ b/src/client.ts
@@ -69,7 +69,7 @@ type TurnSession = LettaCodeSession & {
 };
 
 /**
- * Top-level Letta Code SDK client.
+ * Top-level Letta Agent SDK client.
  *
  * `backend` selects how the SDK reaches or runs the Letta Code harness.
  * `local` spawns an SDK-owned Letta Code app-server and speaks the websocket

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -45,7 +45,7 @@ const MIN_SANDBOX_TTL_MINUTES = 1;
 const MAX_SANDBOX_TTL_MINUTES = 60;
 const DEFAULT_SANDBOX_READY_TIMEOUT_MS = 120_000;
 const DEFAULT_SANDBOX_READY_POLL_INTERVAL_MS = 1_000;
-const SDK_AGENT_ORIGIN = "@letta-ai/letta-code-sdk";
+const SDK_AGENT_ORIGIN = "@letta-ai/letta-agent-sdk";
 
 type FetchLike = typeof fetch;
 
@@ -757,7 +757,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     const command: Record<string, unknown> = {
       client_info: {
         name: SDK_AGENT_ORIGIN,
-        title: "Letta Code SDK",
+        title: "Letta Agent SDK",
       },
       agent_id: runtime.agent_id,
       conversation_id: runtime.conversation_id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 /**
- * Letta Code SDK
+ * Letta Agent SDK
  *
  * Programmatic control of Letta Code CLI with persistent agent memory.
  *
  * @example
  * ```typescript
- * import { LettaCodeClient, createAgent, createSession, resumeSession, prompt } from '@letta-ai/letta-code-sdk';
+ * import { LettaCodeClient, createAgent, createSession, resumeSession, prompt } from '@letta-ai/letta-agent-sdk';
  *
  * const client = new LettaCodeClient({ backend: 'local' });
  * const agentId = await client.createAgent();

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -288,7 +288,7 @@ function assertRawMessageShape(page: ListMessagesResult): void {
   }
 }
 
-describeLive("live integration: letta-code-sdk", () => {
+describeLive("live integration: letta-agent-sdk", () => {
   afterAll(() => {
     for (const session of openedSessions) {
       session.close();

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -134,7 +134,7 @@ export function buildCliArgs(options: InternalSessionOptions): string[] {
         args.push("--memory-blocks", JSON.stringify(memoryBlocksJson));
         if (presetNames.length > 0) {
           console.warn(
-            "[letta-code-sdk] Using custom memory blocks. " +
+            "[letta-agent-sdk] Using custom memory blocks. " +
             `Preset blocks are ignored when custom blocks are provided: ${presetNames.join(", ")}`
           );
         }
@@ -275,7 +275,7 @@ export class SubprocessTransport {
       this.process.stderr.on("data", (data: Buffer) => {
         const msg = data.toString().trim();
         if (msg) {
-          console.error("[letta-code-sdk] CLI stderr:", msg);
+          console.error("[letta-agent-sdk] CLI stderr:", msg);
           this.stderrLines.push(msg);
         }
       });
@@ -291,7 +291,7 @@ export class SubprocessTransport {
     // process exit lets messages() break out of its loop cleanly.
     this.process.on("close", (code, signal) => {
       if (code !== 0 && code !== null) {
-        console.error(`[letta-code-sdk] CLI process exited with code ${code}`);
+        console.error(`[letta-agent-sdk] CLI process exited with code ${code}`);
       }
       sdkLog("close", `CLI process exited: pid=${pid} code=${code} signal=${signal} wireMessages=${this.wireMessageCount} msSinceLastMsg=${this.lastMessageAt ? Date.now() - this.lastMessageAt : 0} pendingResolvers=${this.messageResolvers.length} queueLen=${this.messageQueue.length}`);
       this.closed = true;
@@ -303,7 +303,7 @@ export class SubprocessTransport {
     });
 
     this.process.on("error", (err) => {
-      console.error("[letta-code-sdk] CLI process error:", err);
+      console.error("[letta-agent-sdk] CLI process error:", err);
       this.closed = true;
     });
   }


### PR DESCRIPTION
## Summary
- rename the published package identity to `@letta-ai/letta-agent-sdk`
- update README install/import snippets, npm badge, docs link, and example docs
- update SDK runtime identity metadata and log prefixes from Letta Code SDK to Letta Agent SDK

## Testing
- `bun run check`
- `bun test`
- `bun run build`
- `npm pack --dry-run --json | jq -r '.[0].id, .[0].filename'`
