### PR TITLE
fix: improve cloud API error messages with action, URL, and auth hints

### DIFF
--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -205,11 +205,22 @@ function responseErrorMessage(body: unknown, fallback: string): string {
   return fallback;
 }
 
-function assertOkResponse(response: Response, body: unknown, action: string): void {
+function assertOkResponse(response: Response, body: unknown, action: string, url?: string): void {
   if (!response.ok) {
-    throw new Error(
-      responseErrorMessage(body, `${action} failed with HTTP ${response.status}`),
-    );
+    const detail = responseErrorMessage(body, `HTTP ${response.status}`);
+    const parts = [`${action} failed`, detail];
+    if (url) parts.push(`URL: ${url}`);
+    if (response.status === 401 || response.status === 403) {
+      const env = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+        .process?.env;
+      const hasKey = !!(env?.LETTA_API_KEY ?? env?.LETTA_CLOUD_API_KEY);
+      parts.push(
+        hasKey
+          ? "Authentication failed — the API key may be invalid or lack permissions for this resource."
+          : "No API key found. Set LETTA_API_KEY (or pass apiKey in client options).",
+      );
+    }
+    throw new Error(parts.join(" — "));
   }
 }
 
@@ -839,7 +850,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       body: JSON.stringify({}),
     });
     const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud createSession()");
+    assertOkResponse(response, body, "Cloud createSession()", url.toString());
     if (!isCloudConversation(body)) {
       throw new Error("Cloud createSession() response did not include a conversation id.");
     }
@@ -854,7 +865,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       { headers: cloudHeaders(this.cloudOptions) },
     );
     const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud resumeSession()");
+    assertOkResponse(response, body, "Cloud resumeSession()", `${baseUrl}/v1/conversations/${encodeURIComponent(conversationId)}`);
     if (!isCloudConversation(body)) {
       throw new Error(`Cloud resumeSession() could not retrieve conversation ${conversationId}.`);
     }
@@ -912,7 +923,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       },
     );
     const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud create managed sandbox");
+    assertOkResponse(response, body, "Cloud create managed sandbox", `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/sandboxes`);
     if (!isCloudAgentSandbox(body)) {
       throw new Error("Cloud create managed sandbox response did not include sandbox connection details.");
     }
@@ -967,7 +978,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       },
     );
     const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud refresh managed sandbox");
+    assertOkResponse(response, body, "Cloud refresh managed sandbox", `${baseUrl}/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes/refresh`);
     if (!isCloudAgentSandboxRefresh(body) || !body.success) {
       throw new Error("Cloud refresh managed sandbox response did not confirm refresh.");
     }
@@ -992,7 +1003,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     );
     const body = await parseJsonResponse(response);
     if (response.status === 404) return;
-    assertOkResponse(response, body, "Cloud terminate managed sandbox");
+    assertOkResponse(response, body, "Cloud terminate managed sandbox", `${baseUrl}/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes`);
   }
 
   private async waitForManagedSandboxConnection(


### PR DESCRIPTION
The assertOkResponse function in cloud-session.ts previously threw bare errors like Unauthorized with no context about what failed or how to fix it. Now error messages include the action being performed, the HTTP status code, the API URL that was called, and for 401/403 responses whether an API key was found plus a hint to set LETTA_API_KEY if missing.

This makes cloud backend failures much easier to debug, especially for new users who hit auth issues on first run.

Generated with Letta Code