### PR TITLE
fix: keep SDK default system prompt empty

### DIFF
--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -4,7 +4,6 @@ import {
   type AppServerExternalToolCallHandler,
   type AppServerSocketConstructor,
 } from "@letta-ai/letta-code/app-server-client";
-import { buildSystemPrompt } from "@letta-ai/letta-code/agent-presets";
 import {
   isHeadlessAutoAllowTool,
   requiresRuntimeUserInput,
@@ -145,10 +144,6 @@ function isPresetSystemPrompt(value: string): boolean {
   ].includes(value);
 }
 
-function buildDefaultSystemPrompt(options: CreateAgentOptions): string {
-  return buildSystemPrompt("default", options.memfs === false ? "standard" : "memfs");
-}
-
 function includeSdkAgentOriginTag(tags: string[] | undefined): string[] {
   const normalizedTags: string[] = [];
   let hasOriginTag = false;
@@ -235,7 +230,7 @@ export function createAgentBody(
   if (options.baseTools !== undefined) body.tools = options.baseTools;
 
   if (options.systemPrompt === undefined) {
-    body.system = buildDefaultSystemPrompt(options);
+    body.system = "";
   } else {
     if (typeof options.systemPrompt === "string") {
       if (isPresetSystemPrompt(options.systemPrompt)) {

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -4,6 +4,7 @@ import {
   type AppServerExternalToolCallHandler,
   type AppServerSocketConstructor,
 } from "@letta-ai/letta-code/app-server-client";
+import { buildSystemPrompt } from "@letta-ai/letta-code/agent-presets";
 import {
   isHeadlessAutoAllowTool,
   requiresRuntimeUserInput,
@@ -144,6 +145,10 @@ function isPresetSystemPrompt(value: string): boolean {
   ].includes(value);
 }
 
+function buildDefaultSystemPrompt(options: CreateAgentOptions): string {
+  return buildSystemPrompt("default", options.memfs === false ? "standard" : "memfs");
+}
+
 function includeSdkAgentOriginTag(tags: string[] | undefined): string[] {
   const normalizedTags: string[] = [];
   let hasOriginTag = false;
@@ -229,7 +234,9 @@ export function createAgentBody(
   if (options.hidden !== undefined) body.hidden = options.hidden;
   if (options.baseTools !== undefined) body.tools = options.baseTools;
 
-  if (options.systemPrompt !== undefined) {
+  if (options.systemPrompt === undefined) {
+    body.system = buildDefaultSystemPrompt(options);
+  } else {
     if (typeof options.systemPrompt === "string") {
       if (isPresetSystemPrompt(options.systemPrompt)) {
         throw new Error("createAgent() does not yet support system prompt presets for this backend.");

--- a/src/tests/app-server-session.test.ts
+++ b/src/tests/app-server-session.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { buildSystemPrompt } from "@letta-ai/letta-code/agent-presets";
+import { createAgentBody } from "../app-server-session.js";
+
+describe("createAgentBody", () => {
+  test("uses the Letta Code MemFS prompt when systemPrompt is omitted", () => {
+    const body = createAgentBody({ model: "openai/gpt-5.2" });
+
+    expect(body.system).toBe(buildSystemPrompt("default", "memfs"));
+  });
+
+  test("uses the Letta Code non-MemFS prompt for worker agents", () => {
+    const body = createAgentBody({
+      model: "openai/gpt-5.2",
+      memfs: false,
+    });
+
+    expect(body.system).toBe(buildSystemPrompt("default", "standard"));
+  });
+
+  test("preserves custom prompts", () => {
+    expect(
+      createAgentBody({
+        model: "openai/gpt-5.2",
+        systemPrompt: "You are a focused research assistant.",
+      }).system,
+    ).toBe("You are a focused research assistant.");
+  });
+});

--- a/src/tests/app-server-session.test.ts
+++ b/src/tests/app-server-session.test.ts
@@ -1,21 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { buildSystemPrompt } from "@letta-ai/letta-code/agent-presets";
 import { createAgentBody } from "../app-server-session.js";
 
 describe("createAgentBody", () => {
-  test("uses the Letta Code MemFS prompt when systemPrompt is omitted", () => {
+  test("uses an empty prompt when systemPrompt is omitted", () => {
     const body = createAgentBody({ model: "openai/gpt-5.2" });
 
-    expect(body.system).toBe(buildSystemPrompt("default", "memfs"));
-  });
-
-  test("uses the Letta Code non-MemFS prompt for worker agents", () => {
-    const body = createAgentBody({
-      model: "openai/gpt-5.2",
-      memfs: false,
-    });
-
-    expect(body.system).toBe(buildSystemPrompt("default", "standard"));
+    expect(body.system).toBe("");
   });
 
   test("preserves custom prompts", () => {


### PR DESCRIPTION
## Summary

SDK-created app-server agents currently omit `system` when callers do not provide `systemPrompt`, causing Letta Core to substitute its generic `<base_instructions>` prompt.

Send `system: ""` explicitly for the omitted case so the Agent SDK starts bare and does not inherit Core’s legacy default. Explicit custom system prompts remain unchanged.

Validated with the full SDK suite (301 passed), type checking, package build, and a live Cloud creation/retrieval smoke test confirming the stored system prompt is exactly empty.