### PR TITLE
chore(deps): bump letta-code to 0.27.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/letta-ai/letta-agent-sdk"
   },
   "dependencies": {
-    "@letta-ai/letta-code": "0.27.14"
+    "@letta-ai/letta-code": "0.27.18"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary
- Bump @letta-ai/letta-code from 0.27.14 to 0.27.18
- Align the SDK dependency with the current npm latest for letta-code

## Context
Local quickstart testing against SDK source 0.2.3 showed the pinned 0.27.14 CLI rejecting SDK-emitted --block-value flags, while forcing the current 0.27.18 CLI let the local app-server quickstart proceed to the model call / deterministic executor path.

## Test plan
- bun run check
- bun test
- bun run build