### PR TITLE
Require explicit model for Cloud agent creation

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -60,6 +60,10 @@ function hasCreateAgentEnvironment(options: CreateAgentOptions): boolean {
   return "environment" in (options as Record<string, unknown>);
 }
 
+function hasExplicitCreateAgentModel(options: CreateAgentOptions): boolean {
+  return typeof options.model === "string" && options.model.trim().length > 0;
+}
+
 function looksLikeConversationId(id: string): boolean {
   return id.startsWith("conv-") || id.startsWith("local-conv-");
 }
@@ -176,6 +180,11 @@ export class LettaCodeClient {
       return initMsg.agentId;
     }
     if (this.backend === "cloud") {
+      if (!hasExplicitCreateAgentModel(options)) {
+        throw new Error(
+          'Constellation createAgent() requires an explicit model. Pass model in createAgent({ model: "provider/model" }).',
+        );
+      }
       return createCloudAgent(this.cloudOptions(), options);
     }
     this.assertLocalBackend("createAgent");

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1055,9 +1055,39 @@ describe("CloudEnvironmentSession", () => {
     ]);
     expect(controlSocket.sent).toContainEqual(expect.objectContaining({ type: "enable_memfs" }));
 
-    await expect(client.createAgent({ systemPrompt: "default" })).rejects.toThrow(
+    await expect(client.createAgent({
+      model: "anthropic/claude-sonnet-4",
+      systemPrompt: "default",
+    })).rejects.toThrow(
       "App-server createAgent() does not yet support system prompt presets",
     );
+  });
+
+  test("rejects Cloud createAgent without an explicit model", async () => {
+    resetFakeCloud();
+    resetFakeAppServer();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaCodeClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      appServer: {
+        url: "ws://app-server.test/ws",
+        WebSocket: FakeAppServerSocket,
+      },
+    });
+
+    await expect(client.createAgent({
+      systemPrompt: "You are a repo assistant.",
+    })).rejects.toThrow("Constellation createAgent() requires an explicit model");
+    await expect(client.createAgent({
+      model: "   ",
+    })).rejects.toThrow("Constellation createAgent() requires an explicit model");
+
+    expect(requests).toHaveLength(0);
+    expect(FakeAppServerSocket.instances).toHaveLength(0);
   });
 
   test("responds to Remote Client approval requests through canUseTool", async () => {


### PR DESCRIPTION
## Summary
- Reject Cloud `createAgent()` calls that omit `model` or pass only whitespace.
- Keep other backends unchanged while preserving existing Cloud app-server creation behavior when a model is explicit.
- Add test coverage for the fail-fast Cloud validation path.

## Test plan
- [x] `npm run check --prefix /Users/ariwebb/Documents/letta-agent-sdk`
- [x] `npm test --prefix /Users/ariwebb/Documents/letta-agent-sdk -- src/tests/cloud-session.test.ts`
- [x] `npm test --prefix /Users/ariwebb/Documents/letta-agent-sdk`

👾 Generated with [Letta Code](https://letta.com)