### PR TITLE
chore: declare packageManager and engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@letta-ai/letta-agent-sdk",
   "version": "0.2.6",
+  "packageManager": "bun@1.3.0",
   "description": "SDK for programmatic control of Letta agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -41,5 +42,8 @@
   "license": "Apache-2.0",
   "trustedDependencies": [
     "@letta-ai/letta-code"
-  ]
+  ],
+  "engines": {
+    "node": ">=22.19.0"
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `packageManager: bun@1.3.0` and `engines: node >=22.19.0` to package.json, aligning with the other published letta-ai packages (letta-code, trajectory, letta-acp).
- The engines floor matches the `@letta-ai/letta-code` dependency (>=22.19.0), so consumers on older Node get a clear engines warning instead of runtime failures.
- No behavior change; lockfile unaffected.

👾 Generated with [Letta Code](https://letta.com)