### PR TITLE
fix: align SDK permission modes with harness names

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ const agentId = await client.createAgent({
 });
 
 await using session = client.resumeSession(agentId, {
-  permissionMode: "bypassPermissions",
+  permissionMode: "unrestricted",
 });
 
 await session.send("Summarize this repository.");
@@ -238,7 +238,7 @@ const session = client.resumeSession("agent-123", {
   // For local sessions this may be a local path; for remote/Constellation
   // sessions, use a path inside the selected runtime environment.
   cwd: "/workspace/project",
-  permissionMode: "bypassPermissions",
+  permissionMode: "unrestricted",
   dreaming: {
     trigger: "step-count", // off | step-count | compaction-event
     stepCount: 8,

--- a/examples/bug-fixer/fixer.ts
+++ b/examples/bug-fixer/fixer.ts
@@ -84,7 +84,7 @@ export async function getOrCreateAgent(state: BugFixerState): Promise<Session> {
     return resumeSession(state.agentId, {
       model: DEFAULT_CONFIG.model,
       allowedTools: ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
 
@@ -120,7 +120,7 @@ export async function getOrCreateAgent(state: BugFixerState): Promise<Session> {
       },
     ],
     allowedTools: ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 
   return session;

--- a/examples/dungeon-master/dm.ts
+++ b/examples/dungeon-master/dm.ts
@@ -96,7 +96,7 @@ export async function createDM(state: GameState): Promise<Session> {
     return resumeSession(state.dmAgentId, {
       model: DEFAULT_CONFIG.model,
       allowedTools: ['Read', 'Write'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
 
@@ -163,7 +163,7 @@ None - waiting to start or load a campaign
       },
     ],
     allowedTools: ['Read', 'Write'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 
   return session;

--- a/examples/economics-seminar/README.md
+++ b/examples/economics-seminar/README.md
@@ -118,7 +118,7 @@ After running a seminar, the agents can be "teleported" into other contexts:
 import { resumeSession } from '@letta-ai/letta-agent-sdk';
 
 // Get agent ID from --status
-const drChen = resumeSession('agent-xxx', { permissionMode: 'bypassPermissions' });
+const drChen = resumeSession('agent-xxx', { permissionMode: 'unrestricted' });
 
 // Dr. Chen remembers all past seminars!
 await drChen.send('What patterns have you noticed in economics presentations?');

--- a/examples/economics-seminar/faculty.ts
+++ b/examples/economics-seminar/faculty.ts
@@ -60,7 +60,7 @@ export async function createFacultyMember(
     return resumeSession(existingAgentId, {
       model: config.model,
       allowedTools: ['Read', 'Write'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
   
@@ -118,7 +118,7 @@ export async function createFacultyMember(
       },
     ],
     allowedTools: ['Read', 'Write'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 

--- a/examples/economics-seminar/presenter.ts
+++ b/examples/economics-seminar/presenter.ts
@@ -51,7 +51,7 @@ export async function createPresenter(
     return resumeSession(existingAgentId, {
       model: config.model,
       allowedTools: ['web_search', 'Read', 'Write'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
   
@@ -105,7 +105,7 @@ export async function createPresenter(
       },
     ],
     allowedTools: ['web_search', 'Read', 'Write'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 

--- a/examples/file-organizer/organizer.ts
+++ b/examples/file-organizer/organizer.ts
@@ -89,7 +89,7 @@ export async function getOrCreateAgent(state: FileOrganizerState): Promise<Sessi
     return resumeSession(state.agentId, {
       model: DEFAULT_CONFIG.model,
       allowedTools: ['Bash', 'Read', 'Glob'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
 
@@ -114,7 +114,7 @@ export async function getOrCreateAgent(state: FileOrganizerState): Promise<Sessi
       },
     ],
     allowedTools: ['Bash', 'Read', 'Glob'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 
   return session;

--- a/examples/focus-group/agents.ts
+++ b/examples/focus-group/agents.ts
@@ -48,14 +48,14 @@ export async function createCandidateAgent(): Promise<Session> {
         description: 'Insights gathered from voter feedback',
       },
     ],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 
 export async function resumeCandidateAgent(agentId: string): Promise<Session> {
   return resumeSession(agentId, {
     model: CONFIG.model,
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 
@@ -113,14 +113,14 @@ Background: ${persona.background}`,
         description: 'My emotional reactions to political positions',
       },
     ],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 
 export async function resumeVoterAgent(agentId: string): Promise<Session> {
   return resumeSession(agentId, {
     model: CONFIG.model,
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 
@@ -159,14 +159,14 @@ export async function createAnalystAgent(): Promise<Session> {
         description: 'Tactical recommendations based on focus group insights',
       },
     ],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 
 export async function resumeAnalystAgent(agentId: string): Promise<Session> {
   return resumeSession(agentId, {
     model: CONFIG.model,
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 

--- a/examples/release-notes/generator.ts
+++ b/examples/release-notes/generator.ts
@@ -101,7 +101,7 @@ export async function getOrCreateAgent(state: ReleaseNotesState): Promise<Sessio
     return resumeSession(state.agentId, {
       model: DEFAULT_CONFIG.model,
       allowedTools: ['Bash', 'Read', 'Write', 'Glob'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
 
@@ -126,7 +126,7 @@ export async function getOrCreateAgent(state: ReleaseNotesState): Promise<Sessio
       },
     ],
     allowedTools: ['Bash', 'Read', 'Write', 'Glob'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 
   return session;

--- a/examples/research-team/README.md
+++ b/examples/research-team/README.md
@@ -209,7 +209,7 @@ const researcherAgentId = 'agent-xxx-yyy-zzz';
 // Teleport the trained researcher into your code
 const researcher = resumeSession(researcherAgentId, {
   allowedTools: ['web_search', 'Read', 'Write'],
-  permissionMode: 'bypassPermissions',
+  permissionMode: 'unrestricted',
 });
 
 // The agent remembers everything it learned!
@@ -235,7 +235,7 @@ app.post('/research', async (req, res) => {
   
   // Teleport the trained researcher
   const researcher = resumeSession(teamState.agentIds.researcher!, {
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
   
   await researcher.send(`Research: ${query}`);

--- a/examples/research-team/agents/analyst.ts
+++ b/examples/research-team/agents/analyst.ts
@@ -56,7 +56,7 @@ export async function createAnalyst(
     return resumeSession(existingAgentId, {
       model: 'haiku',
       allowedTools: ['Glob', 'Read', 'Write'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
   
@@ -126,7 +126,7 @@ List full references at end
       },
     ],
     allowedTools: ['Glob', 'Read', 'Write'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 

--- a/examples/research-team/agents/coordinator.ts
+++ b/examples/research-team/agents/coordinator.ts
@@ -55,7 +55,7 @@ export async function createCoordinator(
     return resumeSession(existingAgentId, {
       model: 'haiku',
       allowedTools: ['Glob', 'Read', 'Write'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
   
@@ -127,7 +127,7 @@ export async function createCoordinator(
       },
     ],
     allowedTools: ['Glob', 'Read', 'Write'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 

--- a/examples/research-team/agents/researcher.ts
+++ b/examples/research-team/agents/researcher.ts
@@ -67,7 +67,7 @@ export async function createResearcher(
     return resumeSession(existingAgentId, {
       model: 'haiku',
       allowedTools: ['Glob', 'Read', 'Write'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
   
@@ -120,7 +120,7 @@ export async function createResearcher(
       },
     ],
     allowedTools: ['web_search', 'Glob', 'Read', 'Write'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 

--- a/examples/research-team/agents/writer.ts
+++ b/examples/research-team/agents/writer.ts
@@ -74,7 +74,7 @@ export async function createWriter(
     return resumeSession(existingAgentId, {
       model: 'haiku',
       allowedTools: ['Glob', 'Read', 'Write'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
   
@@ -159,7 +159,7 @@ export async function createWriter(
       },
     ],
     allowedTools: ['Glob', 'Read', 'Write'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 }
 

--- a/examples/research-team/teleport-example.ts
+++ b/examples/research-team/teleport-example.ts
@@ -56,7 +56,7 @@ async function main() {
 
   const researcher = resumeSession(teamState.agentIds.researcher!, {
     allowedTools: ['web_search', 'Read', 'Write'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 
   console.log('   Asking: "What search strategies have you found effective?"\n');
@@ -89,7 +89,7 @@ async function main() {
 
     const analyst = resumeSession(teamState.agentIds.analyst, {
       allowedTools: ['Read', 'Write'],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
 
     console.log('   Asking: "What analysis frameworks have worked well?"\n');

--- a/examples/v2-examples.ts
+++ b/examples/v2-examples.ts
@@ -85,7 +85,7 @@ async function basicSession() {
   // Create agent, then resume default conversation
   const agentId = await createAgent();
   await using session = resumeSession(agentId, {
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
   
   await session.send('Hello! Introduce yourself in one sentence.');
@@ -110,7 +110,7 @@ async function multiTurn() {
   // Create new agent + new conversation
   await using session = createSession(undefined, {
     model: 'haiku',
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 
   // Turn 1
@@ -158,7 +158,7 @@ async function sessionResume() {
   // First session - establish a memory
   {
     const session = resumeSession(agentId, {
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
     
     console.log('[Session 1] Teaching agent a secret word...');
@@ -181,7 +181,7 @@ async function sessionResume() {
   // Resume and verify agent remembers
   {
     await using session = resumeSession(agentId, {
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
     
     console.log('[Session 2] Asking agent for the secret word...');
@@ -215,7 +215,7 @@ async function testOptions() {
   console.log('Testing systemPrompt preset...');
   const sysPromptSession = createSession(undefined, {
     systemPrompt: 'letta-claude',
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
   await sysPromptSession.send('Hello, what kind of agent are you?');
   let sysPromptResponse = '';
@@ -230,7 +230,7 @@ async function testOptions() {
   const cwdSession = createSession(undefined, {
     cwd: '/tmp',
     allowedTools: ['Bash'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
   await cwdSession.send('Run pwd to show current directory');
   let cwdResponse = '';
@@ -245,7 +245,7 @@ async function testOptions() {
   console.log('Testing allowedTools option...');
   const toolsSession = createSession(undefined, {
     allowedTools: ['Bash'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
   await toolsSession.send('Run: echo tool-test-ok');
   let toolsResponse = '';
@@ -256,20 +256,20 @@ async function testOptions() {
   const hasToolOutput = toolsResponse.includes('tool-test-ok');
   console.log(`  allowedTools: ${hasToolOutput ? 'PASS' : 'CHECK'} - ${toolsResponse.slice(0, 60)}`);
 
-  // Test permissionMode: bypassPermissions
-  console.log('Testing permissionMode: bypassPermissions...');
-  const bypassSession = createSession(undefined, {
+  // Test permissionMode: unrestricted
+  console.log('Testing permissionMode: unrestricted...');
+  const unrestrictedSession = createSession(undefined, {
     allowedTools: ['Bash'],
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
-  await bypassSession.send('Run: echo bypass-test');
-  let bypassResponse = '';
-  for await (const msg of bypassSession.stream()) {
-    if (msg.type === 'result') bypassResponse = msg.result || '';
+  await unrestrictedSession.send('Run: echo unrestricted-test');
+  let unrestrictedResponse = '';
+  for await (const msg of unrestrictedSession.stream()) {
+    if (msg.type === 'result') unrestrictedResponse = msg.result || '';
   }
-  bypassSession.close();
-  const hasBypassOutput = bypassResponse.includes('bypass-test');
-  console.log(`  permissionMode: ${hasBypassOutput ? 'PASS' : 'CHECK'}`);
+  unrestrictedSession.close();
+  const hasUnrestrictedOutput = unrestrictedResponse.includes('unrestricted-test');
+  console.log(`  permissionMode: ${hasUnrestrictedOutput ? 'PASS' : 'CHECK'}`);
 
   console.log();
 }
@@ -283,7 +283,7 @@ async function testMessageTypes() {
 
   const agentId = await createAgent();
   const session = resumeSession(agentId, {
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 
   await session.send('Say "hello" exactly');
@@ -329,7 +329,7 @@ async function testSessionProperties() {
   // Create new agent + new conversation
   const session = createSession(undefined, {
     model: 'haiku',
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'unrestricted',
   });
 
   // Before send - properties should be null
@@ -367,7 +367,7 @@ async function testToolExecution() {
   async function runWithTools(message: string, tools: string[]): Promise<string> {
     const session = createSession(agentId, {
       allowedTools: tools,
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
     await session.send(message);
     let result = '';
@@ -412,14 +412,14 @@ async function testToolExecution() {
 async function testPermissionCallback() {
   console.log('=== Testing Permission Callback ===\n');
 
-  // Note: permissionMode 'default' with NO allowedTools triggers callback
+  // Note: permissionMode 'standard' with NO allowedTools triggers callback
   // allowedTools auto-allows tools, bypassing the callback
 
   // Test 1: Allow specific commands via callback
   console.log('Testing canUseTool callback (allow)...');
   const allowSession = createSession(undefined, {
     // NO allowedTools - this ensures callback is invoked
-    permissionMode: 'default',
+    permissionMode: 'standard',
     canUseTool: async (toolName, toolInput) => {
       console.error('CALLBACK:', toolName, toolInput);
       const command = (toolInput as { command?: string }).command || '';
@@ -441,7 +441,7 @@ async function testPermissionCallback() {
   // Test 2: Deny specific commands via callback
   console.log('Testing canUseTool callback (deny)...');
   const denySession = createSession(undefined, {
-    permissionMode: 'default',
+    permissionMode: 'standard',
     canUseTool: async (toolName, toolInput) => {
       const command = (toolInput as { command?: string }).command || '';
       if (command.includes('dangerous')) {
@@ -472,7 +472,7 @@ async function testSystemPrompt() {
 
   async function runWithSystemPrompt(msg: string, systemPrompt: any): Promise<string> {
     const agentId = await createAgent({ systemPrompt });
-    const session = resumeSession(agentId, { permissionMode: 'bypassPermissions' });
+    const session = resumeSession(agentId, { permissionMode: 'unrestricted' });
     await session.send(msg);
     let result = '';
     for await (const m of session.stream()) {
@@ -533,7 +533,7 @@ async function testMemoryConfig() {
 
   async function runWithMemory(msg: string, memory?: any[]): Promise<{ success: boolean; result: string }> {
     const agentId = await createAgent({ memory });
-    const session = resumeSession(agentId, { permissionMode: 'bypassPermissions' });
+    const session = resumeSession(agentId, { permissionMode: 'unrestricted' });
     await session.send(msg);
     let result = '';
     let success = false;
@@ -595,7 +595,7 @@ async function testConvenienceProps() {
 
   async function runWithProps(msg: string, props: Record<string, any>): Promise<{ success: boolean; result: string }> {
     const agentId = await createAgent(props);
-    const session = resumeSession(agentId, { permissionMode: 'bypassPermissions' });
+    const session = resumeSession(agentId, { permissionMode: 'unrestricted' });
     await session.send(msg);
     let result = '';
     let success = false;
@@ -688,7 +688,7 @@ async function testConversations() {
   console.log('Test 1: Resume default conversation...');
   {
     const session = resumeSession(agentId, {
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
 
     await session.send('Remember: the secret code is ALPHA. Store this in memory.');
@@ -710,7 +710,7 @@ async function testConversations() {
   console.log('\nTest 2: Create new conversation (createSession)...');
   {
     const session = createSession(agentId, {
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
 
     await session.send('Remember: the secret code for THIS conversation is BETA.');
@@ -734,7 +734,7 @@ async function testConversations() {
     console.log('  Use resumeSession(agentId) to resume default conversation');
   } else {
     await using session = resumeSession(conversationId1!, {
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
 
     await session.send('What is the secret code for this conversation?');
@@ -757,7 +757,7 @@ async function testConversations() {
   console.log('\nTest 4: Create another new conversation...');
   {
     await using session = createSession(agentId, {
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
 
     await session.send('Say "third conversation"');
@@ -780,7 +780,7 @@ async function testConversations() {
   console.log('\nTest 5: Resume default conversation via resumeSession(agentId)...');
   {
     await using session = resumeSession(agentId, {
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
 
     await session.send('What is the secret code? (should be ALPHA from default conversation)');
@@ -799,7 +799,7 @@ async function testConversations() {
   console.log('\nTest 6: conversationId in result message...');
   {
     await using session = resumeSession(conversationId1!, {
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
 
     await session.send('Hi');
@@ -822,7 +822,7 @@ async function testConversations() {
   {
     await using session = createSession(undefined, {
       model: 'haiku',
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
 
     await session.send('Say "lru agent test ok"');

--- a/examples/web-chat/server.ts
+++ b/examples/web-chat/server.ts
@@ -61,7 +61,7 @@ async function getSession(): Promise<Session> {
     console.log(`Resuming agent: ${state.agentId}`);
     session = await resumeSession(state.agentId, {
       model: 'haiku',
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   } else {
     console.log('Creating new agent...');
@@ -88,7 +88,7 @@ You have memory that persists across conversations. Use it to remember important
           description: 'Important things from our conversations',
         },
       ],
-      permissionMode: 'bypassPermissions',
+      permissionMode: 'unrestricted',
     });
   }
 

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -12,6 +12,7 @@ import { startLocalAppServer, type LocalAppServerHandle } from "./local-app-serv
 import {
   RemoteClientSessionCore,
   ensureSuccess,
+  isUnrestrictedPermissionMode,
   mapPermissionMode,
   normalizeSendMessage,
   type ProtocolMessage,
@@ -329,7 +330,7 @@ export async function resolveAppServerToolApproval(
     };
   }
 
-  if (options.permissionMode === "bypassPermissions" && !toolNeedsRuntimeUserInput) {
+  if (isUnrestrictedPermissionMode(options.permissionMode) && !toolNeedsRuntimeUserInput) {
     return { behavior: "allow", updatedInput: null, updatedPermissions: [] };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,7 @@ export async function listMessagesDirect(
   // resumeSession uses --default which maps to the agent's default conversation.
   // The session is transient: we only need it long enough to list messages.
   const session = new LettaAgentClient().resumeSession(agentId, {
-    permissionMode: "bypassPermissions",
+    permissionMode: "unrestricted",
   });
   await (session as InitializableSession).initialize();
   try {

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -170,16 +170,46 @@ const KNOWN_SDK_ERROR_CODES = new Set<SDKErrorCode>([
   "stream_closed",
 ]);
 
-export function mapPermissionMode(
-  mode: LettaCodeClientSessionOptions["permissionMode"],
-): string | undefined {
-  if (mode === undefined || mode === "default" || mode === "standard") {
+type LegacyPermissionMode = "default" | "bypassPermissions" | "fullAccess";
+
+export function normalizePermissionMode(
+  mode:
+    | LettaCodeClientSessionOptions["permissionMode"]
+    | LegacyPermissionMode
+    | undefined,
+): LettaCodeClientSessionOptions["permissionMode"] | undefined {
+  if (mode === undefined || mode === "default") {
     return "standard";
   }
-  if (mode === "acceptEdits") return "acceptEdits";
-  if (mode === "bypassPermissions") return "unrestricted";
-  if (mode === "plan") return "memory";
+  if (mode === "bypassPermissions" || mode === "fullAccess") {
+    return "unrestricted";
+  }
+  if (
+    mode === "standard" ||
+    mode === "acceptEdits" ||
+    mode === "unrestricted"
+  ) {
+    return mode;
+  }
   return undefined;
+}
+
+export function mapPermissionMode(
+  mode:
+    | LettaCodeClientSessionOptions["permissionMode"]
+    | LegacyPermissionMode
+    | undefined,
+): string | undefined {
+  return normalizePermissionMode(mode);
+}
+
+export function isUnrestrictedPermissionMode(
+  mode:
+    | LettaCodeClientSessionOptions["permissionMode"]
+    | LegacyPermissionMode
+    | undefined,
+): boolean {
+  return normalizePermissionMode(mode) === "unrestricted";
 }
 
 export function ensureSuccess(message: Record<string, unknown>, fallback: string): void {
@@ -792,8 +822,10 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     }
     const payload: Record<string, unknown> = {};
     if (updates.cwd !== undefined) payload.cwd = updates.cwd;
-    const mode = mapPermissionMode(updates.permissionMode);
-    if (mode !== undefined) payload.mode = mode;
+    if (updates.permissionMode !== undefined) {
+      const mode = mapPermissionMode(updates.permissionMode);
+      if (mode !== undefined) payload.mode = mode;
+    }
     if (updates.agentId !== undefined) payload.agent_id = updates.agentId;
     if (updates.conversationId !== undefined) payload.conversation_id = updates.conversationId;
 

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -173,7 +173,9 @@ const KNOWN_SDK_ERROR_CODES = new Set<SDKErrorCode>([
 export function mapPermissionMode(
   mode: LettaCodeClientSessionOptions["permissionMode"],
 ): string | undefined {
-  if (mode === undefined || mode === "default") return undefined;
+  if (mode === undefined || mode === "default" || mode === "standard") {
+    return "standard";
+  }
   if (mode === "acceptEdits") return "acceptEdits";
   if (mode === "bypassPermissions") return "unrestricted";
   if (mode === "plan") return "memory";

--- a/src/session.ts
+++ b/src/session.ts
@@ -41,6 +41,7 @@ import {
   isHeadlessAutoAllowTool,
   requiresRuntimeUserInput,
 } from "./interactiveToolPolicy.js";
+import { isUnrestrictedPermissionMode } from "./remote-client-session-core.js";
 
 
 // All logging gated behind DEBUG_SDK env var
@@ -972,7 +973,7 @@ export class Session implements AsyncDisposable {
     const autoAllowWithoutCallback =
       isHeadlessAutoAllowTool(toolName);
 
-    sessionLog("canUseTool", `tool=${toolName} mode=${this.options.permissionMode || "default"} requestId=${requestId}`);
+    sessionLog("canUseTool", `tool=${toolName} mode=${this.options.permissionMode || "standard"} requestId=${requestId}`);
 
     // Tools that require runtime user input cannot be auto-allowed without a callback.
     if (toolNeedsRuntimeUserInput && !hasCallback) {
@@ -982,11 +983,11 @@ export class Session implements AsyncDisposable {
         interrupt: false,
       };
     } else if (
-      this.options.permissionMode === "bypassPermissions" &&
+      isUnrestrictedPermissionMode(this.options.permissionMode) &&
       !toolNeedsRuntimeUserInput
     ) {
-      // bypassPermissions auto-allows non-interactive tools.
-      sessionLog("canUseTool", `AUTO-ALLOW ${toolName} (bypassPermissions)`);
+      // unrestricted auto-allows non-interactive tools.
+      sessionLog("canUseTool", `AUTO-ALLOW ${toolName} (unrestricted)`);
       response = {
         behavior: "allow",
         updatedInput: null,

--- a/src/tests/advanced-session.ts
+++ b/src/tests/advanced-session.ts
@@ -15,6 +15,12 @@ export type AdvancedSession = LettaCodeSession & {
   recoverPendingApprovals(
     options?: RecoverPendingApprovalsOptions,
   ): Promise<RecoverPendingApprovalsResult>;
+  changeDeviceState(updates: {
+    cwd?: string;
+    permissionMode?: "standard" | "acceptEdits" | "unrestricted";
+    agentId?: string;
+    conversationId?: string;
+  }): Promise<void>;
   updateToolset(toolsetPreference: string): Promise<void>;
   bootstrapState(options?: BootstrapStateOptions): Promise<BootstrapStateResult>;
 };

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1140,6 +1140,24 @@ describe("LettaAgentClient", () => {
         toolset_preference: "developer",
       });
 
+      await asAdvanced(session).changeDeviceState({ cwd: "/workspace/method" });
+      const cwdOnlyDeviceState = fakeControlSocket().sent.at(-1) as {
+        payload?: Record<string, unknown>;
+      };
+      expect(cwdOnlyDeviceState).toMatchObject({
+        type: "change_device_state",
+        runtime: { agent_id: "agent-123", conversation_id: "default" },
+        payload: { cwd: "/workspace/method" },
+      });
+      expect(cwdOnlyDeviceState.payload).not.toHaveProperty("mode");
+
+      await asAdvanced(session).changeDeviceState({ permissionMode: "unrestricted" });
+      expect(fakeControlSocket().sent.at(-1)).toMatchObject({
+        type: "change_device_state",
+        runtime: { agent_id: "agent-123", conversation_id: "default" },
+        payload: { mode: "unrestricted" },
+      });
+
       await session.sendCommand({
         type: "change_device_state",
         runtime: { agent_id: "agent-123", conversation_id: "default" },

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -675,7 +675,7 @@ describe("CloudEnvironmentSession", () => {
     const session = client.resumeSession("agent-1", {
       model: "anthropic/claude-sonnet-4",
       cwd: "/repo",
-      permissionMode: "bypassPermissions",
+      permissionMode: "unrestricted",
       dreaming: { trigger: "step-count", stepCount: 3 },
     });
     const init = await asAdvanced(session).initialize();

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -302,7 +302,7 @@ describeLive("live integration: letta-agent-sdk", () => {
       await ensureAgentReady();
 
       const session = createSession(agentId, {
-        permissionMode: "bypassPermissions",
+        permissionMode: "unrestricted",
       });
       openedSessions.push(session);
 
@@ -332,7 +332,7 @@ describeLive("live integration: letta-agent-sdk", () => {
       expect(conversationId.startsWith("conv-")).toBe(true);
 
       const session = resumeSession(conversationId, {
-        permissionMode: "bypassPermissions",
+        permissionMode: "unrestricted",
       });
       openedSessions.push(session);
 
@@ -350,7 +350,7 @@ describeLive("live integration: letta-agent-sdk", () => {
       await ensureAgentReady();
 
       const session = createSession(agentId, {
-        permissionMode: "bypassPermissions",
+        permissionMode: "unrestricted",
       });
       openedSessions.push(session);
 
@@ -380,7 +380,7 @@ describeLive("live integration: letta-agent-sdk", () => {
       await ensureAgentReady();
 
       const session = createSession(agentId, {
-        permissionMode: "bypassPermissions",
+        permissionMode: "unrestricted",
       });
       openedSessions.push(session);
 
@@ -425,7 +425,7 @@ describeLive("live integration: letta-agent-sdk", () => {
       await ensureAgentReady();
 
       const session = createSession(agentId, {
-        permissionMode: "bypassPermissions",
+        permissionMode: "unrestricted",
       });
       openedSessions.push(session);
 
@@ -492,7 +492,7 @@ describeLive("live integration: letta-agent-sdk", () => {
       await ensureAgentReady();
 
       const session = createSession(agentId, {
-        permissionMode: "bypassPermissions",
+        permissionMode: "unrestricted",
       });
       openedSessions.push(session);
 
@@ -546,7 +546,7 @@ describeLive("live integration: letta-agent-sdk", () => {
       await ensureAgentReady();
 
       const session = createSession(agentId, {
-        permissionMode: "bypassPermissions",
+        permissionMode: "unrestricted",
       });
       openedSessions.push(session);
 
@@ -613,7 +613,7 @@ describeLive("live integration: letta-agent-sdk", () => {
 
       try {
         const session = createSession(stuckAgentId, {
-          permissionMode: "bypassPermissions",
+          permissionMode: "unrestricted",
         });
         openedSessions.push(session);
 

--- a/src/tests/permission-mode.test.ts
+++ b/src/tests/permission-mode.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { mapPermissionMode } from "../remote-client-session-core.js";
+
+describe("mapPermissionMode", () => {
+  test("maps unset and default modes to app-server standard mode", () => {
+    expect(mapPermissionMode(undefined)).toBe("standard");
+    expect(mapPermissionMode("default")).toBe("standard");
+  });
+
+  test("maps explicit SDK modes to app-server device modes", () => {
+    expect(mapPermissionMode("standard")).toBe("standard");
+    expect(mapPermissionMode("acceptEdits")).toBe("acceptEdits");
+    expect(mapPermissionMode("plan")).toBe("memory");
+    expect(mapPermissionMode("bypassPermissions")).toBe("unrestricted");
+  });
+});

--- a/src/tests/permission-mode.test.ts
+++ b/src/tests/permission-mode.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mapPermissionMode } from "../remote-client-session-core.js";
 
 describe("mapPermissionMode", () => {
-  test("maps unset and default modes to app-server standard mode", () => {
+  test("maps unset and legacy default alias to app-server standard mode", () => {
     expect(mapPermissionMode(undefined)).toBe("standard");
     expect(mapPermissionMode("default")).toBe("standard");
   });
@@ -10,7 +10,11 @@ describe("mapPermissionMode", () => {
   test("maps explicit SDK modes to app-server device modes", () => {
     expect(mapPermissionMode("standard")).toBe("standard");
     expect(mapPermissionMode("acceptEdits")).toBe("acceptEdits");
-    expect(mapPermissionMode("plan")).toBe("memory");
+    expect(mapPermissionMode("unrestricted")).toBe("unrestricted");
+  });
+
+  test("normalizes legacy permission mode aliases without exposing them in the SDK type", () => {
     expect(mapPermissionMode("bypassPermissions")).toBe("unrestricted");
+    expect(mapPermissionMode("fullAccess")).toBe("unrestricted");
   });
 });

--- a/src/tests/session.test.ts
+++ b/src/tests/session.test.ts
@@ -314,7 +314,7 @@ describe("Session", () => {
     }
   });
 
-  describe("handleCanUseTool with bypassPermissions", () => {
+  describe("handleCanUseTool with unrestricted", () => {
     async function invokeCanUseTool(
       session: Session,
       tool_name: string,
@@ -341,10 +341,10 @@ describe("Session", () => {
       return capturedResponse;
     }
 
-    test("auto-approves tools when permissionMode is bypassPermissions", async () => {
-      // Create a session with bypassPermissions
+    test("auto-approves tools when permissionMode is unrestricted", async () => {
+      // Create a session with unrestricted
       const session = new Session({
-        permissionMode: "bypassPermissions",
+        permissionMode: "unrestricted",
       });
 
       const capturedResponse = await invokeCanUseTool(session, "Bash", {
@@ -366,10 +366,10 @@ describe("Session", () => {
       });
     });
 
-    test("denies tools by default when no callback and not bypassPermissions", async () => {
-      // Create a session with default permission mode
+    test("denies tools by default when no callback and not unrestricted", async () => {
+      // Create a session with standard permission mode
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
       });
 
       const capturedResponse = await invokeCanUseTool(session, "Bash", {
@@ -393,7 +393,7 @@ describe("Session", () => {
 
     test("auto-allows EnterPlanMode without callback", async () => {
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
       });
 
       const capturedResponse = await invokeCanUseTool(
@@ -416,9 +416,9 @@ describe("Session", () => {
       });
     });
 
-    test("denies AskUserQuestion without callback even in bypassPermissions", async () => {
+    test("denies AskUserQuestion without callback even in unrestricted", async () => {
       const session = new Session({
-        permissionMode: "bypassPermissions",
+        permissionMode: "unrestricted",
       });
 
       const capturedResponse = await invokeCanUseTool(
@@ -443,9 +443,9 @@ describe("Session", () => {
       });
     });
 
-    test("uses canUseTool callback when provided and not bypassPermissions", async () => {
+    test("uses canUseTool callback when provided and not unrestricted", async () => {
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
         canUseTool: async (toolName) => {
           if (toolName === "Bash") {
             return { behavior: "allow" };
@@ -728,7 +728,7 @@ describe("Session", () => {
   describe("approval recovery flow", () => {
     test("recoverPendingApprovals returns unknown pending state on timeout", async () => {
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
       });
       const transport = new MockTransport();
       attachMockTransport(session, transport);
@@ -750,7 +750,7 @@ describe("Session", () => {
 
     test("recoverPendingApprovals reports unsupported when CLI rejects subtype", async () => {
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
       });
       const transport = new MockTransport();
       attachMockTransport(session, transport);
@@ -795,7 +795,7 @@ describe("Session", () => {
 
     test("runTurn terminalizes approval conflict when recovery is unsupported", async () => {
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
       });
       const transport = new MockTransport();
       attachMockTransport(session, transport);
@@ -851,7 +851,7 @@ describe("Session", () => {
 
     test("runTurn retries once after successful recovery", async () => {
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
       });
       const transport = new MockTransport();
       attachMockTransport(session, transport);
@@ -920,7 +920,7 @@ describe("Session", () => {
 
     test("runTurn preserves non-conflict error detail on terminal result", async () => {
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
       });
       const transport = new MockTransport();
       attachMockTransport(session, transport);
@@ -953,7 +953,7 @@ describe("Session", () => {
   describe("background pump parity", () => {
     test("propagates approval conflict detail from error message to terminal result", async () => {
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
       });
       const transport = new MockTransport();
       attachMockTransport(session, transport);
@@ -992,7 +992,7 @@ describe("Session", () => {
     test("handles can_use_tool control requests before stream iteration starts", async () => {
       let callbackInvocations = 0;
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
         canUseTool: () => {
           callbackInvocations += 1;
           return { behavior: "allow" };
@@ -1041,7 +1041,7 @@ describe("Session", () => {
 
     test("bounds buffered stream messages and drops oldest deterministically", async () => {
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
       });
       const transport = new MockTransport();
       attachMockTransport(session, transport);
@@ -1096,7 +1096,7 @@ describe("Session", () => {
 
     test("emits error and retry messages instead of dropping them", async () => {
       const session = new Session({
-        permissionMode: "default",
+        permissionMode: "standard",
       });
       const transport = new MockTransport();
       attachMockTransport(session, transport);

--- a/src/tests/transport-args.test.ts
+++ b/src/tests/transport-args.test.ts
@@ -155,21 +155,23 @@ describe("buildCliArgs — model and embedding", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("buildCliArgs — permission mode", () => {
-  test("bypassPermissions → --yolo", () => {
-    const args = buildCliArgs({ permissionMode: "bypassPermissions" });
-    expect(args).toContain("--yolo");
-    expect(args).not.toContain("--permission-mode");
+  test("unrestricted → --permission-mode unrestricted", () => {
+    const args = buildCliArgs({ permissionMode: "unrestricted" });
+    const idx = args.indexOf("--permission-mode");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("unrestricted");
+    expect(args).not.toContain("--yolo");
   });
 
-  test("other non-default modes → --permission-mode <mode>", () => {
+  test("acceptEdits → --permission-mode acceptEdits", () => {
     const args = buildCliArgs({ permissionMode: "acceptEdits" });
     const idx = args.indexOf("--permission-mode");
     expect(idx).toBeGreaterThan(-1);
     expect(args[idx + 1]).toBe("acceptEdits");
   });
 
-  test("default mode → standard permission mode", () => {
-    const args = buildCliArgs({ permissionMode: "default" });
+  test("standard mode → --permission-mode standard", () => {
+    const args = buildCliArgs({ permissionMode: "standard" });
     const idx = args.indexOf("--permission-mode");
     expect(idx).toBeGreaterThan(-1);
     expect(args[idx + 1]).toBe("standard");
@@ -181,6 +183,14 @@ describe("buildCliArgs — permission mode", () => {
     const idx = args.indexOf("--permission-mode");
     expect(idx).toBeGreaterThan(-1);
     expect(args[idx + 1]).toBe("standard");
+    expect(args).not.toContain("--yolo");
+  });
+
+  test("legacy bypassPermissions alias → unrestricted permission mode", () => {
+    const args = buildCliArgs({ permissionMode: "bypassPermissions" as never });
+    const idx = args.indexOf("--permission-mode");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("unrestricted");
     expect(args).not.toContain("--yolo");
   });
 });

--- a/src/tests/transport-args.test.ts
+++ b/src/tests/transport-args.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, test } from "bun:test";
 import { buildCliArgs } from "../transport.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Baseline: every invocation includes these two pairs
+// Baseline: every invocation includes stream-json I/O and standard permissions.
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("buildCliArgs — baseline args", () => {
@@ -25,11 +25,12 @@ describe("buildCliArgs — baseline args", () => {
     expect(args[inIdx + 1]).toBe("stream-json");
   });
 
-  test("minimum invocation (empty options) produces exactly the two baseline pairs", () => {
+  test("minimum invocation (empty options) produces exactly the baseline flags", () => {
     const args = buildCliArgs({});
     expect(args).toEqual([
       "--output-format", "stream-json",
       "--input-format", "stream-json",
+      "--permission-mode", "standard",
     ]);
   });
 });
@@ -167,15 +168,19 @@ describe("buildCliArgs — permission mode", () => {
     expect(args[idx + 1]).toBe("acceptEdits");
   });
 
-  test("default mode → no permission flag", () => {
+  test("default mode → standard permission mode", () => {
     const args = buildCliArgs({ permissionMode: "default" });
-    expect(args).not.toContain("--permission-mode");
+    const idx = args.indexOf("--permission-mode");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("standard");
     expect(args).not.toContain("--yolo");
   });
 
-  test("no permissionMode → no permission flag", () => {
+  test("no permissionMode → standard permission mode", () => {
     const args = buildCliArgs({});
-    expect(args).not.toContain("--permission-mode");
+    const idx = args.indexOf("--permission-mode");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("standard");
     expect(args).not.toContain("--yolo");
   });
 });

--- a/src/tests/transport.test.ts
+++ b/src/tests/transport.test.ts
@@ -27,7 +27,7 @@ describe("CLI resolution", () => {
 
 describe("transport args", () => {
   function buildArgsFor(options: {
-    permissionMode?: "default" | "acceptEdits" | "plan" | "bypassPermissions";
+    permissionMode?: "default" | "standard" | "acceptEdits" | "plan" | "bypassPermissions";
     allowedTools?: string[];
     disallowedTools?: string[];
     createOnly?: boolean;
@@ -51,6 +51,18 @@ describe("transport args", () => {
     expect(args).toContain("--permission-mode");
     expect(args).toContain("acceptEdits");
     expect(args).not.toContain("--accept-edits");
+  });
+
+  test("default uses --permission-mode standard", () => {
+    const args = buildArgsFor({ permissionMode: "default" });
+    expect(args).toContain("--permission-mode");
+    expect(args).toContain("standard");
+  });
+
+  test("standard uses --permission-mode standard", () => {
+    const args = buildArgsFor({ permissionMode: "standard" });
+    expect(args).toContain("--permission-mode");
+    expect(args).toContain("standard");
   });
 
   test("plan mode uses --permission-mode plan", () => {

--- a/src/tests/transport.test.ts
+++ b/src/tests/transport.test.ts
@@ -27,7 +27,7 @@ describe("CLI resolution", () => {
 
 describe("transport args", () => {
   function buildArgsFor(options: {
-    permissionMode?: "default" | "standard" | "acceptEdits" | "plan" | "bypassPermissions";
+    permissionMode?: "standard" | "acceptEdits" | "unrestricted";
     allowedTools?: string[];
     disallowedTools?: string[];
     createOnly?: boolean;
@@ -53,28 +53,17 @@ describe("transport args", () => {
     expect(args).not.toContain("--accept-edits");
   });
 
-  test("default uses --permission-mode standard", () => {
-    const args = buildArgsFor({ permissionMode: "default" });
-    expect(args).toContain("--permission-mode");
-    expect(args).toContain("standard");
-  });
-
   test("standard uses --permission-mode standard", () => {
     const args = buildArgsFor({ permissionMode: "standard" });
     expect(args).toContain("--permission-mode");
     expect(args).toContain("standard");
   });
 
-  test("plan mode uses --permission-mode plan", () => {
-    const args = buildArgsFor({ permissionMode: "plan" });
+  test("unrestricted uses --permission-mode unrestricted", () => {
+    const args = buildArgsFor({ permissionMode: "unrestricted" });
     expect(args).toContain("--permission-mode");
-    expect(args).toContain("plan");
-  });
-
-  test("bypassPermissions still uses --yolo alias", () => {
-    const args = buildArgsFor({ permissionMode: "bypassPermissions" });
-    expect(args).toContain("--yolo");
-    expect(args).not.toContain("--permission-mode");
+    expect(args).toContain("unrestricted");
+    expect(args).not.toContain("--yolo");
   });
 
   test("allowedTools and disallowedTools are forwarded to CLI flags", () => {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -6,6 +6,7 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { createInterface, type Interface } from "node:readline";
+import { normalizePermissionMode } from "./remote-client-session-core.js";
 import type { InternalSessionOptions, WireMessage } from "./types.js";
 
 // All logging gated behind DEBUG_SDK env var
@@ -154,14 +155,8 @@ export function buildCliArgs(options: InternalSessionOptions): string[] {
     }
   }
 
-  // Permission mode
-  if (options.permissionMode === "bypassPermissions") {
-    args.push("--yolo");
-  } else {
-    const mode =
-      options.permissionMode === undefined || options.permissionMode === "default"
-        ? "standard"
-        : options.permissionMode;
+  const mode = normalizePermissionMode(options.permissionMode);
+  if (mode !== undefined) {
     args.push("--permission-mode", mode);
   }
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -157,8 +157,12 @@ export function buildCliArgs(options: InternalSessionOptions): string[] {
   // Permission mode
   if (options.permissionMode === "bypassPermissions") {
     args.push("--yolo");
-  } else if (options.permissionMode && options.permissionMode !== "default") {
-    args.push("--permission-mode", options.permissionMode);
+  } else {
+    const mode =
+      options.permissionMode === undefined || options.permissionMode === "default"
+        ? "standard"
+        : options.permissionMode;
+    args.push("--permission-mode", mode);
   }
 
   // Allowed / disallowed tools

--- a/src/types.ts
+++ b/src/types.ts
@@ -543,11 +543,9 @@ export interface InternalSessionOptions {
 }
 
 export type PermissionMode =
-  | "default"
   | "standard"
   | "acceptEdits"
-  | "plan"
-  | "bypassPermissions";
+  | "unrestricted";
 
 export type ReasoningEffort =
   | "none"

--- a/src/types.ts
+++ b/src/types.ts
@@ -544,6 +544,7 @@ export interface InternalSessionOptions {
 
 export type PermissionMode =
   | "default"
+  | "standard"
   | "acceptEdits"
   | "plan"
   | "bypassPermissions";


### PR DESCRIPTION
## Summary
- make the public `PermissionMode` union match the harness values: `standard`, `acceptEdits`, `unrestricted`
- default unset SDK sessions to app-server `standard` while preserving runtime normalization for legacy JS callers
- pass canonical `--permission-mode <mode>` args instead of advertising/using legacy `--yolo` or `bypassPermissions`
- update approval auto-allow logic, README/examples, and tests to use `unrestricted`
- ensure `changeDeviceState({ cwd })` does not implicitly reset permission mode

## Tests
- `bun run check`
- `bun test src/tests/permission-mode.test.ts src/tests/transport.test.ts src/tests/transport-args.test.ts src/tests/session.test.ts src/tests/cloud-session.test.ts`
- `bun test src/tests/client.test.ts src/tests/permission-mode.test.ts src/tests/transport.test.ts src/tests/transport-args.test.ts`
- `bun test`
- `bun run build`
- `git diff --check`
