### PR TITLE
fix: add sharp and node-pty to trustedDependencies for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   },
   "license": "Apache-2.0",
   "trustedDependencies": [
-    "@letta-ai/letta-code"
+    "@letta-ai/letta-code",
+    "sharp",
+    "node-pty"
   ]
 }


### PR DESCRIPTION
Bun blocks lifecycle scripts by default for security. The sharp and node-pty packages need their install scripts to download platform-specific native binaries. Without this, bun install fails to set up these modules correctly on Windows, causing the CLI to crash on startup.

This ensures bun install works out of the box for all platforms.