### PR TITLE
fix(local): pass --backend local when spawning local app-server

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -415,6 +415,7 @@ export class LettaCodeClient {
     const appServer = localOptions.appServer;
     return {
       local: appServer?.url === undefined,
+      localBackend: "local",
       ...(appServer?.url !== undefined ? { url: appServer.url } : {}),
       ...(appServer?.WebSocket !== undefined ? { WebSocket: appServer.WebSocket } : {}),
       ...(appServer?.requestTimeoutMs !== undefined


### PR DESCRIPTION
## Summary

When using `new LettaCodeClient({ backend: "local" })`, the SDK spawns a local app-server via `startLocalAppServer()`. `localAppServerOptions()` did **not** include `localBackend`, so `buildLocalAppServerArgs()` never emitted `--backend local`. The spawned app-server inherited the machine's global default (`letta backend`) — which is `api` (Letta Cloud) on most machines — causing `createAgent()` to fail with `Missing LETTA_API_KEY` / connection errors even though the caller explicitly requested local mode.

`localAppServerOptions()` now returns `localBackend: "local"`, so the spawned CLI runs with `--backend local`.

```ts
// src/client.ts — localAppServerOptions()
return {
  local: appServer?.url === undefined,
  localBackend: "local",   // <-- added
  ...
};
```

This mirrors the existing `cloudHarnessAppServerOptions()` in `cloud-session.ts`, which already sets `localBackend` explicitly (`"api"` for the cloud-harness case).

## Test plan
- [x] Built the SDK and symlinked it into a quickstart (`"@letta-ai/letta-agent-sdk": "file:../letta-code-sdk"`)
- [x] Ran `npx tsx quickstart.ts` with `backend: "local"` and **no** global `letta backend local` — full flow succeeded:
  - `createAgent()` → `agent-local-…`
  - `createSession()` → `conversationId` populated after first `send()`
  - `send()` + `stream()` → agent produced output end-to-end
- [x] Confirmed the spawned process args now include `--backend local`

👾 Generated with [Letta Code](https://letta.com)