### PR TITLE
feat: conversation-scoped managed sandboxes with legacy fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,12 @@ for await (const msg of session.stream()) {
 ### Constellation
 
 Use `backend: "cloud"` to create or resume agents hosted on Constellation. If
-no `environment` is provided, the SDK creates an agent-scoped sandbox, waits for
-it to come online, refreshes it while the session is active, and cleans it up on
-close.
+no `environment` is provided, the SDK creates a managed sandbox, waits for it to
+come online, and refreshes it while the session is active. Non-default
+conversations request a conversation-scoped sandbox from supporting servers;
+the default conversation and legacy servers retain the agent-scoped lifecycle.
+Managed sandboxes are left for TTL cleanup by default so another session for the
+same conversation can reconnect to them.
 
 ```ts
 const client = new LettaAgentClient({
@@ -127,8 +130,8 @@ const client = new LettaAgentClient({
   sandbox: {
     // Optional: defaults to a 5-minute refresh TTL.
     ttlMinutes: 5,
-    // Optional: defaults true. Set false for concurrent same-agent sessions.
-    terminateOnClose: true,
+    // Optional: defaults false. Set true only with exclusive ownership.
+    terminateOnClose: false,
   },
 });
 
@@ -180,10 +183,52 @@ await using session = client.resumeSession(agentId, {
 `environment` also accepts `{ id: "env-..." }` for an environment record or
 `{ deviceId: "device-..." }` for a stable device selector.
 
-`environment` and `sandbox` are mutually exclusive. Managed sandbox refresh and
-termination operate on the latest active sandbox for an agent; set
-`sandbox.terminateOnClose: false` when multiple SDK sessions may run
-concurrently against the same agent and rely on TTL cleanup instead.
+`environment` and `sandbox` are mutually exclusive. Conversation-scoped
+sandboxes refresh and terminate by sandbox ID. Legacy agent-scoped sandboxes
+retain the latest-active ownership check. Pass `sandbox.terminateOnClose: true`
+to request best-effort eager cleanup, but only when no other session or
+reconnecting client needs the sandbox.
+
+If Cloud reaps a conversation-scoped sandbox before the next refresh,
+`send()` throws `CloudManagedSandboxExpiredError` before transmitting the turn.
+Close the old SDK session and resume the same conversation to create a fresh
+connection, then retry safely:
+
+```ts
+import {
+  CloudManagedSandboxExpiredError,
+  LettaAgentClient,
+} from "@letta-ai/letta-agent-sdk";
+
+const client = new LettaAgentClient({
+  backend: "cloud",
+  apiKey: process.env.LETTA_API_KEY,
+});
+const conversationId = "conv-123";
+let session = client.resumeSession(conversationId);
+
+async function sendWithSandboxRecovery(message: string): Promise<void> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await session.send(message);
+      for await (const event of session.stream()) {
+        if (event.type === "assistant") console.log(event.content);
+      }
+      return;
+    } catch (error) {
+      if (!(error instanceof CloudManagedSandboxExpiredError) || attempt > 0) {
+        throw error;
+      }
+      session.close();
+      session = client.resumeSession(conversationId);
+    }
+  }
+}
+```
+
+Only retry automatically for this pre-send expiration error. If a connection
+fails after `send()` succeeds, inspect conversation history before retrying
+because the original message may already have reached the runtime.
 
 By default, websocket authentication uses `Authorization` headers. Set
 `webSocketAuth: "query"` for browser-style websocket clients that cannot send

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -124,6 +124,26 @@ type ResolvedCloudConnection = {
 
 class CloudManagedSandboxOwnershipError extends Error {}
 
+/**
+ * The Cloud API reaped a conversation-scoped managed sandbox before the SDK
+ * could refresh it. The failed refresh happens before the next turn is sent,
+ * so callers can safely create a new SDK session for {@link conversationId}
+ * and retry that turn.
+ */
+export class CloudManagedSandboxExpiredError extends Error {
+  readonly code = "managed_sandbox_expired" as const;
+
+  constructor(
+    readonly sandboxId: string,
+    readonly conversationId: string,
+  ) {
+    super(
+      `Cloud managed sandbox ${sandboxId} expired. Resume conversation ${conversationId} with a new SDK session and retry the turn.`,
+    );
+    this.name = "CloudManagedSandboxExpiredError";
+  }
+}
+
 type CloudSessionMode = Extract<RuntimeSessionMode, { kind: "session" }>;
 
 type CloudAgentRepository = {
@@ -685,6 +705,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   private managedSandbox: ManagedCloudSandbox | null = null;
   private sandboxRefreshTimer: ReturnType<typeof setInterval> | null = null;
   private sandboxRefreshInFlight: Promise<void> | null = null;
+  private sandboxLifecycleClosing = false;
   private attachedRepositoryIds = new Set<string>();
   private readonly cloudMode: CloudSessionMode;
 
@@ -1039,6 +1060,11 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     );
     this.managedSandbox = sandbox;
 
+    if (this.sandboxLifecycleClosing) {
+      await this.cleanupManagedSandbox();
+      throw new Error("Cloud managed sandbox session closed during initialization.");
+    }
+
     try {
       await this.refreshManagedSandbox(sandbox);
       const connection = await this.waitForManagedSandboxConnection(sandbox);
@@ -1070,6 +1096,17 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       throw new Error("Cloud create managed sandbox response did not include sandbox connection details.");
     }
 
+    const responseConversationId =
+      typeof body.conversationId === "string" ? body.conversationId : null;
+    if (
+      responseConversationId !== null &&
+      responseConversationId !== conversationId
+    ) {
+      throw new Error(
+        `Cloud managed sandbox response conversation mismatch: expected ${conversationId ?? "none"}, got ${responseConversationId}.`,
+      );
+    }
+
     const sandboxOptions = this.resolvedSandboxOptions();
     const ttlMinutes = sandboxOptions.ttlMinutes ?? DEFAULT_SANDBOX_TTL_MINUTES;
     const readyTimeoutMs = sandboxOptions.readyTimeoutMs
@@ -1083,8 +1120,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
 
     return {
       agentId,
-      conversationId:
-        typeof body.conversationId === "string" ? body.conversationId : null,
+      conversationId: responseConversationId,
       sandboxId: body.sandboxId,
       deviceId: body.deviceId,
       connectionName: body.connectionName,
@@ -1129,19 +1165,16 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
         },
       );
       if (response.status === 404) {
-        // The TTL reaped the sandbox mid-session. Create-or-resume brings up
-        // a replacement with the same deterministic deviceId, so environment
-        // resolution (and reconnects) keep working; adopt its identity and
-        // keep refreshing.
         await parseJsonResponse(response);
-        const replacement = await this.createManagedSandbox(
-          sandbox.agentId,
+        // The current control and stream WebSockets are bound to this
+        // sandbox's ephemeral connection id. Recreating only the sandbox would
+        // leave both sockets targeting the dead connection, so surface a
+        // pre-turn error and let the caller resume the same conversation with
+        // a new SDK session.
+        throw new CloudManagedSandboxExpiredError(
+          sandbox.sandboxId,
           sandbox.conversationId,
         );
-        sandbox.sandboxId = replacement.sandboxId;
-        sandbox.deviceId = replacement.deviceId;
-        sandbox.connectionName = replacement.connectionName;
-        return;
       }
       const body = await parseJsonResponse(response);
       assertOkResponse(response, body, "Cloud refresh managed sandbox");
@@ -1240,7 +1273,10 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     this.stopManagedSandboxRefresh();
     this.sandboxRefreshTimer = setInterval(() => {
       void this.refreshManagedSandbox(sandbox).catch((error) => {
-        if (error instanceof CloudManagedSandboxOwnershipError) {
+        if (
+          error instanceof CloudManagedSandboxOwnershipError ||
+          error instanceof CloudManagedSandboxExpiredError
+        ) {
           this.stopManagedSandboxRefresh();
         }
       });
@@ -1255,9 +1291,20 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   }
 
   private async cleanupManagedSandbox(): Promise<void> {
+    this.sandboxLifecycleClosing = true;
     this.stopManagedSandboxRefresh();
     const sandbox = this.managedSandbox;
     this.managedSandbox = null;
+
+    // Do not race termination against a refresh already in flight. In
+    // particular, this ensures cleanup observes the final refresh outcome
+    // before issuing the by-id terminate request.
+    try {
+      await this.sandboxRefreshInFlight;
+    } catch {
+      // Expiration/refresh failures do not prevent best-effort cleanup.
+    }
+
     if (!sandbox || !sandbox.terminateOnClose) return;
     try {
       await this.terminateManagedSandbox(sandbox);

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -92,6 +92,8 @@ type CloudAgentSandbox = Record<string, unknown> & {
   sandboxId?: string;
   deviceId?: string;
   connectionName?: string;
+  conversationId?: string;
+  resumed?: boolean;
 };
 
 type CloudAgentSandboxRefresh = Record<string, unknown> & {
@@ -102,6 +104,10 @@ type CloudAgentSandboxRefresh = Record<string, unknown> & {
 
 type ManagedCloudSandbox = {
   agentId: string;
+  /** Non-null when the server confirmed conversation scoping by echoing the
+   * conversationId (legacy servers strip unknown body keys and answer
+   * without it, so the sandbox falls back to the agent-scoped lifecycle). */
+  conversationId: string | null;
   sandboxId: string;
   deviceId: string;
   connectionName: string;
@@ -1019,7 +1025,18 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   private async createManagedSandboxConnection(
     runtime: RuntimeScope,
   ): Promise<ResolvedCloudConnection> {
-    const sandbox = await this.createManagedSandbox(runtime.agent_id);
+    // Scope the managed sandbox to the conversation when one exists: the
+    // server treats create-with-conversationId as create-or-resume, so
+    // sessions of the same conversation share one sandbox and sessions of
+    // different conversations stop contending for a single per-agent one.
+    const conversationId =
+      runtime.conversation_id && runtime.conversation_id !== "default"
+        ? runtime.conversation_id
+        : undefined;
+    const sandbox = await this.createManagedSandbox(
+      runtime.agent_id,
+      conversationId,
+    );
     this.managedSandbox = sandbox;
 
     try {
@@ -1033,7 +1050,10 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     }
   }
 
-  private async createManagedSandbox(agentId: string): Promise<ManagedCloudSandbox> {
+  private async createManagedSandbox(
+    agentId: string,
+    conversationId?: string,
+  ): Promise<ManagedCloudSandbox> {
     const fetchImpl = getFetch(this.cloudOptions.fetch);
     const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
     const response = await fetchImpl(
@@ -1041,7 +1061,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       {
         method: "POST",
         headers: cloudHeaders(this.cloudOptions),
-        body: JSON.stringify({}),
+        body: JSON.stringify(conversationId ? { conversationId } : {}),
       },
     );
     const body = await parseJsonResponse(response);
@@ -1063,6 +1083,8 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
 
     return {
       agentId,
+      conversationId:
+        typeof body.conversationId === "string" ? body.conversationId : null,
       sandboxId: body.sandboxId,
       deviceId: body.deviceId,
       connectionName: body.connectionName,
@@ -1070,7 +1092,10 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       readyTimeoutMs,
       readyPollIntervalMs,
       refreshIntervalMs: sandboxOptions.refreshIntervalMs ?? defaultRefreshIntervalMs,
-      terminateOnClose: sandboxOptions.terminateOnClose ?? true,
+      // Default to TTL cleanup: terminating on close kills a sandbox that
+      // other sessions of the same conversation (or a reconnecting client)
+      // may still be using; the server-side TTL bounds leaked sandboxes.
+      terminateOnClose: sandboxOptions.terminateOnClose ?? false,
     };
   }
 
@@ -1091,6 +1116,41 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   private async refreshManagedSandboxOnce(sandbox: ManagedCloudSandbox): Promise<void> {
     const fetchImpl = getFetch(this.cloudOptions.fetch);
     const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+
+    if (sandbox.conversationId) {
+      // Conversation-scoped sandboxes refresh by id — no "latest active"
+      // indirection, so ownership changes are structurally impossible.
+      const response = await fetchImpl(
+        `${baseUrl}/v1/sandboxes/${encodeURIComponent(sandbox.sandboxId)}/refresh`,
+        {
+          method: "POST",
+          headers: cloudHeaders(this.cloudOptions),
+          body: JSON.stringify({ ttlMinutes: sandbox.ttlMinutes }),
+        },
+      );
+      if (response.status === 404) {
+        // The TTL reaped the sandbox mid-session. Create-or-resume brings up
+        // a replacement with the same deterministic deviceId, so environment
+        // resolution (and reconnects) keep working; adopt its identity and
+        // keep refreshing.
+        await parseJsonResponse(response);
+        const replacement = await this.createManagedSandbox(
+          sandbox.agentId,
+          sandbox.conversationId,
+        );
+        sandbox.sandboxId = replacement.sandboxId;
+        sandbox.deviceId = replacement.deviceId;
+        sandbox.connectionName = replacement.connectionName;
+        return;
+      }
+      const body = await parseJsonResponse(response);
+      assertOkResponse(response, body, "Cloud refresh managed sandbox");
+      if (!isCloudAgentSandboxRefresh(body) || !body.success) {
+        throw new Error("Cloud refresh managed sandbox response did not confirm refresh.");
+      }
+      return;
+    }
+
     const response = await fetchImpl(
       `${baseUrl}/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes/refresh`,
       {
@@ -1112,10 +1172,30 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   }
 
   private async terminateManagedSandbox(sandbox: ManagedCloudSandbox): Promise<void> {
-    await this.refreshManagedSandbox(sandbox);
-
     const fetchImpl = getFetch(this.cloudOptions.fetch);
     const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+
+    if (sandbox.conversationId) {
+      // Terminate exactly this sandbox — the agent-scoped DELETE targets the
+      // agent's "latest active" sandbox, which may not be ours.
+      const response = await fetchImpl(
+        `${baseUrl}/v1/sandboxes/${encodeURIComponent(sandbox.sandboxId)}/terminate`,
+        {
+          method: "POST",
+          headers: cloudHeaders(this.cloudOptions),
+          body: JSON.stringify({}),
+        },
+      );
+      const body = await parseJsonResponse(response);
+      if (response.status === 404) return;
+      assertOkResponse(response, body, "Cloud terminate managed sandbox");
+      return;
+    }
+
+    // Agent-scoped: refresh first so the ownership check confirms the
+    // "latest active" sandbox the DELETE will target is still ours.
+    await this.refreshManagedSandbox(sandbox);
+
     const response = await fetchImpl(
       `${baseUrl}/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes`,
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export type {
 export { Session } from "./session.js";
 export { RepositoriesClient } from "./repositories.js";
 export { LettaAgentClient } from "./client.js";
+export { CloudManagedSandboxExpiredError } from "./cloud-session.js";
 
 export { extractStreamTextDelta } from "./stream-events.js";
 

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -33,10 +33,20 @@ function bodyOf(init?: RequestInit): unknown {
   return JSON.parse(String(init.body));
 }
 
+type CloudFetchMockOptions = {
+  /** Simulate a server without conversation-scoped sandbox support: it
+   * strips the conversationId body key and never echoes it back. */
+  legacySandboxServer?: boolean;
+  /** Sandbox ids whose by-id refresh should 404 (TTL reaped). */
+  reapedSandboxes?: Set<string>;
+};
+
 function createCloudFetchMock(
   requests: RecordedRequest[],
   environmentConnections?: Array<Record<string, unknown>>,
+  options: CloudFetchMockOptions = {},
 ): typeof fetch {
+  let sandboxCreates = 0;
   return ((input: FetchInput | URL, init?: RequestInit) => {
     const url = urlOf(input);
     const parsed = new URL(url);
@@ -63,11 +73,43 @@ function createCloudFetchMock(
     const agentSandboxMatch = /^\/v1\/agents\/([^/]+)\/sandboxes$/.exec(parsed.pathname);
     if (agentSandboxMatch && method === "POST") {
       const agentId = decodeURIComponent(agentSandboxMatch[1]!);
+      sandboxCreates += 1;
+      const body = bodyOf(init) as { conversationId?: string } | undefined;
+      const sandboxId = sandboxCreates === 1
+        ? `sandbox-${agentId}`
+        : `sandbox-${agentId}-r${sandboxCreates}`;
+      const conversationEcho =
+        body?.conversationId && !options.legacySandboxServer
+          ? { conversationId: body.conversationId, resumed: false }
+          : {};
       return Promise.resolve(jsonResponse({
-        sandboxId: `sandbox-${agentId}`,
+        sandboxId,
         deviceId: `device-${agentId}`,
         connectionName: `sandbox-${agentId}-session`,
+        ...conversationEcho,
       }));
+    }
+
+    const sandboxRefreshMatch = /^\/v1\/sandboxes\/([^/]+)\/refresh$/.exec(parsed.pathname);
+    if (sandboxRefreshMatch && method === "POST") {
+      const sandboxId = decodeURIComponent(sandboxRefreshMatch[1]!);
+      if (options.reapedSandboxes?.has(sandboxId)) {
+        return Promise.resolve(jsonResponse(
+          { errorCode: "SANDBOX_NOT_FOUND", message: `Sandbox ${sandboxId} no longer exists` },
+          { status: 404 },
+        ));
+      }
+      const body = bodyOf(init) as { ttlMinutes?: number } | undefined;
+      return Promise.resolve(jsonResponse({
+        success: true,
+        sandboxId,
+        ttlMinutes: body?.ttlMinutes ?? 5,
+      }));
+    }
+
+    const sandboxTerminateMatch = /^\/v1\/sandboxes\/([^/]+)\/terminate$/.exec(parsed.pathname);
+    if (sandboxTerminateMatch && method === "POST") {
+      return Promise.resolve(jsonResponse({ success: true, message: "terminated" }));
     }
 
     const agentSandboxRefreshMatch = /^\/v1\/agents\/([^/]+)\/sandboxes\/refresh$/.exec(parsed.pathname);
@@ -531,7 +573,7 @@ function resetFakeAppServer(): void {
 }
 
 describe("CloudEnvironmentSession", () => {
-  test("creates, refreshes, and cleans up a managed Cloud sandbox when no environment is specified", async () => {
+  test("creates, refreshes, and cleans up a managed Cloud sandbox with terminateOnClose", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
@@ -541,7 +583,7 @@ describe("CloudEnvironmentSession", () => {
       fetch: createCloudFetchMock(requests),
       WebSocket: FakeCloudSocket,
       requestTimeoutMs: 1_000,
-      sandbox: { ttlMinutes: 2 },
+      sandbox: { ttlMinutes: 2, terminateOnClose: true },
     });
 
     const session = client.resumeSession("agent-1");
@@ -593,7 +635,7 @@ describe("CloudEnvironmentSession", () => {
     }));
   });
 
-  test("can leave managed Cloud sandbox cleanup to TTL", async () => {
+  test("leaves managed Cloud sandbox cleanup to TTL by default", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
@@ -603,7 +645,6 @@ describe("CloudEnvironmentSession", () => {
       fetch: createCloudFetchMock(requests),
       WebSocket: FakeCloudSocket,
       requestTimeoutMs: 1_000,
-      sandbox: { terminateOnClose: false },
     });
 
     const session = client.resumeSession("agent-1");
@@ -617,6 +658,145 @@ describe("CloudEnvironmentSession", () => {
     expect(requests.some((request) =>
       new URL(request.url).pathname === "/v1/agents/agent-1/sandboxes" &&
         request.method === "DELETE"
+    )).toBe(false);
+  });
+
+  test("scopes the managed sandbox to the conversation when the server supports it", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+    });
+
+    const session = client.resumeSession("conv-1");
+    try {
+      const init = await asAdvanced(session).initialize();
+      expect(init).toMatchObject({
+        type: "init",
+        agentId: "agent-from-conv",
+        conversationId: "conv-1",
+      });
+
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "POST",
+        url: "https://api.test/v1/agents/agent-from-conv/sandboxes",
+        body: { conversationId: "conv-1" },
+      }));
+      // Refreshes go by sandbox id — never the agent-scoped "latest active"
+      // route, whose target another conversation's create could displace.
+      expect(requests.some((request) =>
+        new URL(request.url).pathname === "/v1/sandboxes/sandbox-agent-from-conv/refresh"
+      )).toBe(true);
+      expect(requests.some((request) =>
+        new URL(request.url).pathname === "/v1/agents/agent-from-conv/sandboxes/refresh"
+      )).toBe(false);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("falls back to the agent-scoped sandbox lifecycle against legacy servers", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests, undefined, { legacySandboxServer: true }),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+    });
+
+    const session = client.resumeSession("conv-1");
+    try {
+      await asAdvanced(session).initialize();
+
+      // The request still carries conversationId (legacy servers strip
+      // unknown body keys), but without the response echo the SDK must stay
+      // on the agent-scoped lifecycle.
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "POST",
+        url: "https://api.test/v1/agents/agent-from-conv/sandboxes",
+        body: { conversationId: "conv-1" },
+      }));
+      expect(requests.some((request) =>
+        new URL(request.url).pathname === "/v1/agents/agent-from-conv/sandboxes/refresh"
+      )).toBe(true);
+      expect(requests.some((request) =>
+        new URL(request.url).pathname.startsWith("/v1/sandboxes/")
+      )).toBe(false);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("recreates a reaped conversation sandbox on refresh 404", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const reapedSandboxes = new Set<string>();
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests, undefined, { reapedSandboxes }),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+    });
+
+    const session = client.resumeSession("conv-1");
+    try {
+      await asAdvanced(session).initialize();
+      reapedSandboxes.add("sandbox-agent-from-conv");
+
+      // The next turn's refresh hits the 404 and must transparently
+      // create-or-resume a replacement instead of failing the session.
+      const result = await asAdvanced(session).runTurn("hello");
+      expect(result).toMatchObject({ success: true });
+
+      const creates = requests.filter((request) =>
+        request.method === "POST" &&
+          new URL(request.url).pathname === "/v1/agents/agent-from-conv/sandboxes"
+      );
+      expect(creates).toHaveLength(2);
+      expect(creates[1]!.body).toEqual({ conversationId: "conv-1" });
+    } finally {
+      session.close();
+    }
+  });
+
+  test("terminates a conversation sandbox by id when terminateOnClose is set", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { terminateOnClose: true },
+    });
+
+    const session = client.resumeSession("conv-1");
+    await asAdvanced(session).initialize();
+    session.close();
+
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "POST",
+      url: "https://api.test/v1/sandboxes/sandbox-agent-from-conv/terminate",
+    }));
+    expect(requests.some((request) =>
+      request.method === "DELETE" &&
+        new URL(request.url).pathname === "/v1/agents/agent-from-conv/sandboxes"
     )).toBe(false);
   });
 

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { LettaAgentClient } from "../index.js";
+import {
+  CloudManagedSandboxExpiredError,
+  LettaAgentClient,
+} from "../index.js";
 import { asAdvanced } from "./advanced-session.js";
 
 type Listener = (event: unknown) => void;
@@ -37,8 +40,15 @@ type CloudFetchMockOptions = {
   /** Simulate a server without conversation-scoped sandbox support: it
    * strips the conversationId body key and never echoes it back. */
   legacySandboxServer?: boolean;
+  /** Override the conversation id echoed by a supporting sandbox server. */
+  sandboxConversationEcho?: string;
   /** Sandbox ids whose by-id refresh should 404 (TTL reaped). */
   reapedSandboxes?: Set<string>;
+  /** Override a by-id refresh response for lifecycle race tests. */
+  sandboxRefreshResponse?: (
+    sandboxId: string,
+    attempt: number,
+  ) => Response | Promise<Response> | undefined;
 };
 
 function createCloudFetchMock(
@@ -47,6 +57,7 @@ function createCloudFetchMock(
   options: CloudFetchMockOptions = {},
 ): typeof fetch {
   let sandboxCreates = 0;
+  let sandboxRefreshes = 0;
   return ((input: FetchInput | URL, init?: RequestInit) => {
     const url = urlOf(input);
     const parsed = new URL(url);
@@ -80,7 +91,11 @@ function createCloudFetchMock(
         : `sandbox-${agentId}-r${sandboxCreates}`;
       const conversationEcho =
         body?.conversationId && !options.legacySandboxServer
-          ? { conversationId: body.conversationId, resumed: false }
+          ? {
+              conversationId:
+                options.sandboxConversationEcho ?? body.conversationId,
+              resumed: false,
+            }
           : {};
       return Promise.resolve(jsonResponse({
         sandboxId,
@@ -93,6 +108,12 @@ function createCloudFetchMock(
     const sandboxRefreshMatch = /^\/v1\/sandboxes\/([^/]+)\/refresh$/.exec(parsed.pathname);
     if (sandboxRefreshMatch && method === "POST") {
       const sandboxId = decodeURIComponent(sandboxRefreshMatch[1]!);
+      sandboxRefreshes += 1;
+      const responseOverride = options.sandboxRefreshResponse?.(
+        sandboxId,
+        sandboxRefreshes,
+      );
+      if (responseOverride) return Promise.resolve(responseOverride);
       if (options.reapedSandboxes?.has(sandboxId)) {
         return Promise.resolve(jsonResponse(
           { errorCode: "SANDBOX_NOT_FOUND", message: `Sandbox ${sandboxId} no longer exists` },
@@ -735,7 +756,31 @@ describe("CloudEnvironmentSession", () => {
     }
   });
 
-  test("recreates a reaped conversation sandbox on refresh 404", async () => {
+  test("rejects a mismatched conversation id echoed by the sandbox server", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests, undefined, {
+        sandboxConversationEcho: "conv-other",
+      }),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+    });
+
+    const session = client.resumeSession("conv-1");
+    try {
+      await expect(asAdvanced(session).initialize()).rejects.toThrow(
+        "expected conv-1, got conv-other",
+      );
+    } finally {
+      session.close();
+    }
+  });
+
+  test("surfaces a typed pre-turn error when a conversation sandbox expires", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const reapedSandboxes = new Set<string>();
@@ -753,17 +798,31 @@ describe("CloudEnvironmentSession", () => {
       await asAdvanced(session).initialize();
       reapedSandboxes.add("sandbox-agent-from-conv");
 
-      // The next turn's refresh hits the 404 and must transparently
-      // create-or-resume a replacement instead of failing the session.
-      const result = await asAdvanced(session).runTurn("hello");
-      expect(result).toMatchObject({ success: true });
+      // The next turn's refresh happens before its input frame is sent. The
+      // caller can therefore create a new SDK session for this conversation
+      // and retry without duplicating the message.
+      let thrown: unknown;
+      try {
+        await asAdvanced(session).runTurn("hello");
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(CloudManagedSandboxExpiredError);
+      expect(thrown).toMatchObject({
+        code: "managed_sandbox_expired",
+        sandboxId: "sandbox-agent-from-conv",
+        conversationId: "conv-1",
+      });
+      expect(FakeCloudSocket.allSent().some((command) =>
+        command.type === "input"
+      )).toBe(false);
 
       const creates = requests.filter((request) =>
         request.method === "POST" &&
           new URL(request.url).pathname === "/v1/agents/agent-from-conv/sandboxes"
       );
-      expect(creates).toHaveLength(2);
-      expect(creates[1]!.body).toEqual({ conversationId: "conv-1" });
+      expect(creates).toHaveLength(1);
     } finally {
       session.close();
     }
@@ -798,6 +857,61 @@ describe("CloudEnvironmentSession", () => {
       request.method === "DELETE" &&
         new URL(request.url).pathname === "/v1/agents/agent-from-conv/sandboxes"
     )).toBe(false);
+  });
+
+  test("waits for an in-flight refresh before terminating on close", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    let releaseRefresh = () => {};
+    const pendingRefresh = new Promise<Response>((resolve) => {
+      releaseRefresh = () => resolve(jsonResponse({
+        success: true,
+        sandboxId: "sandbox-agent-from-conv",
+        ttlMinutes: 5,
+      }));
+    });
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests, undefined, {
+        sandboxRefreshResponse: (_sandboxId, attempt) =>
+          attempt === 2 ? pendingRefresh : undefined,
+      }),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { refreshIntervalMs: 1, terminateOnClose: true },
+    });
+
+    const session = client.resumeSession("conv-1");
+    try {
+      await asAdvanced(session).initialize();
+      for (let i = 0; i < 20; i += 1) {
+        const refreshes = requests.filter((request) =>
+          new URL(request.url).pathname.endsWith("/refresh")
+        );
+        if (refreshes.length >= 2) break;
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      }
+
+      session.close();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(requests.some((request) =>
+        new URL(request.url).pathname.endsWith("/terminate")
+      )).toBe(false);
+
+      releaseRefresh();
+      for (let i = 0; i < 5; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "POST",
+        url: "https://api.test/v1/sandboxes/sandbox-agent-from-conv/terminate",
+      }));
+    } finally {
+      releaseRefresh();
+      session.close();
+    }
   });
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -340,7 +340,9 @@ export interface LettaCodeCloudSandboxOptions {
   refreshIntervalMs?: number;
   /**
    * Best-effort terminate the SDK-managed sandbox on session close. Defaults to
-   * true. Set false when multiple SDK sessions may race on the same agent.
+   * false so other sessions for the same conversation and reconnecting clients
+   * can continue using it. Set true to restore eager cleanup when this session
+   * exclusively owns the sandbox.
    */
   terminateOnClose?: boolean;
 }


### PR DESCRIPTION
## What

Managed Cloud sessions now scope their sandbox to the conversation when the server supports it, using the API added in letta-ai/letta-cloud#12846. Against older servers the SDK detects the missing response echo at runtime and falls back to the existing agent-scoped lifecycle.

## Why

Previously, every managed session created a new per-agent sandbox while refresh and termination targeted the agent's latest active sandbox. Concurrent sessions for one agent could therefore displace each other and eventually fail with `CloudManagedSandboxOwnershipError`.

Conversation scoping removes that contention: sessions for the same conversation share one server-managed sandbox, while different conversations use disjoint sandboxes. Refresh and termination can then address the exact sandbox by ID.

## Changes

- **Create:** pass the runtime `conversationId` for non-default conversations. An exact response echo enables conversation-scoped lifecycle behavior; no echo means legacy fallback, and a mismatched echo is rejected.
- **Refresh:** conversation-scoped sandboxes use `POST /v1/sandboxes/{id}/refresh`; legacy sandboxes retain the agent-scoped refresh and ownership check.
- **Expiration:** a by-ID refresh `404` throws the exported `CloudManagedSandboxExpiredError` before the next input frame is sent. Callers can close the expired SDK session, resume the same conversation, and safely retry the unsent turn. The SDK does not recreate a sandbox behind WebSockets bound to the expired connection ID.
- **Terminate:** conversation-scoped sandboxes use `POST /v1/sandboxes/{id}/terminate`. Cleanup waits for any refresh already in flight before terminating.
- **Default cleanup:** `terminateOnClose` now defaults to `false`, allowing same-conversation sessions and reconnecting clients to keep using the shared sandbox. Pass `sandbox: { terminateOnClose: true }` when the SDK session has exclusive ownership.
- **Docs:** update the public option contract and README, including a same-conversation expiration recovery example and the safe-retry boundary.

## Compatibility

- **Old SDK to new server:** unchanged.
- **New SDK to old server:** the extra create-body key is stripped; absence of the response echo selects the legacy agent-scoped lifecycle.
- **Explicit-environment sessions:** unchanged because they do not enter the managed-sandbox path.
- **Observable changes:** `terminateOnClose` defaults to `false`, and a reaped conversation sandbox produces a typed pre-send error requiring a new SDK session for the same conversation.

## Tests

`cloud-session.test.ts` covers conversation-scoped creation and by-ID refresh, legacy fallback, mismatched response echoes, typed pre-turn expiration without an input frame, by-ID termination, and close/refresh serialization.

- `npm run check`
- `npm test`: 292 passed, 9 live tests skipped, 0 failed
- `npm run build`
