### PR TITLE
refactor!: rename LettaCodeClient to LettaAgentClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ npm install @letta-ai/letta-agent-sdk
 ### Client creation
 
 ```ts
-import { LettaCodeClient } from "@letta-ai/letta-agent-sdk";
+import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";
 
 // Local: SDK-owned Letta Code app-server over loopback websockets. The SDK
 // spawns/manages the app-server process for you.
-const localClient = new LettaCodeClient({ backend: "local" });
+const localClient = new LettaAgentClient({ backend: "local" });
 
 // Remote: connect to a user-managed Letta Code app-server over websockets.
-const remoteClient = new LettaCodeClient({
+const remoteClient = new LettaAgentClient({
   backend: "remote",
   url: "http://127.0.0.1:4500",
   // Required when the app-server is bound to a non-loopback interface with
@@ -32,7 +32,7 @@ const remoteClient = new LettaCodeClient({
 
 // Constellation: create or resume agents whose state lives in Letta's
 // agent cloud, with an SDK-managed sandbox by default.
-const client = new LettaCodeClient({
+const client = new LettaAgentClient({
   backend: "cloud",
   apiKey: process.env.LETTA_API_KEY,
 });
@@ -41,9 +41,9 @@ const client = new LettaCodeClient({
 ### Persistent agent with multi-turn conversations
 
 ```ts
-import { LettaCodeClient } from "@letta-ai/letta-agent-sdk";
+import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";
 
-const client = new LettaCodeClient({ backend: "local" });
+const client = new LettaAgentClient({ backend: "local" });
 
 const agentId = await client.createAgent({
   persona: "You are a helpful coding assistant for TypeScript projects.",
@@ -92,7 +92,7 @@ Letta Code websocket protocol for `runtime_start`, `input`, streaming deltas,
 and SDK-defined external tools.
 
 ```ts
-const client = new LettaCodeClient({
+const client = new LettaAgentClient({
   backend: "remote",
   url: "http://127.0.0.1:4500",
   authToken: process.env.LETTA_APP_SERVER_TOKEN,
@@ -121,7 +121,7 @@ it to come online, refreshes it while the session is active, and cleans it up on
 close.
 
 ```ts
-const client = new LettaCodeClient({
+const client = new LettaAgentClient({
   backend: "cloud",
   apiKey: process.env.LETTA_API_KEY,
   sandbox: {
@@ -156,7 +156,7 @@ session to use an existing remote runtime instead of an SDK-managed sandbox. Use
 the environment name from `letta remote --env-name <name>`:
 
 ```ts
-const client = new LettaCodeClient({
+const client = new LettaAgentClient({
   backend: "cloud",
   apiKey: process.env.LETTA_API_KEY,
   environment: { name: "devbox" },
@@ -197,9 +197,9 @@ remote and Constellation sessions, `cwd` must be a path inside the selected
 runtime environment.
 
 ```ts
-import { LettaCodeClient } from "@letta-ai/letta-agent-sdk";
+import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";
 
-const client = new LettaCodeClient({ backend: "local" });
+const client = new LettaAgentClient({ backend: "local" });
 
 const session = client.resumeSession("agent-123", {
   model: "anthropic/claude-sonnet-4",

--- a/src/client.ts
+++ b/src/client.ts
@@ -82,7 +82,7 @@ type TurnSession = LettaCodeSession & {
  * `cloud` uses agents hosted on Constellation, with an explicit remote
  * environment or SDK-managed sandbox.
  */
-export class LettaCodeClient {
+export class LettaAgentClient {
   readonly backend: LettaCodeBackend;
   readonly environment: LettaCodeEnvironment | undefined;
   private readonly options: LettaCodeClientOptions;
@@ -101,16 +101,16 @@ export class LettaCodeClient {
 
     if (this.backend === "local" && this.environment !== undefined) {
       throw new Error(
-        'LettaCodeClient environment is only valid with backend: "cloud".',
+        'LettaAgentClient environment is only valid with backend: "cloud".',
       );
     }
     if (this.backend === "remote" && this.environment !== undefined) {
       throw new Error(
-        'LettaCodeClient environment is only valid with backend: "cloud"; remote url selects the app-server runtime.',
+        'LettaAgentClient environment is only valid with backend: "cloud"; remote url selects the app-server runtime.',
       );
     }
     if (this.backend !== "cloud" && (options as { sandbox?: unknown }).sandbox !== undefined) {
-      throw new Error('LettaCodeClient sandbox options are only valid with backend: "cloud".');
+      throw new Error('LettaAgentClient sandbox options are only valid with backend: "cloud".');
     }
 
     if (this.backend === "local") {
@@ -140,7 +140,7 @@ export class LettaCodeClient {
 
     if (this.backend === "remote") {
       if (!("url" in options) || typeof options.url !== "string" || options.url.length === 0) {
-        throw new Error("LettaCodeClient remote backend requires a non-empty url.");
+        throw new Error("LettaAgentClient remote backend requires a non-empty url.");
       }
       if (
         options.requestTimeoutMs !== undefined &&
@@ -354,7 +354,7 @@ export class LettaCodeClient {
     }
 
     throw new Error(
-      `LettaCodeClient backend '${this.backend}' is not implemented yet. ${action} currently supports backend 'local' only.`,
+      `LettaAgentClient backend '${this.backend}' is not implemented yet. ${action} currently supports backend 'local' only.`,
     );
   }
 
@@ -402,7 +402,7 @@ export class LettaCodeClient {
       return;
     }
     throw new Error(
-      `LettaCodeClient backend '${this.backend}' is not implemented yet. ${action} currently supports backend 'local' only.`,
+      `LettaAgentClient backend '${this.backend}' is not implemented yet. ${action} currently supports backend 'local' only.`,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,9 @@
  *
  * @example
  * ```typescript
- * import { LettaCodeClient, createAgent, createSession, resumeSession, prompt } from '@letta-ai/letta-agent-sdk';
+ * import { LettaAgentClient, createAgent, createSession, resumeSession, prompt } from '@letta-ai/letta-agent-sdk';
  *
- * const client = new LettaCodeClient({ backend: 'local' });
+ * const client = new LettaAgentClient({ backend: 'local' });
  * const agentId = await client.createAgent();
  * const clientSession = client.resumeSession(agentId);
  *
@@ -33,7 +33,7 @@
  */
 
 import { Session } from "./session.js";
-import { LettaCodeClient } from "./client.js";
+import { LettaAgentClient } from "./client.js";
 import type {
   CreateSessionOptions,
   CreateAgentOptions,
@@ -118,7 +118,7 @@ export type {
 } from "./types.js";
 
 export { Session } from "./session.js";
-export { LettaCodeClient } from "./client.js";
+export { LettaAgentClient } from "./client.js";
 
 export { extractStreamTextDelta } from "./stream-events.js";
 
@@ -154,7 +154,7 @@ export {
  */
 export async function createAgent(options: CreateAgentOptions = {}): Promise<string> {
   validateCreateAgentOptions(options);
-  return new LettaCodeClient().createAgent(options);
+  return new LettaAgentClient().createAgent(options);
 }
 
 /**
@@ -178,11 +178,11 @@ export function createSession(
 ): LettaCodeSession {
   validateCreateSessionOptions(options);
   if (agentId) {
-    return new LettaCodeClient().createSession(agentId, options);
+    return new LettaAgentClient().createSession(agentId, options);
   }
   // The app-server runtime_start protocol requires an explicit agent id. Keep
   // the historical default/LRU-agent helper on the legacy stdio transport.
-  return new LettaCodeClient({ backend: "local", transport: "stdio" }).createSession(options);
+  return new LettaAgentClient({ backend: "local", transport: "stdio" }).createSession(options);
 }
 
 /**
@@ -208,7 +208,7 @@ export function resumeSession(
   options: CreateSessionOptions = {},
 ): LettaCodeSession {
   validateCreateSessionOptions(options);
-  return new LettaCodeClient().resumeSession(id, options);
+  return new LettaAgentClient().resumeSession(id, options);
 }
 
 /**
@@ -287,7 +287,7 @@ export async function listMessagesDirect(
 ): Promise<ListMessagesResult> {
   // resumeSession uses --default which maps to the agent's default conversation.
   // The session is transient: we only need it long enough to list messages.
-  const session = new LettaCodeClient().resumeSession(agentId, {
+  const session = new LettaAgentClient().resumeSession(agentId, {
     permissionMode: "bypassPermissions",
   });
   await (session as InitializableSession).initialize();

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { LettaCodeClient, Session } from "../index.js";
+import { LettaAgentClient, Session } from "../index.js";
 import { asAdvanced } from "./advanced-session.js";
 
 type Listener = (event: unknown) => void;
@@ -457,9 +457,9 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
   }
 }
 
-describe("LettaCodeClient", () => {
+describe("LettaAgentClient", () => {
   test("defaults to the implemented local backend", () => {
-    const client = new LettaCodeClient();
+    const client = new LettaAgentClient();
 
     expect(client.backend).toBe("local");
     expect(client.environment).toBeUndefined();
@@ -467,7 +467,7 @@ describe("LettaCodeClient", () => {
 
   test("creates local app-server sessions without starting transport until use", () => {
     FakeAppServerSocket.instances = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "local",
       appServer: { url: "ws://127.0.0.1:4500/ws", WebSocket: FakeAppServerSocket },
     });
@@ -482,7 +482,7 @@ describe("LettaCodeClient", () => {
   });
 
   test("explicit local stdio transport keeps legacy Session fallback", async () => {
-    const client = new LettaCodeClient({ backend: "local", transport: "stdio" });
+    const client = new LettaAgentClient({ backend: "local", transport: "stdio" });
     const session = client.resumeSession("agent-123");
 
     try {
@@ -496,7 +496,7 @@ describe("LettaCodeClient", () => {
   });
 
   test("rejects environment overrides on local sessions", () => {
-    const client = new LettaCodeClient({ backend: "local" });
+    const client = new LettaAgentClient({ backend: "local" });
 
     expect(() =>
       client.resumeSession("agent-123", { environment: "work-laptop" }),
@@ -505,14 +505,14 @@ describe("LettaCodeClient", () => {
 
   test("rejects environment on remote app-server clients", () => {
     expect(() =>
-      new LettaCodeClient({
+      new LettaAgentClient({
         backend: "remote",
         url: "wss://example.com/ws",
         environment: "work-laptop",
       } as never),
     ).toThrow("remote url selects the app-server runtime");
 
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "wss://example.com/ws",
     });
@@ -523,7 +523,7 @@ describe("LettaCodeClient", () => {
 
   test("local backend uses app-server when an agent id is provided", async () => {
     FakeAppServerSocket.instances = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "local",
       appServer: { url: "ws://127.0.0.1:4500/ws", WebSocket: FakeAppServerSocket },
     });
@@ -548,7 +548,7 @@ describe("LettaCodeClient", () => {
   test("app-server init tools are backend-reported, not SDK external tools", async () => {
     FakeAppServerSocket.instances = [];
     FakeAppServerSocket.reportedAgentTools = [{ name: "Bash" }, { name: "Read" }];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "ws://127.0.0.1:4500/ws",
       WebSocket: FakeAppServerSocket,
@@ -583,11 +583,11 @@ describe("LettaCodeClient", () => {
   });
 
   test("constructs remote backend and keeps cloud construction typed", () => {
-    const remoteClient = new LettaCodeClient({
+    const remoteClient = new LettaAgentClient({
       backend: "remote",
       url: "wss://example.com/ws",
     });
-    const cloudClient = new LettaCodeClient({
+    const cloudClient = new LettaAgentClient({
       backend: "cloud",
       environment: { name: "LettaDevelopers" },
     });
@@ -599,7 +599,7 @@ describe("LettaCodeClient", () => {
 
   test("passes remote auth tokens to app-server websocket upgrades", async () => {
     FakeAppServerSocket.instances = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "http://127.0.0.1:4500",
       authToken: " super-secret-token\n",
@@ -622,7 +622,7 @@ describe("LettaCodeClient", () => {
   });
 
   test("constructs cloud backend sessions without using the local fallback", () => {
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       environment: "LettaDevelopers",
     });
@@ -635,7 +635,7 @@ describe("LettaCodeClient", () => {
 
   test("starts remote app-server sessions and runs a turn", async () => {
     FakeAppServerSocket.instances = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "http://127.0.0.1:4500",
       WebSocket: FakeAppServerSocket,
@@ -678,7 +678,7 @@ describe("LettaCodeClient", () => {
   test("websocket protocol sessions respond to can_use_tool control requests through the shared approval bridge", async () => {
     FakeAppServerSocket.instances = [];
     const approvals: Array<{ toolName: string; input: Record<string, unknown> }> = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "http://127.0.0.1:4500",
       WebSocket: FakeAppServerSocket,
@@ -742,7 +742,7 @@ describe("LettaCodeClient", () => {
   test("websocket protocol transport failures emit streamed error before failed result", async () => {
     FakeAppServerSocket.instances = [];
     FakeAppServerSocket.inputScenario = "hang";
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "http://127.0.0.1:4500",
       WebSocket: FakeAppServerSocket,
@@ -776,7 +776,7 @@ describe("LettaCodeClient", () => {
   test("websocket protocol sessions wait through auto-handled requires_approval stops", async () => {
     FakeAppServerSocket.instances = [];
     FakeAppServerSocket.inputScenario = "autoApprovalContinuation";
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "http://127.0.0.1:4500",
       WebSocket: FakeAppServerSocket,
@@ -817,7 +817,7 @@ describe("LettaCodeClient", () => {
   test("websocket protocol sessions terminalize only genuine pending approvals", async () => {
     FakeAppServerSocket.instances = [];
     FakeAppServerSocket.inputScenario = "manualApprovalWait";
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "http://127.0.0.1:4500",
       WebSocket: FakeAppServerSocket,
@@ -843,7 +843,7 @@ describe("LettaCodeClient", () => {
   test("websocket protocol sessions let the listener queue sends during an active turn", async () => {
     FakeAppServerSocket.instances = [];
     FakeAppServerSocket.inputScenario = "queuedSecond";
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "http://127.0.0.1:4500",
       WebSocket: FakeAppServerSocket,
@@ -946,7 +946,7 @@ describe("LettaCodeClient", () => {
 
   test("creates remote app-server agents through runtime_start", async () => {
     FakeAppServerSocket.instances = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "ws://127.0.0.1:4500/ws",
       WebSocket: FakeAppServerSocket,
@@ -975,7 +975,7 @@ describe("LettaCodeClient", () => {
 
   test("resumes remote conversations by resolving their agent first", async () => {
     FakeAppServerSocket.instances = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "ws://127.0.0.1:4500/ws",
       WebSocket: FakeAppServerSocket,
@@ -1002,7 +1002,7 @@ describe("LettaCodeClient", () => {
 
   test("resumes local-backend conversation ids through remote app-server", async () => {
     FakeAppServerSocket.instances = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "ws://127.0.0.1:4500/ws",
       WebSocket: FakeAppServerSocket,
@@ -1029,7 +1029,7 @@ describe("LettaCodeClient", () => {
 
   test("registers SDK tools as app-server external tools", async () => {
     FakeAppServerSocket.instances = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "ws://127.0.0.1:4500/ws",
       WebSocket: FakeAppServerSocket,
@@ -1097,7 +1097,7 @@ describe("LettaCodeClient", () => {
 
   test("websocket protocol sessions apply model dreaming and list messages", async () => {
     FakeAppServerSocket.instances = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "ws://127.0.0.1:4500/ws",
       WebSocket: FakeAppServerSocket,
@@ -1178,7 +1178,7 @@ describe("LettaCodeClient", () => {
 
   test("websocket protocol sessions list models, apply reasoning effort, and abort", async () => {
     FakeAppServerSocket.instances = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "ws://127.0.0.1:4500/ws",
       WebSocket: FakeAppServerSocket,
@@ -1242,7 +1242,7 @@ describe("LettaCodeClient", () => {
   });
 
   test("websocket protocol sessions reject unsupported stdio-only options", () => {
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "remote",
       url: "ws://127.0.0.1:4500/ws",
       WebSocket: FakeAppServerSocket,
@@ -1255,7 +1255,7 @@ describe("LettaCodeClient", () => {
 
 
   test("keeps environment out of createAgent payloads", async () => {
-    const client = new LettaCodeClient({ backend: "local" });
+    const client = new LettaAgentClient({ backend: "local" });
 
     await expect(
       client.createAgent({ environment: "work-laptop" } as never),

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { LettaCodeClient } from "../index.js";
+import { LettaAgentClient } from "../index.js";
 import { asAdvanced } from "./advanced-session.js";
 
 type Listener = (event: unknown) => void;
@@ -516,7 +516,7 @@ describe("CloudEnvironmentSession", () => {
   test("creates, refreshes, and cleans up a managed Cloud sandbox when no environment is specified", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -578,7 +578,7 @@ describe("CloudEnvironmentSession", () => {
   test("can leave managed Cloud sandbox cleanup to TTL", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -605,7 +605,7 @@ describe("CloudEnvironmentSession", () => {
   test("uses an explicit environment before using the Remote Client websocket", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -708,7 +708,7 @@ describe("CloudEnvironmentSession", () => {
   test("attaches to an explicit environment without creating a sandbox", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -738,7 +738,7 @@ describe("CloudEnvironmentSession", () => {
     resetFakeCloud();
     FakeCloudSocket.scenario = "duplicate_idempotency";
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -768,7 +768,7 @@ describe("CloudEnvironmentSession", () => {
     resetFakeCloud();
     FakeCloudSocket.syncSucceeds = false;
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -794,7 +794,7 @@ describe("CloudEnvironmentSession", () => {
   test("sends recovery sync on Cloud stream event sequence gaps", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -841,7 +841,7 @@ describe("CloudEnvironmentSession", () => {
   test("lists default-conversation messages through runtime protocol instead of Cloud REST", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -873,7 +873,7 @@ describe("CloudEnvironmentSession", () => {
   test("lists resumed conversation messages through runtime protocol instead of Cloud REST", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -907,7 +907,7 @@ describe("CloudEnvironmentSession", () => {
   test("lists explicit Cloud conversation ids through runtime protocol instead of Cloud REST", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -941,7 +941,7 @@ describe("CloudEnvironmentSession", () => {
   test("bootstraps resumed Cloud conversations from runtime history", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -983,7 +983,7 @@ describe("CloudEnvironmentSession", () => {
   test("uses bearer auth from headers for Cloud REST, environment polling, and websocket upgrades", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       headers: { Authorization: "Bearer sk-header", "x-project-id": "project-1" },
@@ -1016,7 +1016,7 @@ describe("CloudEnvironmentSession", () => {
     resetFakeCloud();
     resetFakeAppServer();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -1067,7 +1067,7 @@ describe("CloudEnvironmentSession", () => {
     resetFakeCloud();
     resetFakeAppServer();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -1095,7 +1095,7 @@ describe("CloudEnvironmentSession", () => {
     FakeCloudSocket.scenario = "approval";
     const requests: RecordedRequest[] = [];
     const decisions: Array<{ toolName: string; input: Record<string, unknown> }> = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -1138,7 +1138,7 @@ describe("CloudEnvironmentSession", () => {
   test("executes SDK-hosted external tool requests from the Cloud websocket", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -1256,7 +1256,7 @@ describe("CloudEnvironmentSession", () => {
   });
 
   test("validates managed Cloud sandbox options and environment exclusivity", () => {
-    expect(() => new LettaCodeClient({
+    expect(() => new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -1266,7 +1266,7 @@ describe("CloudEnvironmentSession", () => {
       sandbox: { ttlMinutes: 5 },
     })).toThrow("cannot specify both environment and sandbox options");
 
-    expect(() => new LettaCodeClient({
+    expect(() => new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -1275,7 +1275,7 @@ describe("CloudEnvironmentSession", () => {
       sandbox: { ttlMinutes: 61 },
     })).toThrow("Invalid sandbox.ttlMinutes");
 
-    const clientWithEnvironment = new LettaCodeClient({
+    const clientWithEnvironment = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -1287,7 +1287,7 @@ describe("CloudEnvironmentSession", () => {
       sandbox: { ttlMinutes: 5 },
     })).toThrow("cannot specify sandbox options when the client has a default environment");
 
-    const clientWithSandbox = new LettaCodeClient({
+    const clientWithSandbox = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -1299,7 +1299,7 @@ describe("CloudEnvironmentSession", () => {
       environment: { connectionId: "conn-explicit" },
     })).toThrow("cannot specify an environment when the client has default sandbox options");
 
-    expect(() => new LettaCodeClient({
+    expect(() => new LettaAgentClient({
       backend: "remote",
       url: "ws://app-server.test/ws",
       sandbox: { ttlMinutes: 5 },
@@ -1310,7 +1310,7 @@ describe("CloudEnvironmentSession", () => {
     resetFakeCloud();
     FakeCloudSocket.scenario = "terminal_error";
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",
@@ -1341,7 +1341,7 @@ describe("CloudEnvironmentSession", () => {
     resetFakeCloud();
     FakeCloudSocket.scenario = "stale_idle_then_error";
     const requests: RecordedRequest[] = [];
-    const client = new LettaCodeClient({
+    const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
       apiKey: "sk-test",

--- a/src/types.ts
+++ b/src/types.ts
@@ -587,7 +587,7 @@ export interface CreateSessionOptions {
 }
 
 /**
- * Session options accepted by LettaCodeClient methods.
+ * Session options accepted by LettaAgentClient methods.
  *
  * `environment` is a cloud execution-target override. It is deliberately
  * session-scoped rather than part of createAgent() options.


### PR DESCRIPTION
## Summary

The package is published as the **Letta Agent SDK** (`@letta-ai/letta-agent-sdk`), but the primary public class was still named `LettaCodeClient`. Rename it to `LettaAgentClient` so the main entry point matches the product name.

```diff
-import { LettaCodeClient } from "@letta-ai/letta-agent-sdk";
-const client = new LettaCodeClient({ backend: "local" });
+import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";
+const client = new LettaAgentClient({ backend: "local" });
```

## Scope (intentionally limited to the client class)

Only `LettaCodeClient` → `LettaAgentClient` is renamed. Supporting types are **left unchanged**:
- `LettaCodeClientOptions`, `LettaCodeClientSessionOptions`, `LettaCodeSession`, `LettaCodeBackend`
- transport/socket types (`LettaCodeSocketLike`, `LettaCodeLocalAppServerOptions`, etc.)

Rationale: several of these describe the underlying **Letta Code** harness/transport the SDK wraps (e.g. `LettaCodeBackend` = `"local" | "remote" | "cloud"` harness backends, `LettaCodeLocalAppServerOptions` = app-server config). A blanket rename would be a larger breaking change and arguably less accurate. The class is the one name nearly every user touches.

## Breaking change

Hard rename, **no back-compat alias**. Existing `LettaCodeClient` imports must update to `LettaAgentClient`. SDK is pre-1.0 (0.2.x), so this is acceptable.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun run build` clean
- [x] `bun test` → 196 pass, 0 fail (9 live-integration skipped)
- [x] Quickstart runs end-to-end with `new LettaAgentClient({ backend: "local" })`

👾 Generated with [Letta Code](https://letta.com)