### PR TITLE
examples: custom external tools

### DIFF
--- a/examples/custom-tools/README.md
+++ b/examples/custom-tools/README.md
@@ -1,0 +1,65 @@
+# Custom External Tools
+
+A minimal example showing how to define custom tools that execute locally in the SDK process while the agent runs in a cloud sandbox.
+
+## How it works
+
+1. You define tools as `AgentTool` objects — each with a `name`, `description`, JSON Schema `parameters`, and an `execute` function.
+2. Tools are passed to `resumeSession()` via the `tools` option.
+3. The SDK sends tool definitions to the agent as `external_tools` in the `runtime_start` command.
+4. When the agent calls a tool, the app-server sends an `external_tool_call_request` over the websocket.
+5. The SDK intercepts it, runs your `execute()` function locally, and sends the result back.
+6. The agent incorporates the result and continues.
+
+The agent runs in the cloud; your tool code runs on your machine. The SDK bridges the two over the websocket.
+
+## Quick start
+
+```bash
+# Requires LETTA_API_KEY in the environment
+bun run examples/custom-tools/main.ts
+```
+
+## What it demonstrates
+
+- **`get_local_time`** — returns the SDK process's local time and timezone. Shows a tool with optional parameters.
+- **`roll_dice`** — rolls dice with a configurable count and number of sides. Shows a tool with required parameters.
+
+The example runs two turns: one for each tool. Each turn logs the tool call, tool result, and the agent's final response.
+
+## Defining your own tools
+
+```typescript
+import { type AnyAgentTool } from "@letta-ai/letta-agent-sdk";
+
+const myTool: AnyAgentTool = {
+  name: "my_tool",
+  label: "My Tool",
+  description: "What this tool does, shown to the agent.",
+  parameters: {
+    type: "object",
+    properties: {
+      input: { type: "string", description: "The input to process" },
+    },
+    required: ["input"],
+  },
+  execute: async (toolCallId, args) => {
+    const { input } = args as { input: string };
+    return {
+      content: [{ type: "text", text: `Result: ${input.toUpperCase()}` }],
+    };
+  },
+};
+
+// Pass to resumeSession
+const session = client.resumeSession(agentId, {
+  tools: [myTool],
+});
+```
+
+## Key points
+
+- Tools execute in the SDK process, not in the agent's sandbox. This means they have access to your local filesystem, environment, and network.
+- The `execute` function receives `(toolCallId, args, signal?, onUpdate?)`. The `args` are the parsed JSON arguments from the agent's tool call.
+- Return `AgentToolResult` with a `content` array of `{ type: "text" | "image", text?, data?, mimeType? }` parts.
+- Tools are registered per-session via the `tools` option. They are not persisted on the agent.

--- a/examples/custom-tools/main.ts
+++ b/examples/custom-tools/main.ts
@@ -1,0 +1,159 @@
+/**
+ * Custom External Tools Example
+ *
+ * Demonstrates how to define custom tools that execute locally in the SDK
+ * process while the agent runs in a cloud sandbox. The agent sees the tool,
+ * calls it, and the SDK runs your execute() function — the result is sent
+ * back to the agent automatically over the websocket.
+ *
+ * Requires LETTA_API_KEY in the environment.
+ *
+ * Run:
+ *   bun run examples/custom-tools/main.ts
+ */
+
+import { LettaCodeClient, type AnyAgentTool } from "../../src/index.js";
+
+// ─── Custom tool definitions ─────────────────────────────────────────
+
+/**
+ * Returns the local time of the SDK process.
+ * The agent can call this to answer "what time is it locally?"
+ */
+const getLocalTime: AnyAgentTool = {
+  name: "get_local_time",
+  label: "Get Local Time",
+  description:
+    "Get the current local time and timezone of the SDK process. " +
+    "Use this when the user asks what time it is locally.",
+  parameters: {
+    type: "object",
+    properties: {
+      format: {
+        type: "string",
+        description: "Optional format: '12h' or '24h'. Defaults to '24h'.",
+      },
+    },
+  },
+  execute: async (_toolCallId, args) => {
+    const input = args as { format?: string };
+    const now = new Date();
+    const use12h = input.format === "12h";
+    const timeStr = now.toLocaleTimeString("en-US", {
+      hour12: use12h,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    });
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Local time: ${timeStr} (${tz})`,
+        },
+      ],
+    };
+  },
+};
+
+/**
+ * Rolls dice and returns the result.
+ * Demonstrates a tool with required parameters.
+ */
+const rollDice: AnyAgentTool = {
+  name: "roll_dice",
+  label: "Roll Dice",
+  description:
+    "Roll a number of dice and return the results. " +
+    "Useful for games or random decisions.",
+  parameters: {
+    type: "object",
+    properties: {
+      count: {
+        type: "number",
+        description: "Number of dice to roll (1-10).",
+        minimum: 1,
+        maximum: 10,
+      },
+      sides: {
+        type: "number",
+        description: "Number of sides per die (default 6).",
+        minimum: 2,
+        maximum: 100,
+      },
+    },
+    required: ["count"],
+  },
+  execute: async (_toolCallId, args) => {
+    const input = args as { count: number; sides?: number };
+    const sides = input.sides ?? 6;
+    const rolls = Array.from(
+      { length: input.count },
+      () => Math.floor(Math.random() * sides) + 1,
+    );
+    const total = rolls.reduce((a, b) => a + b, 0);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Rolled ${input.count}d${sides}: [${rolls.join(", ")}] = ${total}`,
+        },
+      ],
+    };
+  },
+};
+
+// ─── Main ────────────────────────────────────────────────────────────
+
+async function main() {
+  const client = new LettaCodeClient({
+    backend: "cloud",
+    apiKey: process.env.LETTA_API_KEY,
+  });
+
+  const agentId = await client.createAgent({
+    model: "letta/auto",
+    persona: "You are a helpful assistant with access to custom tools.",
+  });
+  console.log("Created agent:", agentId);
+
+  const session = client.resumeSession(agentId, {
+    permissionMode: "bypassPermissions",
+    tools: [getLocalTime, rollDice],
+  });
+
+  try {
+    console.log("\n--- Turn 1: get_local_time ---");
+    await session.send(
+      "What time is it where the SDK is running? Use the get_local_time tool.",
+    );
+
+    for await (const msg of session.stream()) {
+      if (msg.type === "assistant") process.stdout.write(msg.content);
+      if (msg.type === "tool_call")
+        console.log(`\n  [tool_call] ${msg.toolName}`, msg.toolInput);
+      if (msg.type === "tool_result")
+        console.log(`  [tool_result] ${msg.content}`);
+      if (msg.type === "result") {
+        console.log(`\n  (took ${msg.durationMs}ms)\n`);
+      }
+    }
+
+    console.log("\n--- Turn 2: roll_dice ---");
+    await session.send("Roll 3 dice for me. Use the roll_dice tool.");
+
+    for await (const msg of session.stream()) {
+      if (msg.type === "assistant") process.stdout.write(msg.content);
+      if (msg.type === "tool_call")
+        console.log(`\n  [tool_call] ${msg.toolName}`, msg.toolInput);
+      if (msg.type === "tool_result")
+        console.log(`  [tool_result] ${msg.content}`);
+      if (msg.type === "result") {
+        console.log(`\n  (took ${msg.durationMs}ms)\n`);
+      }
+    }
+  } finally {
+    session.close();
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary

- Adds `examples/custom-tools/main.ts` — a minimal example showing how to define custom `AgentTool` objects that execute locally in the SDK process while the agent runs in a cloud sandbox
- Adds `examples/custom-tools/README.md` — explains the external tool flow, how to run the example, and how to define your own tools

Two tools are demonstrated:
- **`get_local_time`** — returns the SDK process local time/timezone (optional parameter)
- **`roll_dice`** — rolls dice with configurable count and sides (required parameter)

The example runs two turns and logs the full tool call/result round-trip.

## Test plan

- [ ] `bun run examples/custom-tools/main.ts` runs successfully with `LETTA_API_KEY` in the environment
- [ ] Both tools are called by the agent and return results
- [ ] `tool_call` and `tool_result` events appear in the stream output

👾 Generated with [Letta Code](https://letta.com)