### PR TITLE
feat: route the dream instruction to the aggregation pass

### DIFF
--- a/examples/dream.ts
+++ b/examples/dream.ts
@@ -166,7 +166,7 @@ const dreamOptions = {
   client,
   agentId: agent.agentId,
   transcripts,
-  reflectionPrompt: REFLECTION_PROMPT,
+  instruction: REFLECTION_PROMPT,
   maxTranscriptsPerBatch: 10,
 } as const;
 

--- a/run-dream-validation-10.ts
+++ b/run-dream-validation-10.ts
@@ -112,7 +112,7 @@ async function main(): Promise<void> {
     client,
     agentId: agent.agentId,
     transcripts,
-    reflectionPrompt: REFLECTION_PROMPT,
+    instruction: REFLECTION_PROMPT,
     planOnly: true,
   });
   if (plan.kind !== "plan" || plan.transcripts.length !== 10) {
@@ -135,7 +135,7 @@ async function main(): Promise<void> {
     client,
     agentId: agent.agentId,
     transcripts,
-    reflectionPrompt: REFLECTION_PROMPT,
+    instruction: REFLECTION_PROMPT,
     log: (line) =>
       console.log(`[${new Date().toISOString().slice(11, 19)}] ${line}`),
   });

--- a/src/dream/aggregate.ts
+++ b/src/dream/aggregate.ts
@@ -49,12 +49,11 @@ export async function runDreamAggregation(params: {
    */
   personaPreamble?: string;
   /**
-   * Additional caller instruction for the aggregation pass. The aggregator
-   * is the only stage that edits the target memory, so instructions about
-   * maintaining specific files (e.g. a projected AGENTS.md) must reach it
-   * here — reflectionPrompt reaches the reflection batches only.
+   * Additional caller instruction. The aggregator is the only stage that
+   * edits the target memory, so instructions about maintaining specific
+   * files (e.g. a projected AGENTS.md) must reach it here.
    */
-  aggregationPrompt?: string;
+  instruction?: string;
   log?: (line: string) => void;
 }): Promise<DreamAggregationOutcome> {
   const log = params.log ?? (() => {});
@@ -105,9 +104,7 @@ export async function runDreamAggregation(params: {
     batchesDir: join(params.runRoot, "batches"),
     batchCount: params.reflections.length,
     memoryDir: params.memoryDir,
-    ...(params.aggregationPrompt
-      ? { instruction: params.aggregationPrompt }
-      : {}),
+    ...(params.instruction ? { instruction: params.instruction } : {}),
   });
   const userPrompt = params.personaPreamble
     ? `${params.personaPreamble.trim()}\n\n${builtPrompt}`

--- a/src/dream/aggregate.ts
+++ b/src/dream/aggregate.ts
@@ -48,6 +48,13 @@ export async function runDreamAggregation(params: {
    * its own memory).
    */
   personaPreamble?: string;
+  /**
+   * Additional caller instruction for the aggregation pass. The aggregator
+   * is the only stage that edits the target memory, so instructions about
+   * maintaining specific files (e.g. a projected AGENTS.md) must reach it
+   * here — reflectionPrompt reaches the reflection batches only.
+   */
+  aggregationPrompt?: string;
   log?: (line: string) => void;
 }): Promise<DreamAggregationOutcome> {
   const log = params.log ?? (() => {});
@@ -98,6 +105,9 @@ export async function runDreamAggregation(params: {
     batchesDir: join(params.runRoot, "batches"),
     batchCount: params.reflections.length,
     memoryDir: params.memoryDir,
+    ...(params.aggregationPrompt
+      ? { instruction: params.aggregationPrompt }
+      : {}),
   });
   const userPrompt = params.personaPreamble
     ? `${params.personaPreamble.trim()}\n\n${builtPrompt}`

--- a/src/dream/index.ts
+++ b/src/dream/index.ts
@@ -87,6 +87,13 @@ export interface DreamOptions {
   transcripts: readonly NormalizedSession[];
   /** Additional instruction provided to every reflection batch only. */
   reflectionPrompt?: string;
+  /**
+   * Additional instruction provided to the aggregation pass — the stage that
+   * lands the final commit on the memory filesystem. Callers maintaining a
+   * projected doc (e.g. AGENTS.md) must route their maintain-instruction
+   * here as well as to reflectionPrompt.
+   */
+  aggregationPrompt?: string;
   /** Override the harness agents directory (tests). */
   agentsDir?: string;
   /** Per-batch token budget (default 60k, measured on normalized content). */
@@ -278,6 +285,9 @@ export async function dream(options: DreamOptions): Promise<DreamResult> {
     reflections: batchResults,
     memfsPolicy: agent.config.memfs.policy,
     personaPreamble: AGGREGATOR_PERSONA,
+    ...(options.aggregationPrompt
+      ? { aggregationPrompt: options.aggregationPrompt }
+      : {}),
     log,
   });
 

--- a/src/dream/index.ts
+++ b/src/dream/index.ts
@@ -85,15 +85,14 @@ export interface DreamOptions {
   agentId: string;
   /** Immutable normalized transcript snapshots to reflect on. */
   transcripts: readonly NormalizedSession[];
-  /** Additional instruction provided to every reflection batch only. */
-  reflectionPrompt?: string;
   /**
-   * Additional instruction provided to the aggregation pass — the stage that
-   * lands the final commit on the memory filesystem. Callers maintaining a
-   * projected doc (e.g. AGENTS.md) must route their maintain-instruction
-   * here as well as to reflectionPrompt.
+   * Additional caller instruction for the run, provided to every reflection
+   * batch AND to the aggregation pass. The aggregator is the stage that
+   * lands the final commit on the memory filesystem, so instructions about
+   * maintaining specific files (e.g. a projected AGENTS.md) reach it too —
+   * an instruction that steered only the batches would be unreliable.
    */
-  aggregationPrompt?: string;
+  instruction?: string;
   /** Override the harness agents directory (tests). */
   agentsDir?: string;
   /** Per-batch token budget (default 60k, measured on normalized content). */
@@ -271,9 +270,7 @@ export async function dream(options: DreamOptions): Promise<DreamResult> {
     normalizedJsonByKey,
     memfsPolicy: agent.config.memfs.policy,
     concurrency: options.concurrency ?? batches.length,
-    ...(options.reflectionPrompt
-      ? { reflectionPrompt: options.reflectionPrompt }
-      : {}),
+    ...(options.instruction ? { instruction: options.instruction } : {}),
     log,
   });
 
@@ -285,9 +282,7 @@ export async function dream(options: DreamOptions): Promise<DreamResult> {
     reflections: batchResults,
     memfsPolicy: agent.config.memfs.policy,
     personaPreamble: AGGREGATOR_PERSONA,
-    ...(options.aggregationPrompt
-      ? { aggregationPrompt: options.aggregationPrompt }
-      : {}),
+    ...(options.instruction ? { instruction: options.instruction } : {}),
     log,
   });
 

--- a/src/dream/prompts.ts
+++ b/src/dream/prompts.ts
@@ -74,11 +74,13 @@ export function buildAggregatorUserPrompt(input: {
   batchesDir: string;
   batchCount: number;
   memoryDir: string;
+  /** Additional caller instruction for the aggregation pass. */
+  instruction?: string;
 }): string {
   return render(aggregatorUserMd, {
     count: input.batchCount,
     batchesDir: input.batchesDir,
     memoryDir: input.memoryDir,
-    instructionSection: "",
+    instructionSection: instructionSection(input.instruction),
   });
 }

--- a/src/dream/reflect.ts
+++ b/src/dream/reflect.ts
@@ -64,8 +64,8 @@ export interface RunBatchReflectionsParams {
   /** Write policy installed on every isolated clone and checked afterward. */
   memfsPolicy: MemfsWritePolicy;
   concurrency: number;
-  /** Additional scope/instructions provided only to reflection agents. */
-  reflectionPrompt?: string;
+  /** Additional caller instruction, also provided to the aggregation pass. */
+  instruction?: string;
   log?: (line: string) => void;
 }
 
@@ -107,9 +107,7 @@ async function runOneBatch(
     sessionFileNames,
     memoryDir: outputDir,
     timeRange: { start: batch.startTime, end: batch.endTime },
-    ...(params.reflectionPrompt
-      ? { instruction: params.reflectionPrompt }
-      : {}),
+    ...(params.instruction ? { instruction: params.instruction } : {}),
   });
 
   const label = `reflect:batch-${batch.index}`;

--- a/src/tests/dream-prompts.test.ts
+++ b/src/tests/dream-prompts.test.ts
@@ -68,7 +68,7 @@ describe("dream prompt contracts", () => {
   });
 });
 
-describe("aggregationPrompt threading", () => {
+describe("instruction threading to the aggregator", () => {
   const base = {
     batchesDir: "/run/batches",
     batchCount: 2,

--- a/src/tests/dream-prompts.test.ts
+++ b/src/tests/dream-prompts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   AGGREGATOR_PERSONA,
+  buildAggregatorUserPrompt,
   buildReflectionUserPrompt,
   MEMORY_ROUTING_CONTRACT,
   REFLECTION_SYSTEM_PROMPT,
@@ -64,5 +65,37 @@ describe("dream prompt contracts", () => {
       "authoritative absolute memory root for this batch is:\n/tmp/dream/batches/3/output",
     );
     expect(prompt).toContain("never write to a sibling or parent agent's memory");
+  });
+});
+
+describe("aggregationPrompt threading", () => {
+  const base = {
+    batchesDir: "/run/batches",
+    batchCount: 2,
+    memoryDir: "/agents/a1/memory",
+  };
+
+  test("aggregator user prompt includes the caller instruction when provided", () => {
+    const prompt = buildAggregatorUserPrompt({
+      ...base,
+      instruction: "Maintain system/AGENTS.md in place; keep its frontmatter.",
+    });
+    expect(prompt).toContain(
+      "Additional user-provided instruction for this pass:",
+    );
+    expect(prompt).toContain(
+      "Maintain system/AGENTS.md in place; keep its frontmatter.",
+    );
+  });
+
+  test("aggregator user prompt is unchanged when no instruction is provided", () => {
+    const prompt = buildAggregatorUserPrompt(base);
+    expect(prompt).not.toContain("Additional user-provided instruction");
+    expect(prompt).not.toContain("{{instructionSection}}");
+  });
+
+  test("blank instruction is treated as absent", () => {
+    const prompt = buildAggregatorUserPrompt({ ...base, instruction: "   " });
+    expect(prompt).not.toContain("Additional user-provided instruction");
   });
 });


### PR DESCRIPTION
## Why

`reflectionPrompt` reaches the reflection batches only, but the **aggregator** is the only stage that edits the target memory filesystem - it lands the final commit. Callers that maintain a projected doc in the memfs (e.g. `openhands-dreaming` seeding a repo's `AGENTS.md` into `system/` and reading it back out after the run) need their instruction to reach the pass that actually commits, or the projection is unreliable.

## What

One unified field (revised after review discussion - originally a second `aggregationPrompt` field):

- `DreamOptions.instruction?: string`, provided to **every reflection batch AND the aggregation pass**, replacing `reflectionPrompt`. The two-field shape had a trap: setting only `reflectionPrompt` (the natural thing) silently left the committing pass unsteered.
- The aggregator template's existing `{{instructionSection}}` slot (previously hardcoded empty) is now filled via the same `instructionSection()` helper the reflection prompt uses.
- `reflectionPrompt` had two in-repo consumers (`examples/dream.ts`, `run-dream-validation-10.ts`), both updated. If a deprecated alias is preferred instead of the rename, happy to add one.

## Tests

3 new cases in `dream-prompts.test.ts` (instruction present, absent, blank in the aggregator prompt); full suite 298 pass.

Note: #184 (cancellation) is independent; whichever lands second has a trivial adjacent-line merge in `aggregate.ts`/`index.ts`.