### PR TITLE
feat: cancellation for dream() via DreamOptions.signal

### DIFF
--- a/src/dream/aggregate.ts
+++ b/src/dream/aggregate.ts
@@ -48,6 +48,8 @@ export async function runDreamAggregation(params: {
    * its own memory).
    */
   personaPreamble?: string;
+  /** Abort: close the aggregator session and stop nudging. */
+  signal?: AbortSignal;
   log?: (line: string) => void;
 }): Promise<DreamAggregationOutcome> {
   const log = params.log ?? (() => {});
@@ -132,6 +134,7 @@ export async function runDreamAggregation(params: {
     cwd: dirname(params.memoryDir),
     label: "aggregate",
     env: memoryEnv,
+    ...(params.signal ? { signal: params.signal } : {}),
     onProgress: log,
   });
   // The model can end its turn narrating its plan instead of executing it.
@@ -143,6 +146,7 @@ export async function runDreamAggregation(params: {
   for (
     let nudge = 0;
     nudge < 2 &&
+    !params.signal?.aborted &&
     run.success &&
     run.conversationId !== null &&
     (await landedCommits()) === 0;
@@ -158,6 +162,7 @@ export async function runDreamAggregation(params: {
       label: "aggregate",
       resumeConversationId: run.conversationId,
       env: memoryEnv,
+      ...(params.signal ? { signal: params.signal } : {}),
       onProgress: log,
     });
     passes.push({ prompt: AGGREGATOR_CONTINUE_PROMPT, run });

--- a/src/dream/index.ts
+++ b/src/dream/index.ts
@@ -7,7 +7,7 @@
 // caller supplies immutable transcript snapshots, which makes selection easy
 // to inspect and makes a run reproducible after its source files change.
 
-import { mkdir } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import type { LettaAgentClient } from "../client.js";
 import {
@@ -97,6 +97,14 @@ export interface DreamOptions {
   concurrency?: number;
   /** Preview cursor filtering and batch packing without running agents. */
   planOnly?: boolean;
+  /**
+   * Abort the run: in-flight reflector/aggregator sessions are closed, no
+   * new batches start, the run's artifacts (clones, runRoot) are removed,
+   * cursors are NOT advanced, and dream() rejects with the abort reason.
+   * Shutting down a spawned app-server remains the caller's job via
+   * client.close().
+   */
+  signal?: AbortSignal;
   log?: (line: string) => void;
 }
 
@@ -160,6 +168,7 @@ function validateTranscripts(
 
 export async function dream(options: DreamOptions): Promise<DreamResult> {
   const log = options.log ?? (() => {});
+  options.signal?.throwIfAborted();
   validateTranscripts(options.transcripts);
 
   const agent = await loadDreamAgent(options.agentId, {
@@ -236,9 +245,20 @@ export async function dream(options: DreamOptions): Promise<DreamResult> {
     };
   }
 
+  options.signal?.throwIfAborted();
   await mkdir(agent.runsDir, { recursive: true });
   const runRoot = join(agent.runsDir, dreamRunId());
   await mkdir(runRoot, { recursive: true });
+
+  // On abort: remove this run's artifacts (batch clones live under runRoot)
+  // and reject. Cursors are never advanced (the success gate below already
+  // requires a non-aborted, fully successful run).
+  const throwIfAbortedWithCleanup = async () => {
+    if (!options.signal?.aborted) return;
+    log("[abort] dream aborted; removing run artifacts");
+    await rm(runRoot, { recursive: true, force: true }).catch(() => {});
+    options.signal.throwIfAborted();
+  };
 
   const workers = await ensureDreamWorkers(options.client, {
     reflectorAgentId: agent.config.reflectorAgentId,
@@ -267,8 +287,10 @@ export async function dream(options: DreamOptions): Promise<DreamResult> {
     ...(options.reflectionPrompt
       ? { reflectionPrompt: options.reflectionPrompt }
       : {}),
+    ...(options.signal ? { signal: options.signal } : {}),
     log,
   });
+  await throwIfAbortedWithCleanup();
 
   const aggregation = await runDreamAggregation({
     client: options.client,
@@ -278,8 +300,10 @@ export async function dream(options: DreamOptions): Promise<DreamResult> {
     reflections: batchResults,
     memfsPolicy: agent.config.memfs.policy,
     personaPreamble: AGGREGATOR_PERSONA,
+    ...(options.signal ? { signal: options.signal } : {}),
     log,
   });
+  await throwIfAbortedWithCleanup();
 
   const everyBatchSucceeded = batchResults.every((batch) => batch.success);
   const success = everyBatchSucceeded && aggregation.success;

--- a/src/dream/reflect.ts
+++ b/src/dream/reflect.ts
@@ -66,6 +66,8 @@ export interface RunBatchReflectionsParams {
   concurrency: number;
   /** Additional scope/instructions provided only to reflection agents. */
   reflectionPrompt?: string;
+  /** Abort: stop dispatching new batches and close in-flight sessions. */
+  signal?: AbortSignal;
   log?: (line: string) => void;
 }
 
@@ -142,10 +144,12 @@ async function runOneBatch(
     label,
     env: memoryEnv,
     skillSources: [],
+    ...(params.signal ? { signal: params.signal } : {}),
     onProgress: log,
   });
   for (
     let retry = 0;
+    !params.signal?.aborted &&
     !run.success &&
     run.error !== undefined &&
     TRANSIENT_INIT_ERROR.test(run.error) &&
@@ -162,6 +166,7 @@ async function runOneBatch(
       label,
       env: memoryEnv,
       skillSources: [],
+      ...(params.signal ? { signal: params.signal } : {}),
       onProgress: log,
     });
   }
@@ -178,7 +183,10 @@ async function runOneBatch(
     );
   for (
     let nudge = 0;
-    nudge < 2 && run.success && run.conversationId !== null;
+    nudge < 2 &&
+    !params.signal?.aborted &&
+    run.success &&
+    run.conversationId !== null;
     nudge++
   ) {
     const state = await inspectMemoryTree(outputDir, baseRevision);
@@ -199,6 +207,7 @@ async function runOneBatch(
       resumeConversationId: run.conversationId,
       env: memoryEnv,
       skillSources: [],
+      ...(params.signal ? { signal: params.signal } : {}),
       onProgress: log,
     });
     passes.push({ prompt: continuePrompt, run });
@@ -298,7 +307,7 @@ export async function runBatchReflections(
     // Stagger session startups: a same-instant herd of runtime starts can
     // push the slowest past the protocol request timeout.
     await new Promise((resolve) => setTimeout(resolve, workerIndex * 1500));
-    while (next < params.batches.length) {
+    while (!params.signal?.aborted && next < params.batches.length) {
       const batch = params.batches[next++];
       if (!batch) break;
       results.push(await runOneBatch(params, batch));

--- a/src/dream/runner.ts
+++ b/src/dream/runner.ts
@@ -20,6 +20,8 @@ export interface RunAgentOptions {
   env?: Record<string, string>;
   /** Restrict Letta Code skills for this runtime. [] disables every source. */
   skillSources?: SkillSource[];
+  /** Abort: closes the session and returns a failed result promptly. */
+  signal?: AbortSignal;
   onProgress?: (line: string) => void;
 }
 
@@ -41,6 +43,18 @@ export async function runAgentToCompletion(
   const started = Date.now();
   const log = options.onProgress ?? (() => {});
 
+  if (options.signal?.aborted) {
+    return {
+      agentId: options.agentId,
+      conversationId: null,
+      success: false,
+      error: "aborted before start",
+      report: "",
+      durationMs: 0,
+      messages: [],
+    };
+  }
+
   const sessionOptions = {
     permissionMode: "unrestricted" as const,
     cwd: options.cwd,
@@ -59,6 +73,14 @@ export async function runAgentToCompletion(
   let error: string | undefined;
   let report = "";
   let lastAssistant = "";
+
+  // Abort mid-turn by closing the session: the stream ends and the normal
+  // failure handling below reports the run as unsuccessful.
+  const onAbort = () => {
+    log(`[${options.label}] aborted; closing session`);
+    session.close();
+  };
+  options.signal?.addEventListener("abort", onAbort, { once: true });
 
   try {
     await session.send(options.userPrompt);
@@ -80,7 +102,12 @@ export async function runAgentToCompletion(
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
   } finally {
+    options.signal?.removeEventListener("abort", onAbort);
     session.close();
+  }
+  if (options.signal?.aborted) {
+    success = false;
+    error = error ?? "aborted";
   }
 
   return {

--- a/src/tests/dream-cancellation.test.ts
+++ b/src/tests/dream-cancellation.test.ts
@@ -1,0 +1,175 @@
+// Cancellation: DreamOptions.signal aborts the run — in-flight sessions are
+// closed, no new batches start, run artifacts are removed, cursors are not
+// advanced, and dream() rejects with the abort reason.
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LettaAgentClient } from "../client.js";
+import { initDreamAgent } from "../dream/agent.js";
+import { dream } from "../dream/index.js";
+import { runAgentToCompletion } from "../dream/runner.js";
+import { createOpenHandsSource } from "../dream/sources/openhands.js";
+import type { NormalizedSession } from "../dream/types.js";
+
+const FIXTURE_CONV = join(
+  import.meta.dir,
+  "fixtures",
+  "dream",
+  "openhands",
+  "conv-demo",
+);
+
+const AGENT_ID = "agent-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const root = mkdtempSync(join(tmpdir(), "dream-cancel-"));
+const agentsDir = join(root, "agents");
+const memoryDir = join(agentsDir, AGENT_ID, "memory");
+const runsDir = join(agentsDir, AGENT_ID, "dream", "runs");
+
+let transcript: NormalizedSession;
+
+beforeAll(async () => {
+  await mkdir(join(memoryDir, ".letta"), { recursive: true });
+  await writeFile(join(memoryDir, ".letta/config.json"), '{"version":1}\n');
+  execFileSync("git", ["-C", memoryDir, "init", "--quiet"]);
+  execFileSync("git", ["-C", memoryDir, "add", "-A"]);
+  execFileSync("git", [
+    "-C",
+    memoryDir,
+    "-c",
+    "user.name=t",
+    "-c",
+    "user.email=t@t",
+    "commit",
+    "-m",
+    "Initial commit",
+  ]);
+  await initDreamAgent({ createAgent: async () => AGENT_ID } as unknown as LettaAgentClient, {
+    name: "cancel-demo",
+    model: "anthropic/claude-opus-4-8",
+    agentsDir,
+    guard: { allowedNewFilePrefixes: ["skills"] },
+  });
+  const source = createOpenHandsSource();
+  const [session] = await source.discover(FIXTURE_CONV);
+  if (!session) throw new Error("fixture conversation missing");
+  transcript = await source.normalize(session);
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/**
+ * Fake client whose sessions stream forever until close() is called —
+ * modeling an in-flight agent turn that only an abort can end.
+ */
+function hangingClient() {
+  const closed: string[] = [];
+  let counter = 0;
+  let signalStreamStarted: (() => void) | null = null;
+  const firstStreamStarted = new Promise<void>((resolve) => {
+    signalStreamStarted = resolve;
+  });
+  const makeSession = () => {
+    let release: (() => void) | null = null;
+    const conversationId = `conv-${++counter}`;
+    return {
+      conversationId,
+      send: async () => {},
+      stream: async function* () {
+        signalStreamStarted?.();
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        // Stream ends after close() without emitting a result message.
+      },
+      close: () => {
+        closed.push(conversationId);
+        release?.();
+      },
+    };
+  };
+  const client = {
+    createAgent: async () => AGENT_ID,
+    createSession: () => makeSession(),
+    resumeSession: () => makeSession(),
+  } as unknown as LettaAgentClient;
+  return { client, closed, firstStreamStarted };
+}
+
+describe("runAgentToCompletion + signal", () => {
+  test("already-aborted signal returns a failed result without starting", async () => {
+    const { client, closed } = hangingClient();
+    const controller = new AbortController();
+    controller.abort();
+    const result = await runAgentToCompletion(client, {
+      agentId: AGENT_ID,
+      userPrompt: "p",
+      cwd: root,
+      label: "t",
+      signal: controller.signal,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("aborted");
+    expect(closed).toHaveLength(0);
+  });
+
+  test("abort mid-turn closes the session and reports failure", async () => {
+    const { client, closed, firstStreamStarted } = hangingClient();
+    const controller = new AbortController();
+    const pending = runAgentToCompletion(client, {
+      agentId: AGENT_ID,
+      userPrompt: "p",
+      cwd: root,
+      label: "t",
+      signal: controller.signal,
+    });
+    await firstStreamStarted;
+    controller.abort();
+    const result = await pending;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("aborted");
+    expect(closed.length).toBeGreaterThan(0);
+  });
+});
+
+describe("dream() + signal", () => {
+  test("pre-aborted signal rejects before any work", async () => {
+    const { client } = hangingClient();
+    const controller = new AbortController();
+    controller.abort();
+    expect(
+      dream({
+        client,
+        agentId: AGENT_ID,
+        agentsDir,
+        transcripts: [transcript],
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("abort during reflection rejects, closes sessions, and removes run artifacts", async () => {
+    const { client, closed, firstStreamStarted } = hangingClient();
+    const controller = new AbortController();
+    const pending = dream({
+      client,
+      agentId: AGENT_ID,
+      agentsDir,
+      transcripts: [transcript],
+      signal: controller.signal,
+    });
+    // Deterministic: abort only once a reflection session is provably in flight.
+    await firstStreamStarted;
+    controller.abort();
+    await expect(pending).rejects.toThrow();
+    expect(closed.length).toBeGreaterThan(0);
+    // Batch clones live under runRoot; abort must remove the whole run dir.
+    const leftovers = await readdir(runsDir).catch(() => []);
+    expect(leftovers).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Why

A dream run is N parallel worker sessions + N memfs git clones + run artifacts. A caller that times out (e.g. a cron automation bounded by a watchdog) currently has no way to stop it: abandoning the promise leaks live sessions, clones on disk, and `runRoot` - on every overrun.

## What

`DreamOptions.signal?: AbortSignal`, honored at every level:

- **runner** (`runAgentToCompletion`): abort closes the in-flight session; the run returns a failed result with an `aborted` error. Already-aborted signals return immediately without starting.
- **reflect**: the bounded-concurrency workers stop dispatching new batches; the transient-init retry loop and the no-commit nudge loop stop; in-flight batch sessions are closed via the runner.
- **aggregate**: the aggregator session is closed; continuation nudges stop.
- **`dream()`**: checkpoints between stages. On abort it removes the run's artifacts (`runRoot`, which contains the batch clones), does **not** advance cursors, and rejects with the abort reason (`signal.throwIfAborted()` semantics).

Ownership note: shutting down a spawned app-server stays the caller's job via `client.close()` (the client may be reused across runs); `signal` scopes exactly one run.

## Tests

New `dream-cancellation.test.ts` (4 cases): pre-aborted runner result, deterministic mid-turn abort closing the session, pre-aborted `dream()` rejection, and abort-during-reflection asserting rejection + closed sessions + no leftover run dirs. Full suite: 299 pass.

Sibling PR: #183 (`aggregationPrompt`) - independent; trivial adjacent-line merge in `aggregate.ts` whichever lands second.
