### PR TITLE
fix: keep LettaCodeClient compatibility alias

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export type {
 } from "./types.js";
 
 export { Session } from "./session.js";
-export { LettaAgentClient } from "./client.js";
+export { LettaAgentClient, LettaAgentClient as LettaCodeClient } from "./client.js";
 
 export { extractStreamTextDelta } from "./stream-events.js";
 

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { LettaAgentClient, Session } from "../index.js";
+import { LettaAgentClient, LettaCodeClient, Session } from "../index.js";
 import { asAdvanced } from "./advanced-session.js";
 
 type Listener = (event: unknown) => void;
@@ -458,6 +458,14 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
 }
 
 describe("LettaAgentClient", () => {
+  test("keeps LettaCodeClient as a compatibility alias", () => {
+    expect(LettaCodeClient).toBe(LettaAgentClient);
+    const client = new LettaCodeClient();
+
+    expect(client).toBeInstanceOf(LettaAgentClient);
+    expect(client.backend).toBe("local");
+  });
+
   test("defaults to the implemented local backend", () => {
     const client = new LettaAgentClient();
 


### PR DESCRIPTION
## Summary
- export `LettaCodeClient` as a compatibility alias of `LettaAgentClient`
- add a client test covering the alias constructor identity and basic local defaults

This complements #167, which renamed the primary client class to `LettaAgentClient`, while preserving the previous import name for consumers and docs/tests that may straddle the package rename.

## Test plan
- `bun run check`
- `bun test src/tests/client.test.ts`
