### PR TITLE
feat: add cloud repository resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,37 @@ By default, websocket authentication uses `Authorization` headers. Set
 `webSocketAuth: "query"` for browser-style websocket clients that cannot send
 custom upgrade headers.
 
+## Cloud repositories
+
+Cloud clients can create hosted repositories, manage text files inside them,
+and attach repositories to a session as resources. Repository resources are
+attached before the session starts and detached when the SDK session closes.
+
+```ts
+const client = new LettaAgentClient({
+  backend: "cloud",
+  apiKey: process.env.LETTA_API_KEY,
+});
+
+const repo = await client.repositories.create({ name: "inputs" });
+
+await client.repositories.files.create(repo.id, {
+  path: "data.csv",
+  content: csvContent,
+});
+
+await using session = client.createSession(agentId, {
+  resources: [
+    { type: "repository", repositoryId: repo.id },
+  ],
+});
+
+await session.send("Analyze the files in the attached repository.");
+```
+
+Repository file helpers are available under `client.repositories.files`, and
+version history helpers are available under `client.repositories.versions`.
+
 ## Session configuration
 
 Session options let you set runtime defaults before a session starts, including

--- a/src/client.ts
+++ b/src/client.ts
@@ -58,7 +58,7 @@ function stripCloudExecutionOptions(
 }
 
 function hasRepositoryResources(options: LettaCodeClientSessionOptions): boolean {
-  return options.resources !== undefined;
+  return options.resources !== undefined && options.resources.length > 0;
 }
 
 function hasCreateAgentEnvironment(options: CreateAgentOptions): boolean {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import { Session } from "./session.js";
+import { RepositoriesClient } from "./repositories.js";
 import {
   AppServerSession,
   assertRemoteSessionOptionsSupported,
@@ -56,6 +57,10 @@ function stripCloudExecutionOptions(
   return sessionOptions;
 }
 
+function hasRepositoryResources(options: LettaCodeClientSessionOptions): boolean {
+  return options.resources !== undefined;
+}
+
 function hasCreateAgentEnvironment(options: CreateAgentOptions): boolean {
   return "environment" in (options as Record<string, unknown>);
 }
@@ -86,6 +91,7 @@ export class LettaAgentClient {
   readonly backend: LettaCodeBackend;
   readonly environment: LettaCodeEnvironment | undefined;
   private readonly options: LettaCodeClientOptions;
+  private repositoriesClient: RepositoriesClient | null = null;
 
   constructor(options: LettaCodeClientOptions = {}) {
     const backend = options.backend ?? "local";
@@ -161,6 +167,10 @@ export class LettaAgentClient {
    * Environment/device selection is intentionally not part of the agent payload;
    * it belongs to the client/session execution context.
    */
+  get repositories(): RepositoriesClient {
+    return this.getRepositoriesClient();
+  }
+
   async createAgent(options: CreateAgentOptions = {}): Promise<string> {
     if (hasCreateAgentEnvironment(options)) {
       throw new Error(
@@ -372,6 +382,9 @@ export class LettaAgentClient {
       if (options.sandbox !== undefined) {
         throw new Error(`${action}() sandbox options are only valid with backend: "cloud".`);
       }
+      if (hasRepositoryResources(options)) {
+        throw new Error(`${action}() repository resources are only valid with backend: "cloud".`);
+      }
       if (!this.useLegacyLocalStdio()) {
         assertRemoteSessionOptionsSupported(action, options);
       }
@@ -386,6 +399,9 @@ export class LettaAgentClient {
       }
       if (options.sandbox !== undefined) {
         throw new Error(`${action}() sandbox options are only valid with backend: "cloud"; remote url selects the app-server runtime.`);
+      }
+      if (hasRepositoryResources(options)) {
+        throw new Error(`${action}() repository resources are only valid with backend: "cloud".`);
       }
       assertRemoteSessionOptionsSupported(action, options);
       return;
@@ -433,6 +449,14 @@ export class LettaAgentClient {
       throw new Error("Remote options requested for non-remote backend.");
     }
     return this.options as LettaCodeRemoteClientOptions;
+  }
+
+  private getRepositoriesClient(): RepositoriesClient {
+    if (this.backend !== "cloud") {
+      throw new Error('client.repositories is only available with backend: "cloud".');
+    }
+    this.repositoriesClient ??= new RepositoriesClient(this.cloudOptions());
+    return this.repositoriesClient;
   }
 
   private cloudOptions(): LettaCodeCloudClientOptions {

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -46,6 +46,8 @@ const MIN_SANDBOX_TTL_MINUTES = 1;
 const MAX_SANDBOX_TTL_MINUTES = 60;
 const DEFAULT_SANDBOX_READY_TIMEOUT_MS = 120_000;
 const DEFAULT_SANDBOX_READY_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_REPOSITORY_ATTACH_TIMEOUT_MS = 10_000;
+const DEFAULT_REPOSITORY_ATTACH_POLL_INTERVAL_MS = 250;
 const SDK_AGENT_ORIGIN = "@letta-ai/letta-agent-sdk";
 
 type FetchLike = typeof fetch;
@@ -698,7 +700,6 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
 
   protected override async initializeRuntimeController(): Promise<RuntimeSessionInit> {
     const resolved = await this.resolveRuntime();
-    await this.attachSessionRepositories(resolved.runtime.agent_id);
     const connection = await this.resolveConnectionForRuntime(resolved.runtime);
     this.connectionId = connection.connectionId;
 
@@ -815,13 +816,6 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     let agentId = this.cloudMode.agentId;
     let conversationId = this.cloudMode.conversationId;
 
-    if (agentId && this.cloudMode.newConversation) {
-      const conversation = await this.createConversation(agentId);
-      conversationId = conversation.id;
-    } else if (agentId && this.cloudMode.defaultConversation) {
-      conversationId = "default";
-    }
-
     if (!agentId && conversationId) {
       const conversation = await this.retrieveConversation(conversationId);
       if (!conversation.agent_id) {
@@ -830,7 +824,22 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       agentId = conversation.agent_id;
     }
 
-    if (!agentId || !conversationId) {
+    if (!agentId) {
+      throw new Error(
+        "Constellation createSession()/resumeSession() requires an agent id or conversation id.",
+      );
+    }
+
+    await this.attachSessionRepositories(agentId);
+
+    if (this.cloudMode.newConversation) {
+      const conversation = await this.createConversation(agentId);
+      conversationId = conversation.id;
+    } else if (this.cloudMode.defaultConversation) {
+      conversationId = "default";
+    }
+
+    if (!conversationId) {
       throw new Error(
         "Constellation createSession()/resumeSession() requires an agent id or conversation id.",
       );
@@ -852,6 +861,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
           continue;
         }
         await this.linkAgentRepository(agentId, resource.repositoryId);
+        await this.waitForAgentRepository(agentId, resource.repositoryId);
         this.attachedRepositoryIds.add(resource.repositoryId);
       }
     } catch (error) {
@@ -908,6 +918,18 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
         typeof (repository as Record<string, unknown>).id === "string"
       ))
       : [];
+  }
+
+  private async waitForAgentRepository(agentId: string, repositoryId: string): Promise<void> {
+    const deadline = Date.now() + DEFAULT_REPOSITORY_ATTACH_TIMEOUT_MS;
+    while (true) {
+      const repositories = await this.listAgentRepositories(agentId);
+      if (repositories.some((repository) => repository.id === repositoryId)) return;
+      if (Date.now() >= deadline) {
+        throw new Error(`Cloud attach agent repository did not become visible for ${agentId}: ${repositoryId}`);
+      }
+      await sleep(DEFAULT_REPOSITORY_ATTACH_POLL_INTERVAL_MS);
+    }
   }
 
   private async linkAgentRepository(agentId: string, repositoryId: string): Promise<void> {

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -35,6 +35,7 @@ import type {
   LettaCodeEnvironment,
   LettaCodeSocketConstructor,
   LettaCodeSocketLike,
+  RepositoryResource,
 } from "./types.js";
 
 const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
@@ -116,6 +117,12 @@ type ResolvedCloudConnection = {
 class CloudManagedSandboxOwnershipError extends Error {}
 
 type CloudSessionMode = Extract<RuntimeSessionMode, { kind: "session" }>;
+
+type CloudAgentRepository = {
+  id: string;
+  name?: string;
+  is_primary?: boolean;
+};
 
 function getDefaultApiKey(): string | undefined {
   const env = (globalThis as { process?: { env?: Record<string, string | undefined> } })
@@ -673,6 +680,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   private managedSandbox: ManagedCloudSandbox | null = null;
   private sandboxRefreshTimer: ReturnType<typeof setInterval> | null = null;
   private sandboxRefreshInFlight: Promise<void> | null = null;
+  private attachedRepositoryIds = new Set<string>();
   private readonly cloudMode: CloudSessionMode;
 
   constructor(
@@ -690,6 +698,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
 
   protected override async initializeRuntimeController(): Promise<RuntimeSessionInit> {
     const resolved = await this.resolveRuntime();
+    await this.attachSessionRepositories(resolved.runtime.agent_id);
     const connection = await this.resolveConnectionForRuntime(resolved.runtime);
     this.connectionId = connection.connectionId;
 
@@ -745,6 +754,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       this.removeControlRequestHandler = null;
       client.close();
       await this.cleanupManagedSandbox();
+      await this.cleanupSessionRepositories(resolved.runtime.agent_id);
       throw error;
     }
   }
@@ -798,6 +808,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     this.removeControlRequestHandler?.();
     this.removeControlRequestHandler = null;
     void this.cleanupManagedSandbox();
+    if (this.runtime?.agent_id) void this.cleanupSessionRepositories(this.runtime.agent_id);
   }
 
   private async resolveRuntime(): Promise<{ runtime: RuntimeScope }> {
@@ -826,6 +837,104 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     }
 
     return { runtime: { agent_id: agentId, conversation_id: conversationId } };
+  }
+
+  private async attachSessionRepositories(agentId: string): Promise<void> {
+    const resources = this.repositoryResources();
+    if (resources.length === 0) return;
+
+    const existing = await this.listAgentRepositories(agentId);
+    const existingIds = new Set(existing.map((repository) => repository.id));
+
+    try {
+      for (const resource of resources) {
+        if (existingIds.has(resource.repositoryId) || this.attachedRepositoryIds.has(resource.repositoryId)) {
+          continue;
+        }
+        await this.linkAgentRepository(agentId, resource.repositoryId);
+        this.attachedRepositoryIds.add(resource.repositoryId);
+      }
+    } catch (error) {
+      await this.cleanupSessionRepositories(agentId);
+      throw error;
+    }
+  }
+
+  private async cleanupSessionRepositories(agentId: string): Promise<void> {
+    const repositoryIds = [...this.attachedRepositoryIds];
+    this.attachedRepositoryIds.clear();
+    await Promise.all(repositoryIds.map(async (repositoryId) => {
+      try {
+        await this.unlinkAgentRepository(agentId, repositoryId);
+      } catch {
+        // Best-effort cleanup: only repositories this SDK session attached are removed.
+      }
+    }));
+  }
+
+  private repositoryResources(): RepositoryResource[] {
+    const resources = this.cloudMode.options.resources ?? [];
+    const seen = new Set<string>();
+    const result: RepositoryResource[] = [];
+    for (const resource of resources) {
+      if (resource.type !== "repository") {
+        throw new Error(`Unsupported Cloud session resource type: ${String(resource.type)}`);
+      }
+      if (typeof resource.repositoryId !== "string" || resource.repositoryId.length === 0) {
+        throw new Error("Cloud session repository resources require repositoryId.");
+      }
+      if (seen.has(resource.repositoryId)) continue;
+      seen.add(resource.repositoryId);
+      result.push(resource);
+    }
+    return result;
+  }
+
+  private async listAgentRepositories(agentId: string): Promise<CloudAgentRepository[]> {
+    const fetchImpl = getFetch(this.cloudOptions.fetch);
+    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+    const response = await fetchImpl(
+      `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/repositories`,
+      { headers: cloudHeaders(this.cloudOptions) },
+    );
+    const body = await parseJsonResponse(response);
+    assertOkResponse(response, body, "Cloud list agent repositories");
+    if (!body || typeof body !== "object") return [];
+    const repositories = (body as Record<string, unknown>).repositories;
+    return Array.isArray(repositories)
+      ? repositories.filter((repository): repository is CloudAgentRepository => (
+        repository !== null &&
+        typeof repository === "object" &&
+        typeof (repository as Record<string, unknown>).id === "string"
+      ))
+      : [];
+  }
+
+  private async linkAgentRepository(agentId: string, repositoryId: string): Promise<void> {
+    const fetchImpl = getFetch(this.cloudOptions.fetch);
+    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+    const response = await fetchImpl(
+      `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/repositories`,
+      {
+        method: "POST",
+        headers: cloudHeaders(this.cloudOptions),
+        body: JSON.stringify({ repository_id: repositoryId }),
+      },
+    );
+    const body = await parseJsonResponse(response);
+    assertOkResponse(response, body, "Cloud attach agent repository");
+  }
+
+  private async unlinkAgentRepository(agentId: string, repositoryId: string): Promise<void> {
+    const fetchImpl = getFetch(this.cloudOptions.fetch);
+    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+    const response = await fetchImpl(
+      `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/repositories/${encodeURIComponent(repositoryId)}`,
+      { method: "DELETE", headers: cloudHeaders(this.cloudOptions) },
+    );
+    const body = await parseJsonResponse(response);
+    if (response.status === 404) return;
+    assertOkResponse(response, body, "Cloud detach agent repository");
   }
 
   private async createConversation(agentId: string): Promise<{ id: string; agent_id?: string }> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,23 @@ export type {
   LettaCodeModelEntry,
   UpdateModelOptions,
   UpdateModelResult,
+  Repository,
+  CreateRepositoryParams,
+  ListRepositoriesParams,
+  ListRepositoriesResult,
+  RepositoryResource,
+  RepositoryFileEntry,
+  ListRepositoryFilesParams,
+  ListRepositoryFilesResult,
+  CreateRepositoryFileParams,
+  RepositoryFile,
+  UpdateRepositoryFileParams,
+  RepositoryFileMutationResult,
+  DeleteRepositoryFileParams,
+  DeleteRepositoryFileResult,
+  RepositoryVersion,
+  ListRepositoryVersionsParams,
+  GetRepositoryVersionParams,
   // Bootstrap API
   BootstrapStateOptions,
   BootstrapStateResult,
@@ -118,6 +135,7 @@ export type {
 } from "./types.js";
 
 export { Session } from "./session.js";
+export { RepositoriesClient } from "./repositories.js";
 export { LettaAgentClient } from "./client.js";
 
 export { extractStreamTextDelta } from "./stream-events.js";

--- a/src/repositories.ts
+++ b/src/repositories.ts
@@ -159,6 +159,20 @@ export class RepositoriesClient {
     return toRepository(await this.request(`/v1/repositories/${encodeURIComponent(repositoryId)}`, "GET", undefined, "Cloud get repository"));
   }
 
+  /**
+   * Delete a repository. The server soft-deletes it (marks the repository
+   * deleted rather than removing its data). Resolves on success; throws if the
+   * repository does not exist or is not visible to the caller's organization.
+   */
+  async delete(repositoryId: string): Promise<void> {
+    await this.request(
+      `/v1/repositories/${encodeURIComponent(repositoryId)}`,
+      "DELETE",
+      undefined,
+      "Cloud delete repository",
+    );
+  }
+
   readonly files = {
     list: async (
       repositoryId: string,

--- a/src/repositories.ts
+++ b/src/repositories.ts
@@ -1,0 +1,319 @@
+import type {
+  CreateRepositoryFileParams,
+  CreateRepositoryParams,
+  DeleteRepositoryFileParams,
+  DeleteRepositoryFileResult,
+  GetRepositoryVersionParams,
+  LettaCodeCloudClientOptions,
+  ListRepositoriesParams,
+  ListRepositoriesResult,
+  ListRepositoryFilesParams,
+  ListRepositoryFilesResult,
+  ListRepositoryVersionsParams,
+  Repository,
+  RepositoryFile,
+  RepositoryFileMutationResult,
+  RepositoryVersion,
+  UpdateRepositoryFileParams,
+} from "./types.js";
+
+const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
+
+type FetchLike = typeof fetch;
+
+function getDefaultApiKey(): string | undefined {
+  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process?.env;
+  return env?.LETTA_API_KEY ?? env?.LETTA_CLOUD_API_KEY;
+}
+
+function bearerTokenFromHeaders(headers: Record<string, string> | undefined): string | undefined {
+  const authorization = headers?.Authorization ?? headers?.authorization;
+  if (!authorization) return undefined;
+  const match = /^Bearer\s+(.+)$/i.exec(authorization);
+  return match?.[1];
+}
+
+function getCloudApiKey(options: LettaCodeCloudClientOptions): string | undefined {
+  return options.apiKey ?? bearerTokenFromHeaders(options.headers) ?? getDefaultApiKey();
+}
+
+function getFetch(fetchOverride?: FetchLike): FetchLike {
+  const resolved = fetchOverride ?? globalThis.fetch;
+  if (!resolved) throw new Error("No fetch implementation available for cloud backend.");
+  return resolved.bind(globalThis) as FetchLike;
+}
+
+function normalizeCloudApiBaseUrl(url: string | undefined): string {
+  const parsed = new URL(url ?? DEFAULT_CLOUD_API_BASE_URL);
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+function cloudHeaders(options: LettaCodeCloudClientOptions): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers ?? {}),
+  };
+  const apiKey = getCloudApiKey(options);
+  if (apiKey && !headers.Authorization && !headers.authorization) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  return headers;
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function responseErrorMessage(body: unknown, fallback: string): string {
+  if (body && typeof body === "object") {
+    const record = body as Record<string, unknown>;
+    const message = record.message ?? record.error ?? record.detail;
+    const reasonText = record.reason_text;
+    const pieces = [message, reasonText]
+      .filter((value): value is string => typeof value === "string" && value.length > 0);
+    if (pieces.length > 0) return pieces.join(": ");
+  }
+  return fallback;
+}
+
+function assertOkResponse(response: Response, body: unknown, action: string): void {
+  if (!response.ok) {
+    throw new Error(responseErrorMessage(body, `${action} failed with HTTP ${response.status}`));
+  }
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function requireString(value: unknown, name: string): string {
+  if (typeof value !== "string") throw new Error(`Cloud repositories response missing ${name}.`);
+  return value;
+}
+
+function toRepository(body: unknown): Repository {
+  if (!body || typeof body !== "object") {
+    throw new Error("Cloud repositories response did not include a repository.");
+  }
+  const record = body as Record<string, unknown>;
+  return {
+    id: requireString(record.id, "id"),
+    name: requireString(record.name, "name"),
+    createdAt: requireString(record.created_at, "created_at"),
+    updatedAt: requireString(record.updated_at, "updated_at"),
+  };
+}
+
+function toFileMutation(body: unknown): RepositoryFileMutationResult {
+  if (!body || typeof body !== "object") {
+    throw new Error("Cloud repositories file response did not include file details.");
+  }
+  const record = body as Record<string, unknown>;
+  return {
+    path: requireString(record.path, "path"),
+    contentSha256: requireString(record.content_sha256, "content_sha256"),
+    commitSha: requireString(record.commit_sha, "commit_sha"),
+  };
+}
+
+function addOptionalSearchParam(url: URL, key: string, value: string | number | undefined): void {
+  if (value !== undefined) url.searchParams.set(key, String(value));
+}
+
+export class RepositoriesClient {
+  constructor(private readonly options: LettaCodeCloudClientOptions) {}
+
+  async create(params: CreateRepositoryParams): Promise<Repository> {
+    return toRepository(await this.request("/v1/repositories", "POST", { name: params.name }, "Cloud create repository"));
+  }
+
+  async list(params: ListRepositoriesParams = {}): Promise<ListRepositoriesResult> {
+    const url = this.url("/v1/repositories");
+    addOptionalSearchParam(url, "limit", params.limit);
+    addOptionalSearchParam(url, "offset", params.offset);
+    const body = await this.requestUrl(url, "GET", undefined, "Cloud list repositories");
+    if (!body || typeof body !== "object") {
+      throw new Error("Cloud list repositories response did not include repositories.");
+    }
+    const record = body as Record<string, unknown>;
+    const repositories = Array.isArray(record.repositories)
+      ? record.repositories.map(toRepository)
+      : [];
+    return {
+      repositories,
+      hasNextPage: record.has_next_page === true,
+    };
+  }
+
+  async get(repositoryId: string): Promise<Repository> {
+    return toRepository(await this.request(`/v1/repositories/${encodeURIComponent(repositoryId)}`, "GET", undefined, "Cloud get repository"));
+  }
+
+  readonly files = {
+    list: async (
+      repositoryId: string,
+      params: ListRepositoryFilesParams = {},
+    ): Promise<ListRepositoryFilesResult> => {
+      const url = this.url(`/v1/repositories/${encodeURIComponent(repositoryId)}/files`);
+      addOptionalSearchParam(url, "path_prefix", params.pathPrefix);
+      addOptionalSearchParam(url, "depth", params.depth);
+      addOptionalSearchParam(url, "ref", params.ref);
+      const body = await this.requestUrl(url, "GET", undefined, "Cloud list repository files");
+      if (!body || typeof body !== "object") {
+        throw new Error("Cloud list repository files response did not include files.");
+      }
+      const record = body as Record<string, unknown>;
+      const files = Array.isArray(record.files)
+        ? record.files.map((entry) => {
+          if (!entry || typeof entry !== "object") {
+            throw new Error("Cloud list repository files response included an invalid file entry.");
+          }
+          const file = entry as Record<string, unknown>;
+          const type = file.type;
+          if (type !== "file" && type !== "directory") {
+            throw new Error("Cloud list repository files response included an invalid file type.");
+          }
+          return { path: requireString(file.path, "path"), type: type as "file" | "directory" };
+        })
+        : [];
+      return { files, ref: requireString(record.ref, "ref") };
+    },
+
+    create: async (
+      repositoryId: string,
+      params: CreateRepositoryFileParams,
+    ): Promise<RepositoryFileMutationResult> => toFileMutation(await this.request(
+      `/v1/repositories/${encodeURIComponent(repositoryId)}/files`,
+      "POST",
+      { path: params.path, content: params.content },
+      "Cloud create repository file",
+    )),
+
+    read: async (repositoryId: string, params: { path: string; ref?: string }): Promise<RepositoryFile> => {
+      const url = this.url(`/v1/repositories/${encodeURIComponent(repositoryId)}/files/content`);
+      url.searchParams.set("path", params.path);
+      addOptionalSearchParam(url, "ref", params.ref);
+      const body = await this.requestUrl(url, "GET", undefined, "Cloud read repository file");
+      if (!body || typeof body !== "object") {
+        throw new Error("Cloud read repository file response did not include file content.");
+      }
+      const record = body as Record<string, unknown>;
+      return {
+        path: requireString(record.path, "path"),
+        content: requireString(record.content, "content"),
+        contentSha256: requireString(record.content_sha256, "content_sha256"),
+        ref: optionalString(record.ref),
+      };
+    },
+
+    update: async (
+      repositoryId: string,
+      params: UpdateRepositoryFileParams,
+    ): Promise<RepositoryFileMutationResult> => toFileMutation(await this.request(
+      `/v1/repositories/${encodeURIComponent(repositoryId)}/files`,
+      "PATCH",
+      {
+        path: params.path,
+        ...(params.content !== undefined ? { content: params.content } : {}),
+        ...(params.newPath !== undefined ? { new_path: params.newPath } : {}),
+        ...(params.precondition !== undefined
+          ? { precondition: { content_sha256: params.precondition.contentSha256 } }
+          : {}),
+      },
+      "Cloud update repository file",
+    )),
+
+    delete: async (
+      repositoryId: string,
+      params: DeleteRepositoryFileParams,
+    ): Promise<DeleteRepositoryFileResult> => {
+      const body = await this.request(
+        `/v1/repositories/${encodeURIComponent(repositoryId)}/files`,
+        "DELETE",
+        { path: params.path },
+        "Cloud delete repository file",
+      );
+      if (!body || typeof body !== "object") {
+        throw new Error("Cloud delete repository file response did not include delete details.");
+      }
+      const record = body as Record<string, unknown>;
+      return { success: record.success === true, commitSha: requireString(record.commit_sha, "commit_sha") };
+    },
+  };
+
+  readonly versions = {
+    list: async (
+      repositoryId: string,
+      params: ListRepositoryVersionsParams = {},
+    ): Promise<RepositoryVersion[]> => {
+      const url = this.url(`/v1/repositories/${encodeURIComponent(repositoryId)}/versions`);
+      addOptionalSearchParam(url, "path", params.path);
+      addOptionalSearchParam(url, "limit", params.limit);
+      const body = await this.requestUrl(url, "GET", undefined, "Cloud list repository versions");
+      if (Array.isArray(body)) return body as RepositoryVersion[];
+      if (body && typeof body === "object" && Array.isArray((body as Record<string, unknown>).versions)) {
+        return (body as { versions: RepositoryVersion[] }).versions;
+      }
+      return [];
+    },
+
+    get: async (
+      repositoryId: string,
+      sha: string,
+      params: GetRepositoryVersionParams,
+    ): Promise<RepositoryFile> => {
+      const url = this.url(`/v1/repositories/${encodeURIComponent(repositoryId)}/versions/${encodeURIComponent(sha)}`);
+      url.searchParams.set("path", params.path);
+      const body = await this.requestUrl(url, "GET", undefined, "Cloud get repository version");
+      if (!body || typeof body !== "object") {
+        throw new Error("Cloud get repository version response did not include file content.");
+      }
+      const record = body as Record<string, unknown>;
+      return {
+        path: requireString(record.path, "path"),
+        content: requireString(record.content, "content"),
+        contentSha256: requireString(record.content_sha256, "content_sha256"),
+        ref: requireString(record.sha, "sha"),
+      };
+    },
+  };
+
+  private url(path: string): URL {
+    return new URL(`${normalizeCloudApiBaseUrl(this.options.apiBaseUrl)}${path}`);
+  }
+
+  private async request(
+    path: string,
+    method: string,
+    body: unknown,
+    action: string,
+  ): Promise<unknown> {
+    return this.requestUrl(this.url(path), method, body, action);
+  }
+
+  private async requestUrl(
+    url: URL,
+    method: string,
+    body: unknown,
+    action: string,
+  ): Promise<unknown> {
+    const response = await getFetch(this.options.fetch)(url, {
+      method,
+      headers: cloudHeaders(this.options),
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    const parsed = await parseJsonResponse(response);
+    assertOkResponse(response, parsed, action);
+    return parsed;
+  }
+}

--- a/src/repositories.ts
+++ b/src/repositories.ts
@@ -234,14 +234,19 @@ export class RepositoriesClient {
       repositoryId: string,
       params: UpdateRepositoryFileParams,
     ): Promise<RepositoryFileMutationResult> => toFileMutation(await this.request(
-      `/v1/repositories/${encodeURIComponent(repositoryId)}/files`,
-      "PATCH",
+      `/v1/repositories/${encodeURIComponent(repositoryId)}/files/content`,
+      "POST",
       {
         path: params.path,
         ...(params.content !== undefined ? { content: params.content } : {}),
         ...(params.newPath !== undefined ? { new_path: params.newPath } : {}),
         ...(params.precondition !== undefined
-          ? { precondition: { content_sha256: params.precondition.contentSha256 } }
+          ? {
+            precondition: {
+              type: "content_sha256",
+              content_sha256: params.precondition.contentSha256,
+            },
+          }
           : {}),
       },
       "Cloud update repository file",
@@ -252,7 +257,7 @@ export class RepositoriesClient {
       params: DeleteRepositoryFileParams,
     ): Promise<DeleteRepositoryFileResult> => {
       const body = await this.request(
-        `/v1/repositories/${encodeURIComponent(repositoryId)}/files`,
+        `/v1/repositories/${encodeURIComponent(repositoryId)}/files/content`,
         "DELETE",
         { path: params.path },
         "Cloud delete repository file",
@@ -275,8 +280,10 @@ export class RepositoriesClient {
       addOptionalSearchParam(url, "limit", params.limit);
       const body = await this.requestUrl(url, "GET", undefined, "Cloud list repository versions");
       if (Array.isArray(body)) return body as RepositoryVersion[];
-      if (body && typeof body === "object" && Array.isArray((body as Record<string, unknown>).versions)) {
-        return (body as { versions: RepositoryVersion[] }).versions;
+      if (body && typeof body === "object") {
+        const record = body as Record<string, unknown>;
+        if (Array.isArray(record.commits)) return record.commits as RepositoryVersion[];
+        if (Array.isArray(record.versions)) return record.versions as RepositoryVersion[];
       }
       return [];
     },

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -102,6 +102,21 @@ function createCloudFetchMock(
       }));
     }
 
+    const agentRepositoriesMatch = /^\/v1\/agents\/([^/]+)\/repositories$/.exec(parsed.pathname);
+    if (agentRepositoriesMatch && method === "GET") {
+      return Promise.resolve(jsonResponse({ repositories: [] }));
+    }
+
+    if (agentRepositoriesMatch && method === "POST") {
+      const body = bodyOf(init) as { repository_id?: string } | undefined;
+      return Promise.resolve(jsonResponse({ success: true, repository: { id: body?.repository_id ?? "repo-1" } }));
+    }
+
+    const agentRepositoryMatch = /^\/v1\/agents\/([^/]+)\/repositories\/([^/]+)$/.exec(parsed.pathname);
+    if (agentRepositoryMatch && method === "DELETE") {
+      return Promise.resolve(jsonResponse({ success: true }));
+    }
+
     if (parsed.pathname === "/v1/environments" && method === "GET") {
       return Promise.resolve(jsonResponse({
         connections: environmentConnections ?? [
@@ -600,6 +615,45 @@ describe("CloudEnvironmentSession", () => {
       new URL(request.url).pathname === "/v1/agents/agent-1/sandboxes" &&
         request.method === "DELETE"
     )).toBe(false);
+  });
+
+
+  test("attaches Cloud repository resources for the session and detaches on close", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { terminateOnClose: false },
+    });
+
+    const session = client.resumeSession("agent-1", {
+      resources: [{ type: "repository", repositoryId: "repo-1" }],
+    });
+    await asAdvanced(session).initialize();
+    session.close();
+
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "GET",
+      url: "https://api.test/v1/agents/agent-1/repositories",
+    }));
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "POST",
+      url: "https://api.test/v1/agents/agent-1/repositories",
+      body: { repository_id: "repo-1" },
+    }));
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "DELETE",
+      url: "https://api.test/v1/agents/agent-1/repositories/repo-1",
+    }));
   });
 
   test("uses an explicit environment before using the Remote Client websocket", async () => {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -104,7 +104,10 @@ function createCloudFetchMock(
 
     const agentRepositoriesMatch = /^\/v1\/agents\/([^/]+)\/repositories$/.exec(parsed.pathname);
     if (agentRepositoriesMatch && method === "GET") {
-      return Promise.resolve(jsonResponse({ repositories: [] }));
+      return Promise.resolve(jsonResponse({ repositories: requests.some((request) => {
+        const requestPath = new URL(request.url).pathname;
+        return request.method === "POST" && requestPath === parsed.pathname;
+      }) ? [{ id: "repo-1", name: "repo-1", is_primary: false }] : [] }));
     }
 
     if (agentRepositoriesMatch && method === "POST") {

--- a/src/tests/repositories.test.ts
+++ b/src/tests/repositories.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { LettaAgentClient } from "../index.js";
+
+type FetchInput = Parameters<typeof fetch>[0];
+
+type RecordedRequest = {
+  url: string;
+  method: string;
+};
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function createFetchMock(
+  requests: RecordedRequest[],
+  handler: (parsed: URL, method: string) => Response,
+): typeof fetch {
+  return ((input: FetchInput | URL, init?: RequestInit) => {
+    const url = input instanceof URL ? input.toString() : String(input);
+    const method = init?.method ?? "GET";
+    requests.push({ url, method });
+    return Promise.resolve(handler(new URL(url), method));
+  }) as typeof fetch;
+}
+
+function cloudClient(fetchMock: typeof fetch): LettaAgentClient {
+  return new LettaAgentClient({
+    backend: "cloud",
+    apiKey: "test-key",
+    apiBaseUrl: "https://api.letta.com",
+    fetch: fetchMock,
+  });
+}
+
+describe("RepositoriesClient.delete", () => {
+  test("issues DELETE /v1/repositories/:id and resolves on success", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(
+      createFetchMock(requests, () => jsonResponse({ success: true })),
+    );
+
+    await expect(client.repositories.delete("repo-1")).resolves.toBeUndefined();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("DELETE");
+    expect(new URL(requests[0]!.url).pathname).toBe("/v1/repositories/repo-1");
+  });
+
+  test("encodes the repository id in the path", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(
+      createFetchMock(requests, () => jsonResponse({ success: true })),
+    );
+
+    await client.repositories.delete("repo/with space");
+
+    expect(new URL(requests[0]!.url).pathname).toBe("/v1/repositories/repo%2Fwith%20space");
+  });
+
+  test("throws with the server message when the repository is missing", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(
+      createFetchMock(requests, () =>
+        jsonResponse({ message: "Repository not found" }, { status: 404 }),
+      ),
+    );
+
+    await expect(client.repositories.delete("missing")).rejects.toThrow(
+      "Repository not found",
+    );
+  });
+});

--- a/src/tests/repositories.test.ts
+++ b/src/tests/repositories.test.ts
@@ -6,6 +6,7 @@ type FetchInput = Parameters<typeof fetch>[0];
 type RecordedRequest = {
   url: string;
   method: string;
+  body?: unknown;
 };
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -23,7 +24,9 @@ function createFetchMock(
   return ((input: FetchInput | URL, init?: RequestInit) => {
     const url = input instanceof URL ? input.toString() : String(input);
     const method = init?.method ?? "GET";
-    requests.push({ url, method });
+    const body =
+      typeof init?.body === "string" ? (JSON.parse(init.body) as unknown) : undefined;
+    requests.push({ url, method, body });
     return Promise.resolve(handler(new URL(url), method));
   }) as typeof fetch;
 }
@@ -73,5 +76,88 @@ describe("RepositoriesClient.delete", () => {
     await expect(client.repositories.delete("missing")).rejects.toThrow(
       "Repository not found",
     );
+  });
+});
+
+describe("RepositoriesClient.files.update", () => {
+  test("issues POST /v1/repositories/:id/files/content", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(
+      createFetchMock(requests, () =>
+        jsonResponse({ path: "a.txt", content_sha256: "sha", commit_sha: "c1" }),
+      ),
+    );
+
+    const result = await client.repositories.files.update("repo-1", {
+      path: "a.txt",
+      content: "next",
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("POST");
+    expect(new URL(requests[0]!.url).pathname).toBe(
+      "/v1/repositories/repo-1/files/content",
+    );
+    expect(requests[0]?.body).toEqual({ path: "a.txt", content: "next" });
+    expect(result).toEqual({ path: "a.txt", contentSha256: "sha", commitSha: "c1" });
+  });
+
+  test("sends the typed content_sha256 precondition and new_path", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(
+      createFetchMock(requests, () =>
+        jsonResponse({ path: "b.txt", content_sha256: "sha", commit_sha: "c2" }),
+      ),
+    );
+
+    await client.repositories.files.update("repo-1", {
+      path: "a.txt",
+      newPath: "b.txt",
+      precondition: { contentSha256: "expected-sha" },
+    });
+
+    expect(requests[0]?.body).toEqual({
+      path: "a.txt",
+      new_path: "b.txt",
+      precondition: { type: "content_sha256", content_sha256: "expected-sha" },
+    });
+  });
+});
+
+describe("RepositoriesClient.files.delete", () => {
+  test("issues DELETE /v1/repositories/:id/files/content with the path body", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(
+      createFetchMock(requests, () =>
+        jsonResponse({ success: true, commit_sha: "c3" }),
+      ),
+    );
+
+    const result = await client.repositories.files.delete("repo-1", { path: "a.txt" });
+
+    expect(requests[0]?.method).toBe("DELETE");
+    expect(new URL(requests[0]!.url).pathname).toBe(
+      "/v1/repositories/repo-1/files/content",
+    );
+    expect(requests[0]?.body).toEqual({ path: "a.txt" });
+    expect(result).toEqual({ success: true, commitSha: "c3" });
+  });
+});
+
+describe("RepositoriesClient.versions.list", () => {
+  test("returns the commits array from the server response", async () => {
+    const requests: RecordedRequest[] = [];
+    const commits = [
+      { sha: "s1", message: "Update a.txt", timestamp: "2024-01-01T00:00:00Z", author_name: "Ari" },
+      { sha: "s2", message: "Create a.txt", timestamp: "2024-01-01T00:00:00Z", author_name: null },
+    ];
+    const client = cloudClient(
+      createFetchMock(requests, () => jsonResponse({ path: "a.txt", commits })),
+    );
+
+    const result = await client.repositories.versions.list("repo-1", { path: "a.txt" });
+
+    expect(new URL(requests[0]!.url).pathname).toBe("/v1/repositories/repo-1/versions");
+    expect(result).toEqual(commits);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -454,7 +454,12 @@ export interface DeleteRepositoryFileResult {
   commitSha: string;
 }
 
-export type RepositoryVersion = Record<string, unknown>;
+export interface RepositoryVersion {
+  sha: string;
+  message: string;
+  timestamp: string;
+  author_name: string | null;
+}
 
 export interface ListRepositoryVersionsParams {
   path?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -376,6 +376,95 @@ export type LettaCodeClientOptions =
   | LettaCodeRemoteClientOptions
   | LettaCodeCloudClientOptions;
 
+export interface Repository {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateRepositoryParams {
+  name: string;
+}
+
+export interface ListRepositoriesParams {
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListRepositoriesResult {
+  repositories: Repository[];
+  hasNextPage: boolean;
+}
+
+export interface RepositoryResource {
+  type: "repository";
+  repositoryId: string;
+}
+
+export interface RepositoryFileEntry {
+  path: string;
+  type: "file" | "directory";
+}
+
+export interface ListRepositoryFilesParams {
+  pathPrefix?: string;
+  depth?: number;
+  ref?: string;
+}
+
+export interface ListRepositoryFilesResult {
+  files: RepositoryFileEntry[];
+  ref: string;
+}
+
+export interface CreateRepositoryFileParams {
+  path: string;
+  content: string;
+}
+
+export interface RepositoryFile {
+  path: string;
+  content: string;
+  contentSha256: string;
+  ref?: string;
+}
+
+export interface UpdateRepositoryFileParams {
+  path: string;
+  content?: string;
+  newPath?: string;
+  precondition?: {
+    contentSha256: string;
+  };
+}
+
+export interface RepositoryFileMutationResult {
+  path: string;
+  contentSha256: string;
+  commitSha: string;
+}
+
+export interface DeleteRepositoryFileParams {
+  path: string;
+}
+
+export interface DeleteRepositoryFileResult {
+  success: boolean;
+  commitSha: string;
+}
+
+export type RepositoryVersion = Record<string, unknown>;
+
+export interface ListRepositoryVersionsParams {
+  path?: string;
+  limit?: number;
+}
+
+export interface GetRepositoryVersionParams {
+  path: string;
+}
+
 // ═══════════════════════════════════════════════════════════════
 // SESSION OPTIONS
 // ═══════════════════════════════════════════════════════════════
@@ -583,6 +672,9 @@ export interface CreateSessionOptions {
    * Timeout in milliseconds for a single approval recovery request.
    */
   approvalRecoveryTimeoutMs?: number;
+
+  /** Cloud repository resources to attach for the lifetime of the SDK session. */
+  resources?: RepositoryResource[];
 
 }
 


### PR DESCRIPTION
Adds cloud repository support to the SDK.

## Repository management (`client.repositories`)
- CRUD helpers: `create`, `list`, `get`, and **`delete`** (`DELETE /v1/repositories/:repository_id`, soft-delete server-side; resolves on success, throws the server message on 404)
- File helpers under `client.repositories.files` (`list`, `create`, `read`, `update`, `delete`)
- Version helpers under `client.repositories.versions` (`list`, `get`)

## Session resources
- Adds cloud session `resources: [{ type: "repository", repositoryId }]`
- Repositories are attached **before** the conversation and managed sandbox are created (inside `resolveRuntime()`), so the links exist when the sandbox enumerates and clones them at bootstrap
- After each attach, polls `GET /v1/agents/:id/repositories` until the link is visible, avoiding a read-after-write race before sandbox creation
- SDK-created links are best-effort detached on session close

## Docs
- Documents repository usage in the README

## Tests
- `bun run check`
- `bun test` (adds `src/tests/repositories.test.ts` covering the delete request shape, id encoding, and the missing-repository error path)