### PR TITLE
chore: require deployed conversation-scoped sandbox API

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ for await (const msg of session.stream()) {
 Use `backend: "cloud"` to create or resume agents hosted on Constellation. If
 no `environment` is provided, the SDK creates a managed sandbox, waits for it to
 come online, and refreshes it while the session is active. Non-default
-conversations request a conversation-scoped sandbox from supporting servers;
-the default conversation and legacy servers retain the agent-scoped lifecycle.
+conversations use the conversation-scoped sandbox API; the special default
+conversation retains the agent-scoped lifecycle.
 Managed sandboxes are left for TTL cleanup by default so another session for the
 same conversation can reconnect to them.
 
@@ -184,10 +184,10 @@ await using session = client.resumeSession(agentId, {
 `{ deviceId: "device-..." }` for a stable device selector.
 
 `environment` and `sandbox` are mutually exclusive. Conversation-scoped
-sandboxes refresh and terminate by sandbox ID. Legacy agent-scoped sandboxes
-retain the latest-active ownership check. Pass `sandbox.terminateOnClose: true`
-to request best-effort eager cleanup, but only when no other session or
-reconnecting client needs the sandbox.
+sandboxes refresh and terminate by sandbox ID. Default-conversation
+agent-scoped sandboxes retain the latest-active ownership check. Pass
+`sandbox.terminateOnClose: true` to request best-effort eager cleanup, but only
+when no other session or reconnecting client needs the sandbox.
 
 If Cloud reaps a conversation-scoped sandbox before the next refresh,
 `send()` throws `CloudManagedSandboxExpiredError` before transmitting the turn.

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -92,8 +92,6 @@ type CloudAgentSandbox = Record<string, unknown> & {
   sandboxId?: string;
   deviceId?: string;
   connectionName?: string;
-  conversationId?: string;
-  resumed?: boolean;
 };
 
 type CloudAgentSandboxRefresh = Record<string, unknown> & {
@@ -104,9 +102,8 @@ type CloudAgentSandboxRefresh = Record<string, unknown> & {
 
 type ManagedCloudSandbox = {
   agentId: string;
-  /** Non-null when the server confirmed conversation scoping by echoing the
-   * conversationId (legacy servers strip unknown body keys and answer
-   * without it, so the sandbox falls back to the agent-scoped lifecycle). */
+  /** Non-null for a real conversation-scoped sandbox; null only for the
+   * special default conversation, which retains the agent-scoped lifecycle. */
   conversationId: string | null;
   sandboxId: string;
   deviceId: string;
@@ -1096,17 +1093,6 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       throw new Error("Cloud create managed sandbox response did not include sandbox connection details.");
     }
 
-    const responseConversationId =
-      typeof body.conversationId === "string" ? body.conversationId : null;
-    if (
-      responseConversationId !== null &&
-      responseConversationId !== conversationId
-    ) {
-      throw new Error(
-        `Cloud managed sandbox response conversation mismatch: expected ${conversationId ?? "none"}, got ${responseConversationId}.`,
-      );
-    }
-
     const sandboxOptions = this.resolvedSandboxOptions();
     const ttlMinutes = sandboxOptions.ttlMinutes ?? DEFAULT_SANDBOX_TTL_MINUTES;
     const readyTimeoutMs = sandboxOptions.readyTimeoutMs
@@ -1120,7 +1106,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
 
     return {
       agentId,
-      conversationId: responseConversationId,
+      conversationId: conversationId ?? null,
       sandboxId: body.sandboxId,
       deviceId: body.deviceId,
       connectionName: body.connectionName,

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -37,11 +37,6 @@ function bodyOf(init?: RequestInit): unknown {
 }
 
 type CloudFetchMockOptions = {
-  /** Simulate a server without conversation-scoped sandbox support: it
-   * strips the conversationId body key and never echoes it back. */
-  legacySandboxServer?: boolean;
-  /** Override the conversation id echoed by a supporting sandbox server. */
-  sandboxConversationEcho?: string;
   /** Sandbox ids whose by-id refresh should 404 (TTL reaped). */
   reapedSandboxes?: Set<string>;
   /** Override a by-id refresh response for lifecycle race tests. */
@@ -85,23 +80,13 @@ function createCloudFetchMock(
     if (agentSandboxMatch && method === "POST") {
       const agentId = decodeURIComponent(agentSandboxMatch[1]!);
       sandboxCreates += 1;
-      const body = bodyOf(init) as { conversationId?: string } | undefined;
       const sandboxId = sandboxCreates === 1
         ? `sandbox-${agentId}`
         : `sandbox-${agentId}-r${sandboxCreates}`;
-      const conversationEcho =
-        body?.conversationId && !options.legacySandboxServer
-          ? {
-              conversationId:
-                options.sandboxConversationEcho ?? body.conversationId,
-              resumed: false,
-            }
-          : {};
       return Promise.resolve(jsonResponse({
         sandboxId,
         deviceId: `device-${agentId}`,
         connectionName: `sandbox-${agentId}-session`,
-        ...conversationEcho,
       }));
     }
 
@@ -682,7 +667,7 @@ describe("CloudEnvironmentSession", () => {
     )).toBe(false);
   });
 
-  test("scopes the managed sandbox to the conversation when the server supports it", async () => {
+  test("uses the conversation-scoped sandbox lifecycle without response feature detection", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
@@ -716,65 +701,6 @@ describe("CloudEnvironmentSession", () => {
       expect(requests.some((request) =>
         new URL(request.url).pathname === "/v1/agents/agent-from-conv/sandboxes/refresh"
       )).toBe(false);
-    } finally {
-      session.close();
-    }
-  });
-
-  test("falls back to the agent-scoped sandbox lifecycle against legacy servers", async () => {
-    resetFakeCloud();
-    const requests: RecordedRequest[] = [];
-    const client = new LettaAgentClient({
-      backend: "cloud",
-      apiBaseUrl: "https://api.test",
-      apiKey: "sk-test",
-      fetch: createCloudFetchMock(requests, undefined, { legacySandboxServer: true }),
-      WebSocket: FakeCloudSocket,
-      requestTimeoutMs: 1_000,
-    });
-
-    const session = client.resumeSession("conv-1");
-    try {
-      await asAdvanced(session).initialize();
-
-      // The request still carries conversationId (legacy servers strip
-      // unknown body keys), but without the response echo the SDK must stay
-      // on the agent-scoped lifecycle.
-      expect(requests).toContainEqual(expect.objectContaining({
-        method: "POST",
-        url: "https://api.test/v1/agents/agent-from-conv/sandboxes",
-        body: { conversationId: "conv-1" },
-      }));
-      expect(requests.some((request) =>
-        new URL(request.url).pathname === "/v1/agents/agent-from-conv/sandboxes/refresh"
-      )).toBe(true);
-      expect(requests.some((request) =>
-        new URL(request.url).pathname.startsWith("/v1/sandboxes/")
-      )).toBe(false);
-    } finally {
-      session.close();
-    }
-  });
-
-  test("rejects a mismatched conversation id echoed by the sandbox server", async () => {
-    resetFakeCloud();
-    const requests: RecordedRequest[] = [];
-    const client = new LettaAgentClient({
-      backend: "cloud",
-      apiBaseUrl: "https://api.test",
-      apiKey: "sk-test",
-      fetch: createCloudFetchMock(requests, undefined, {
-        sandboxConversationEcho: "conv-other",
-      }),
-      WebSocket: FakeCloudSocket,
-      requestTimeoutMs: 1_000,
-    });
-
-    const session = client.resumeSession("conv-1");
-    try {
-      await expect(asAdvanced(session).initialize()).rejects.toThrow(
-        "expected conv-1, got conv-other",
-      );
     } finally {
       session.close();
     }


### PR DESCRIPTION
## What

Remove response-echo feature detection from conversation-scoped managed sandboxes. For every non-default conversation, the SDK now uses the requested `conversationId` as the sandbox scope and unconditionally follows the by-ID refresh and termination lifecycle.

## Why

The conversation-scoped Cloud API is already deployed. Supporting servers that predate that API is no longer necessary, and the response echo adds a fallback branch plus mismatch handling for a deployment state we do not intend to support. A server rollback is now treated as an incompatible API rollback rather than something the SDK silently accommodates.

## Changes

- Stop reading `conversationId` and `resumed` from sandbox-create responses.
- Derive managed sandbox scope from the conversation ID sent in the request.
- Remove legacy-server and mismatched-echo test fixtures and cases.
- Keep a test response with no echo to prove lifecycle selection does not depend on response fields.
- Update README language to describe the conversation-scoped API as required behavior; the special default conversation remains agent-scoped.

## User impact

There is no behavior change against the deployed Cloud API. Non-default conversations continue to create-or-resume by conversation and refresh/terminate by sandbox ID. Servers without the conversation-scoped API are no longer supported by this SDK path.

## Stack

Stacked on #182 and targets its `conversation-scoped-sandboxes` branch. Merge #182 first, then retarget or merge this PR.

## Validation

- `npm run check`
- `npm run build`
- `npm test`: 290 passed, 9 live tests skipped, 0 failed
