### PR TITLE
Avoid app-server wording in createAgent preset errors

### DIFF
--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -233,11 +233,11 @@ export function createAgentBody(
   if (options.systemPrompt !== undefined) {
     if (typeof options.systemPrompt === "string") {
       if (isPresetSystemPrompt(options.systemPrompt)) {
-        throw new Error("App-server createAgent() does not yet support system prompt presets.");
+        throw new Error("createAgent() does not yet support system prompt presets for this backend.");
       }
       body.system = options.systemPrompt;
     } else {
-      throw new Error("App-server createAgent() does not yet support system prompt preset objects.");
+      throw new Error("createAgent() does not yet support system prompt preset objects for this backend.");
     }
   }
 

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1059,7 +1059,7 @@ describe("CloudEnvironmentSession", () => {
       model: "anthropic/claude-sonnet-4",
       systemPrompt: "default",
     })).rejects.toThrow(
-      "App-server createAgent() does not yet support system prompt presets",
+      "createAgent() does not yet support system prompt presets for this backend",
     );
   });
 


### PR DESCRIPTION
## Summary
- Replace internal app-server wording in unsupported `createAgent()` system prompt preset errors with backend-neutral SDK wording.
- Update Cloud test expectations so Cloud callers see the backend-neutral error.

## Test plan
- [x] `npm test --prefix /Users/ariwebb/Documents/letta-agent-sdk/.letta/worktrees/sdk-preset-error -- src/tests/cloud-session.test.ts`
- [x] `npm run check --prefix /Users/ariwebb/Documents/letta-agent-sdk/.letta/worktrees/sdk-preset-error`
- [x] `git diff --check`

👾 Generated with [Letta Code](https://letta.com)