### PR TITLE
fix: use Cloud REST for session history

### DIFF
--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -28,6 +28,8 @@ import {
 } from "./remote-client-session-core.js";
 import type {
   AnyAgentTool,
+  BootstrapStateOptions,
+  BootstrapStateResult,
   CreateAgentOptions,
   LettaCodeClientSessionOptions,
   LettaCodeCloudClientOptions,
@@ -35,6 +37,8 @@ import type {
   LettaCodeEnvironment,
   LettaCodeSocketConstructor,
   LettaCodeSocketLike,
+  ListMessagesOptions,
+  ListMessagesResult,
 } from "./types.js";
 
 const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
@@ -96,6 +100,8 @@ type CloudAgentSandboxRefresh = Record<string, unknown> & {
   sandboxId?: string;
   ttlMinutes?: number;
 };
+
+type CloudMessageListResponse = unknown[];
 
 type ManagedCloudSandbox = {
   agentId: string;
@@ -594,6 +600,13 @@ function externalToolsByName(tools: AnyAgentTool[] | undefined): Map<string, Any
   return result;
 }
 
+function appendListMessagesQuery(url: URL, options: ListMessagesOptions): void {
+  if (options.before !== undefined) url.searchParams.set("before", options.before);
+  if (options.after !== undefined) url.searchParams.set("after", options.after);
+  if (options.order !== undefined) url.searchParams.set("order", options.order);
+  if (options.limit !== undefined) url.searchParams.set("limit", String(options.limit));
+}
+
 function cloudHarnessAppServerOptions(
   clientOptions: LettaCodeCloudClientOptions,
 ): AppServerSessionOptions {
@@ -792,6 +805,40 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     await this.refreshManagedSandbox(sandbox);
   }
 
+  override async listMessages(options: ListMessagesOptions = {}): Promise<ListMessagesResult> {
+    if (!this.initialized) {
+      await this.initialize();
+    }
+    const conversationId = options.conversationId ?? this._conversationId;
+    if (!conversationId) {
+      throw new Error("No conversation id available for listMessages()");
+    }
+    return this.listCloudMessages(conversationId, options);
+  }
+
+  override async bootstrapState(
+    options: BootstrapStateOptions = {},
+  ): Promise<BootstrapStateResult> {
+    if (!this.initialized) {
+      await this.initialize();
+    }
+    const page = await this.listMessages({
+      limit: options.limit,
+      order: options.order,
+    });
+
+    const state: BootstrapStateResult = {
+      agentId: this._agentId ?? "",
+      conversationId: this._conversationId ?? "",
+      model: this._model,
+      messages: page.messages,
+    };
+    if (this.toolNames !== undefined) state.tools = this.toolNames;
+    if (page.nextBefore !== undefined) state.nextBefore = page.nextBefore;
+    if (page.hasMore !== undefined) state.hasMore = page.hasMore;
+    return state;
+  }
+
   protected override onCoreClose(): void {
     this.removeExternalToolHandler?.();
     this.removeExternalToolHandler = null;
@@ -859,6 +906,35 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       throw new Error(`Cloud resumeSession() could not retrieve conversation ${conversationId}.`);
     }
     return { id: body.id, agent_id: body.agent_id };
+  }
+
+  private async listCloudMessages(
+    conversationId: string,
+    options: ListMessagesOptions,
+  ): Promise<ListMessagesResult> {
+    const fetchImpl = getFetch(this.cloudOptions.fetch);
+    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+    const url = new URL(
+      `${baseUrl}/v1/conversations/${encodeURIComponent(conversationId)}/messages`,
+    );
+    appendListMessagesQuery(url, options);
+    if (conversationId === "default") {
+      if (!this._agentId) {
+        throw new Error("Cloud listMessages() for default conversation requires an agent id.");
+      }
+      url.searchParams.set("agent_id", this._agentId);
+    }
+
+    const response = await fetchImpl(url, {
+      headers: cloudHeaders(this.cloudOptions),
+    });
+    const body = await parseJsonResponse(response);
+    assertOkResponse(response, body, "Cloud listMessages()");
+    if (!Array.isArray(body)) {
+      throw new Error("Cloud listMessages() response was not an array.");
+    }
+    const messages = body as CloudMessageListResponse;
+    return { messages };
   }
 
   private async resolveConnectionForRuntime(

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -494,7 +494,7 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
   private nextTurnId = 0;
   private messageCounter = 0;
   private clientMessageCounter = 0;
-  private toolNames: string[] | undefined;
+  protected toolNames: string[] | undefined;
 
   protected constructor(
     protected readonly mode: RuntimeSessionMode,

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -33,6 +33,10 @@ function bodyOf(init?: RequestInit): unknown {
   return JSON.parse(String(init.body));
 }
 
+function cloudMessagesResponse() {
+  return jsonResponse([{ id: "msg-from-rest" }]);
+}
+
 function createCloudFetchMock(
   requests: RecordedRequest[],
   environmentConnections?: Array<Record<string, unknown>>,
@@ -58,6 +62,11 @@ function createCloudFetchMock(
 
     if (parsed.pathname === "/v1/conversations/conv-1" && method === "GET") {
       return Promise.resolve(jsonResponse({ id: "conv-1", agent_id: "agent-from-conv" }));
+    }
+
+    const conversationMessagesMatch = /^\/v1\/conversations\/([^/]+)\/messages$/.exec(parsed.pathname);
+    if (conversationMessagesMatch && method === "GET") {
+      return Promise.resolve(cloudMessagesResponse());
     }
 
     const agentSandboxMatch = /^\/v1\/agents\/([^/]+)\/sandboxes$/.exec(parsed.pathname);
@@ -838,7 +847,7 @@ describe("CloudEnvironmentSession", () => {
     }
   });
 
-  test("lists default-conversation messages through runtime protocol instead of Cloud REST", async () => {
+  test("lists default-conversation messages through Cloud REST instead of runtime protocol", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
@@ -854,13 +863,21 @@ describe("CloudEnvironmentSession", () => {
     const session = client.resumeSession("agent-1");
     try {
       const page = await session.listMessages({ limit: 1 });
-      expect(page.messages).toEqual([{ id: "msg-from-runtime" }]);
+      expect(page.messages).toEqual([{ id: "msg-from-rest" }]);
       expect(page.hasMore).toBeUndefined();
       expect(page.nextBefore).toBeUndefined();
-      expect(requests.some((request) =>
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "GET",
+        url: expect.stringContaining("/v1/conversations/default/messages"),
+      }));
+      const historyRequest = requests.find((request) =>
         new URL(request.url).pathname === "/v1/conversations/default/messages"
-      )).toBe(false);
-      expect(FakeCloudSocket.socket("control")!.sent).toContainEqual(expect.objectContaining({
+      );
+      expect(historyRequest).toBeTruthy();
+      const historyUrl = new URL(historyRequest!.url);
+      expect(historyUrl.searchParams.get("agent_id")).toBe("agent-1");
+      expect(historyUrl.searchParams.get("limit")).toBe("1");
+      expect(FakeCloudSocket.socket("control")!.sent).not.toContainEqual(expect.objectContaining({
         type: "conversation_messages_list",
         conversation_id: "default",
         query: { limit: 1 },
@@ -870,7 +887,7 @@ describe("CloudEnvironmentSession", () => {
     }
   });
 
-  test("lists resumed conversation messages through runtime protocol instead of Cloud REST", async () => {
+  test("lists resumed conversation messages through Cloud REST instead of runtime protocol", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
@@ -886,13 +903,15 @@ describe("CloudEnvironmentSession", () => {
     const session = client.resumeSession("conv-1");
     try {
       const page = await session.listMessages({ limit: 2, order: "desc" });
-      expect(page.messages).toEqual([{ id: "msg-from-runtime" }]);
-      expect(
-        requests.some((request) =>
-          new URL(request.url).pathname === "/v1/conversations/conv-1/messages"
-        ),
-      ).toBe(false);
-      expect(FakeCloudSocket.socket("control")!.sent).toContainEqual(
+      expect(page.messages).toEqual([{ id: "msg-from-rest" }]);
+      const historyRequest = requests.find((request) =>
+        new URL(request.url).pathname === "/v1/conversations/conv-1/messages"
+      );
+      expect(historyRequest).toBeTruthy();
+      const historyUrl = new URL(historyRequest!.url);
+      expect(historyUrl.searchParams.get("limit")).toBe("2");
+      expect(historyUrl.searchParams.get("order")).toBe("desc");
+      expect(FakeCloudSocket.socket("control")!.sent).not.toContainEqual(
         expect.objectContaining({
           type: "conversation_messages_list",
           conversation_id: "conv-1",
@@ -904,7 +923,7 @@ describe("CloudEnvironmentSession", () => {
     }
   });
 
-  test("lists explicit Cloud conversation ids through runtime protocol instead of Cloud REST", async () => {
+  test("lists explicit Cloud conversation ids through Cloud REST instead of runtime protocol", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
@@ -920,13 +939,14 @@ describe("CloudEnvironmentSession", () => {
     const session = client.resumeSession("agent-1");
     try {
       const page = await session.listMessages({ conversationId: "conv-explicit", limit: 1 });
-      expect(page.messages).toEqual([{ id: "msg-from-runtime" }]);
-      expect(
-        requests.some((request) =>
-          new URL(request.url).pathname === "/v1/conversations/conv-explicit/messages"
-        ),
-      ).toBe(false);
-      expect(FakeCloudSocket.socket("control")!.sent).toContainEqual(
+      expect(page.messages).toEqual([{ id: "msg-from-rest" }]);
+      const historyRequest = requests.find((request) =>
+        new URL(request.url).pathname === "/v1/conversations/conv-explicit/messages"
+      );
+      expect(historyRequest).toBeTruthy();
+      const historyUrl = new URL(historyRequest!.url);
+      expect(historyUrl.searchParams.get("limit")).toBe("1");
+      expect(FakeCloudSocket.socket("control")!.sent).not.toContainEqual(
         expect.objectContaining({
           type: "conversation_messages_list",
           conversation_id: "conv-explicit",
@@ -938,7 +958,7 @@ describe("CloudEnvironmentSession", () => {
     }
   });
 
-  test("bootstraps resumed Cloud conversations from runtime history", async () => {
+  test("bootstraps resumed Cloud conversations from Cloud REST history", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
@@ -957,18 +977,19 @@ describe("CloudEnvironmentSession", () => {
       expect(state).toMatchObject({
         agentId: "agent-from-conv",
         conversationId: "conv-1",
-        messages: [{ id: "msg-from-runtime" }],
+        messages: [{ id: "msg-from-rest" }],
       });
       expect(state.hasMore).toBeUndefined();
       expect(state.nextBefore).toBeUndefined();
       expect(state).not.toHaveProperty("hasPendingApproval");
       expect(state).not.toHaveProperty("timings");
-      expect(
-        requests.some((request) =>
-          new URL(request.url).pathname === "/v1/conversations/conv-1/messages"
-        ),
-      ).toBe(false);
-      expect(FakeCloudSocket.socket("control")!.sent).toContainEqual(
+      const historyRequest = requests.find((request) =>
+        new URL(request.url).pathname === "/v1/conversations/conv-1/messages"
+      );
+      expect(historyRequest).toBeTruthy();
+      const historyUrl = new URL(historyRequest!.url);
+      expect(historyUrl.searchParams.get("limit")).toBe("3");
+      expect(FakeCloudSocket.socket("control")!.sent).not.toContainEqual(
         expect.objectContaining({
           type: "conversation_messages_list",
           conversation_id: "conv-1",


### PR DESCRIPTION
## Summary
- route Cloud `session.listMessages()` through the Cloud REST conversation messages endpoint instead of the runtime websocket command
- make Cloud `bootstrapState()` use the same REST-backed history page
- update Cloud session tests to assert REST history is used and `conversation_messages_list` is no longer sent over the control websocket

## Root cause
Live Cloud sessions currently do not return `conversation_messages_list_response` for the runtime websocket command, so SDK `session.listMessages()` times out waiting for a request-id-correlated response. The same agent/conversation history is immediately available through Cloud REST.

## Verification
- `bun run check`
- `bun test src/tests/cloud-session.test.ts`
- `bun test`
- live Cloud smoke test with `LETTA_API_KEY`: before patch, `session.listMessages({ limit: 5 })` timed out with `Timed out waiting for conversation_messages_list-2`; after patch, `listMessages()` returned 3 messages and `bootstrapState()` returned the same 3-message history for the fresh session.
