### PR TITLE
feat: add portable browser and React Native client

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ const client = new LettaAgentClient({
 });
 
 const agentId = await client.createAgent({
+  personality: "memo",
   model: "anthropic/claude-sonnet-4",
 });
 const session = client.resumeSession(agentId);

--- a/README.md
+++ b/README.md
@@ -38,6 +38,36 @@ const client = new LettaAgentClient({
 });
 ```
 
+### Browser and React Native client
+
+Use the portable `/client` entry point in Expo, React Native, and browser
+applications. It contains the remote and Cloud transports without importing
+Node process-management modules:
+
+```ts
+import { LettaAgentClient } from "@letta-ai/letta-agent-sdk/client";
+
+const client = new LettaAgentClient({
+  backend: "cloud",
+  apiKey: "your-user-provided-api-key",
+  // Browser and React Native WebSockets cannot set upgrade headers.
+  webSocketAuth: "query",
+});
+
+const agentId = await client.createAgent({
+  model: "anthropic/claude-sonnet-4",
+});
+const session = client.resumeSession(agentId);
+```
+
+The `/client` entry requires `backend: "remote"` or `backend: "cloud"`.
+Local execution remains available from the package root because it launches
+and manages a Letta Code process. For authenticated remote app-servers in React
+Native, pass the platform WebSocket through
+`createReactNativeWebSocketConstructor()` so capability-token headers use React
+Native's third constructor argument. Cloud clients should prefer query
+authentication as shown above.
+
 ### Persistent agent with multi-turn conversations
 
 ```ts

--- a/build.ts
+++ b/build.ts
@@ -18,17 +18,46 @@ const version = pkg.version;
 
 console.log(`📦 Building Letta Agent SDK v${version}...`);
 
-// Bundle with Bun
-await Bun.build({
-  entrypoints: ["./src/index.ts"],
+const sharedBuildOptions = {
   outdir: "./dist",
-  target: "node",
-  format: "esm",
+  format: "esm" as const,
   minify: false,
-  sourcemap: "external",
+  sourcemap: "external" as const,
+};
+
+// Keep the package root Node-focused for local process execution.
+const nodeBuild = await Bun.build({
+  ...sharedBuildOptions,
+  entrypoints: ["./src/index.ts"],
+  target: "node",
   // Prompt text lives in .md files (src/dream/prompts/); inline as strings.
   loader: { ".md": "text" },
 });
+if (!nodeBuild.success) {
+  throw new AggregateError(nodeBuild.logs, "Node entry build failed");
+}
+
+// `/client` is the portable remote/cloud surface used by browsers and React
+// Native. A browser-targeted build catches unsupported imports in its graph.
+const portableBuild = await Bun.build({
+  ...sharedBuildOptions,
+  entrypoints: ["./src/client-entry.ts"],
+  target: "browser",
+});
+if (!portableBuild.success) {
+  throw new AggregateError(portableBuild.logs, "Portable client build failed");
+}
+
+const portableOutput = readFileSync(
+  join(__dirname, "dist", "client-entry.js"),
+  "utf-8",
+);
+const forbiddenNodeImport = /(?:from\s*|import\s*\()\s*["']node:/;
+if (forbiddenNodeImport.test(portableOutput)) {
+  throw new Error(
+    'Portable client build contains a Node builtin import. Keep Node-only modules behind the package root.',
+  );
+}
 
 // Generate type declarations
 console.log("📝 Generating type declarations...");

--- a/package.json
+++ b/package.json
@@ -10,6 +10,13 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client-entry.d.ts",
+      "react-native": "./dist/client-entry.js",
+      "browser": "./dist/client-entry.js",
+      "import": "./dist/client-entry.js",
+      "default": "./dist/client-entry.js"
     }
   },
   "files": [

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -8,7 +8,6 @@ import {
   isHeadlessAutoAllowTool,
   requiresRuntimeUserInput,
 } from "./interactiveToolPolicy.js";
-import { startLocalAppServer, type LocalAppServerHandle } from "./local-app-server.js";
 import {
   RemoteClientSessionCore,
   ensureSuccess,
@@ -109,19 +108,15 @@ export function agentToolNames(
 }
 
 export type AppServerSessionOptions = Partial<LettaCodeRemoteClientOptions> & {
-  /** Base websocket URL. Remote sessions require this; local sessions may omit
-   * it to spawn an SDK-owned app-server lazily at initialize(). */
+  /** Base websocket URL. */
   url?: string;
-  /** Spawn a local app-server when url is omitted. */
-  local?: boolean;
-  /** Optional backend for SDK-owned local app-server processes. */
-  localBackend?: string;
-  /** Optional local app-server listen URL. Defaults to ws://127.0.0.1:0. */
-  localListen?: string;
-  /** Timeout for local app-server startup. */
-  localStartupTimeoutMs?: number;
-  /** Extra environment variables for SDK-owned local app-server processes. */
-  localEnv?: Record<string, string | undefined>;
+  /**
+   * Internal lazy connection hook. The Node entry point uses this to start a
+   * local app-server without pulling process-management code into `/client`.
+   */
+  connect?: (
+    sessionEnv?: Record<string, string>,
+  ) => Promise<{ url: string; close(): void }>;
   /** Whether create-agent runtime_start should pin the created agent globally. */
   pinGlobalAgent?: boolean;
   /** Whether SDK create-agent payloads should add the origin tag automatically. */
@@ -702,7 +697,7 @@ export class AppServerRuntimeController implements RemoteClientRuntimeController
 }
 
 export class AppServerSession extends RemoteClientSessionCore {
-  private ownedAppServer: LocalAppServerHandle | null = null;
+  private ownedConnection: { close(): void } | null = null;
   private externalTools = new Map<string, AnyAgentTool>();
   private removeExternalToolHandler: (() => void) | null = null;
   private removeControlRequestHandler: (() => void) | null = null;
@@ -789,29 +784,23 @@ export class AppServerSession extends RemoteClientSessionCore {
     this.removeExternalToolHandler = null;
     this.removeControlRequestHandler?.();
     this.removeControlRequestHandler = null;
-    this.ownedAppServer?.close();
-    this.ownedAppServer = null;
+    this.ownedConnection?.close();
+    this.ownedConnection = null;
   }
 
   private async resolveAppServerUrl(): Promise<string> {
     if (this.remoteOptions.url) {
       return this.remoteOptions.url;
     }
-    if (this.remoteOptions.local !== true) {
-      throw new Error("App-server session requires a url unless local app-server spawning is enabled.");
+    if (!this.remoteOptions.connect) {
+      throw new Error("App-server session requires a url.");
     }
-    // Session-level env layers over client-level env: each SDK-owned session
-    // spawns its own app-server process, so this is a per-session scope.
     const sessionEnv = (
       this.mode.options as { env?: Record<string, string> }
     ).env;
-    this.ownedAppServer = await startLocalAppServer({
-      listen: this.remoteOptions.localListen,
-      backend: this.remoteOptions.localBackend,
-      startupTimeoutMs: this.remoteOptions.localStartupTimeoutMs,
-      env: { ...this.remoteOptions.localEnv, ...sessionEnv },
-    });
-    return this.ownedAppServer.url;
+    const connection = await this.remoteOptions.connect(sessionEnv);
+    this.ownedConnection = connection;
+    return connection.url;
   }
 
   private async startRuntime(client: AppServerClient): Promise<RuntimeStartResponse> {

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -5,6 +5,12 @@ import {
   type AppServerSocketConstructor,
 } from "@letta-ai/letta-code/app-server-client";
 import {
+  buildCreateAgentRequestForPersonality,
+  buildSystemPrompt,
+  GIT_MEMORY_ENABLED_TAG,
+  LETTA_CODE_ORIGIN_TAG,
+} from "@letta-ai/letta-code/agent-presets";
+import {
   isHeadlessAutoAllowTool,
   requiresRuntimeUserInput,
 } from "./interactiveToolPolicy.js";
@@ -125,8 +131,6 @@ export type AppServerSessionOptions = Partial<LettaCodeRemoteClientOptions> & {
 
 export type AppServerSessionMode = RuntimeSessionMode;
 
-const SDK_AGENT_ORIGIN_TAG = "origin:letta-code";
-
 function isPresetSystemPrompt(value: string): boolean {
   return [
     "default",
@@ -137,25 +141,6 @@ function isPresetSystemPrompt(value: string): boolean {
     "codex",
     "gemini",
   ].includes(value);
-}
-
-function includeSdkAgentOriginTag(tags: string[] | undefined): string[] {
-  const normalizedTags: string[] = [];
-  let hasOriginTag = false;
-
-  for (const tag of tags ?? []) {
-    if (tag === SDK_AGENT_ORIGIN_TAG) {
-      if (hasOriginTag) continue;
-      hasOriginTag = true;
-    }
-    normalizedTags.push(tag);
-  }
-
-  if (!hasOriginTag) {
-    normalizedTags.push(SDK_AGENT_ORIGIN_TAG);
-  }
-
-  return normalizedTags;
 }
 
 function assertRemoteCreateAgentOptionsSupported(options: CreateAgentOptions): void {
@@ -205,22 +190,49 @@ function normalizeMemoryBlock(block: Record<string, unknown>): Record<string, un
   return normalized;
 }
 
-export function createAgentBody(
+function upsertMemoryBlock(
+  blocks: Array<Record<string, unknown>>,
+  block: Record<string, unknown>,
+): void {
+  const label = block.label;
+  if (typeof label === "string") {
+    const existingIndex = blocks.findIndex((candidate) => candidate.label === label);
+    if (existingIndex >= 0) {
+      blocks[existingIndex] = block;
+      return;
+    }
+  }
+  blocks.push(block);
+}
+
+export async function createAgentBody(
   options: CreateAgentOptions,
   settings: { includeSdkOriginTag?: boolean } = {},
-): Record<string, unknown> {
+): Promise<Record<string, unknown>> {
   assertRemoteCreateAgentOptionsSupported(options);
 
   const includeOriginTag = settings.includeSdkOriginTag ?? true;
-  const body: Record<string, unknown> = {};
-  if (includeOriginTag || options.tags !== undefined) {
-    body.tags = includeOriginTag ? includeSdkAgentOriginTag(options.tags) : options.tags;
+  const body: Record<string, unknown> = {
+    ...(await buildCreateAgentRequestForPersonality({
+      personalityId: options.personality ?? "memo",
+      ...(options.name !== undefined ? { name: options.name } : {}),
+      ...(options.description !== undefined
+        ? { description: options.description }
+        : {}),
+      ...(options.model !== undefined ? { model: options.model } : {}),
+      ...(options.tags !== undefined ? { extraTags: options.tags } : {}),
+    })),
+  };
+
+  if (Array.isArray(body.tags)) {
+    body.tags = body.tags.filter(
+      (tag) =>
+        (includeOriginTag || tag !== LETTA_CODE_ORIGIN_TAG) &&
+        (options.memfs !== false || tag !== GIT_MEMORY_ENABLED_TAG),
+    );
   }
 
-  if (options.model !== undefined) body.model = options.model;
   if (options.embedding !== undefined) body.embedding = options.embedding;
-  if (options.name !== undefined) body.name = options.name;
-  if (options.description !== undefined) body.description = options.description;
   if (options.hidden !== undefined) body.hidden = options.hidden;
   if (options.baseTools !== undefined) {
     body.tools = options.baseTools;
@@ -232,7 +244,9 @@ export function createAgentBody(
   }
 
   if (options.systemPrompt === undefined) {
-    body.system = "";
+    if (options.memfs === false) {
+      body.system = buildSystemPrompt("default", "standard");
+    }
   } else {
     if (typeof options.systemPrompt === "string") {
       if (isPresetSystemPrompt(options.systemPrompt)) {
@@ -244,7 +258,14 @@ export function createAgentBody(
     }
   }
 
-  const memoryBlocks: Array<Record<string, unknown>> = [];
+  const memoryBlocks = Array.isArray(body.memory_blocks)
+    ? body.memory_blocks
+        .filter(
+          (block): block is Record<string, unknown> =>
+            block !== null && typeof block === "object",
+        )
+        .map((block) => ({ ...block }))
+    : [];
   const blockIds: string[] = [];
   for (const item of options.memory ?? []) {
     if (typeof item === "string") {
@@ -253,16 +274,22 @@ export function createAgentBody(
     if ("blockId" in item) {
       blockIds.push(item.blockId);
     } else {
-      memoryBlocks.push(normalizeMemoryBlock(item as unknown as Record<string, unknown>));
+      upsertMemoryBlock(
+        memoryBlocks,
+        normalizeMemoryBlock(item as unknown as Record<string, unknown>),
+      );
     }
   }
   if (options.persona !== undefined) {
-    memoryBlocks.push({ label: "persona", value: options.persona });
+    upsertMemoryBlock(memoryBlocks, {
+      label: "persona",
+      value: options.persona,
+    });
   }
   if (options.human !== undefined) {
-    memoryBlocks.push({ label: "human", value: options.human });
+    upsertMemoryBlock(memoryBlocks, { label: "human", value: options.human });
   }
-  if (memoryBlocks.length > 0) body.memory_blocks = memoryBlocks;
+  body.memory_blocks = memoryBlocks;
   if (blockIds.length > 0) body.block_ids = blockIds;
 
   return body;
@@ -834,7 +861,7 @@ export class AppServerSession extends RemoteClientSessionCore {
 
     if (this.mode.kind === "create-agent") {
       command.create_agent = {
-        body: createAgentBody(this.mode.options, {
+        body: await createAgentBody(this.mode.options, {
           includeSdkOriginTag: this.remoteOptions.includeSdkOriginTag,
         }),
         // Hidden (worker-style) agents default to unpinned.

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -1,0 +1,419 @@
+import { RepositoriesClient } from "./repositories.js";
+import {
+  AppServerSession,
+  assertRemoteSessionOptionsSupported,
+} from "./app-server-session.js";
+import {
+  CloudEnvironmentSession,
+  assertCloudSessionOptionsSupported,
+  createCloudAgent,
+  validateCloudClientOptions,
+} from "./cloud-session.js";
+import type {
+  CreateAgentOptions,
+  CreateSessionOptions,
+  LettaCodeBackend,
+  LettaCodeClientOptions,
+  LettaCodeClientSessionOptions,
+  LettaCodeEnvironment,
+  LettaCodeRemoteClientOptions,
+  LettaCodeLocalClientOptions,
+  LettaCodeCloudClientOptions,
+  LettaCodeSession,
+  SDKResultMessage,
+  SendMessage,
+} from "./types.js";
+import {
+  validateCreateAgentOptions,
+  validateCreateSessionOptions,
+} from "./validation.js";
+
+const VALID_BACKENDS = new Set<LettaCodeBackend>([
+  "local",
+  "remote",
+  "cloud",
+]);
+
+function isLettaCodeBackend(value: string): value is LettaCodeBackend {
+  return VALID_BACKENDS.has(value as LettaCodeBackend);
+}
+
+function getOptionsEnvironment(
+  options: LettaCodeClientOptions,
+): LettaCodeEnvironment | undefined {
+  if ("environment" in options) {
+    return options.environment;
+  }
+  return undefined;
+}
+
+function stripCloudExecutionOptions(
+  options: LettaCodeClientSessionOptions,
+): CreateSessionOptions {
+  const sessionOptions = { ...options };
+  delete sessionOptions.environment;
+  delete sessionOptions.sandbox;
+  return sessionOptions;
+}
+
+function hasRepositoryResources(options: LettaCodeClientSessionOptions): boolean {
+  return options.resources !== undefined && options.resources.length > 0;
+}
+
+function hasCreateAgentEnvironment(options: CreateAgentOptions): boolean {
+  return "environment" in (options as Record<string, unknown>);
+}
+
+function hasExplicitCreateAgentModel(options: CreateAgentOptions): boolean {
+  return typeof options.model === "string" && options.model.trim().length > 0;
+}
+
+function looksLikeConversationId(id: string): boolean {
+  return id.startsWith("conv-") || id.startsWith("local-conv-");
+}
+
+type TurnSession = LettaCodeSession & {
+  runTurn(message: SendMessage): Promise<SDKResultMessage>;
+};
+
+/**
+ * Top-level Letta Agent SDK client.
+ *
+ * `backend` selects how the SDK reaches or runs the Letta Code harness.
+ * `local` spawns an SDK-owned Letta Code app-server and speaks the websocket
+ * protocol by default, with an explicit stdio fallback for legacy flows.
+ * `remote` connects to a user-managed Letta Code app-server websocket endpoint.
+ * `cloud` uses agents hosted on Constellation, with an explicit remote
+ * environment or SDK-managed sandbox.
+ */
+export class LettaAgentClientBase {
+  readonly backend: LettaCodeBackend;
+  readonly environment: LettaCodeEnvironment | undefined;
+  protected readonly options: LettaCodeClientOptions;
+  private repositoriesClient: RepositoriesClient | null = null;
+
+  constructor(options: LettaCodeClientOptions = {}) {
+    const backend = options.backend ?? "local";
+    if (!isLettaCodeBackend(backend)) {
+      throw new Error(
+        `Invalid Letta Code backend '${String(backend)}'. Valid values: local, remote, cloud.`,
+      );
+    }
+
+    this.backend = backend;
+    this.environment = getOptionsEnvironment(options);
+    this.options = options;
+
+    if (this.backend === "local" && this.environment !== undefined) {
+      throw new Error(
+        'LettaAgentClient environment is only valid with backend: "cloud".',
+      );
+    }
+    if (this.backend === "remote" && this.environment !== undefined) {
+      throw new Error(
+        'LettaAgentClient environment is only valid with backend: "cloud"; remote url selects the app-server runtime.',
+      );
+    }
+    if (this.backend !== "cloud" && (options as { sandbox?: unknown }).sandbox !== undefined) {
+      throw new Error('LettaAgentClient sandbox options are only valid with backend: "cloud".');
+    }
+
+    if (this.backend === "local") {
+      const localOptions = options as LettaCodeLocalClientOptions;
+      if (
+        localOptions.transport !== undefined &&
+        localOptions.transport !== "app-server" &&
+        localOptions.transport !== "stdio"
+      ) {
+        throw new Error("Invalid local transport. Valid values: app-server, stdio.");
+      }
+      const requestTimeoutMs = localOptions.appServer?.requestTimeoutMs;
+      if (
+        requestTimeoutMs !== undefined &&
+        (!Number.isInteger(requestTimeoutMs) || requestTimeoutMs <= 0)
+      ) {
+        throw new Error("Invalid appServer.requestTimeoutMs. Expected a positive integer.");
+      }
+      const startupTimeoutMs = localOptions.appServer?.startupTimeoutMs;
+      if (
+        startupTimeoutMs !== undefined &&
+        (!Number.isInteger(startupTimeoutMs) || startupTimeoutMs <= 0)
+      ) {
+        throw new Error("Invalid appServer.startupTimeoutMs. Expected a positive integer.");
+      }
+    }
+
+    if (this.backend === "remote") {
+      if (!("url" in options) || typeof options.url !== "string" || options.url.length === 0) {
+        throw new Error("LettaAgentClient remote backend requires a non-empty url.");
+      }
+      if (
+        options.requestTimeoutMs !== undefined &&
+        (!Number.isInteger(options.requestTimeoutMs) || options.requestTimeoutMs <= 0)
+      ) {
+        throw new Error("Invalid requestTimeoutMs. Expected a positive integer.");
+      }
+    }
+
+    if (this.backend === "cloud") {
+      validateCloudClientOptions(options as LettaCodeCloudClientOptions);
+    }
+  }
+
+  /**
+   * Create a new Letta Code agent with a default conversation.
+   *
+   * Environment/device selection is intentionally not part of the agent payload;
+   * it belongs to the client/session execution context.
+   */
+  get repositories(): RepositoriesClient {
+    return this.getRepositoriesClient();
+  }
+
+  async createAgent(options: CreateAgentOptions = {}): Promise<string> {
+    if (hasCreateAgentEnvironment(options)) {
+      throw new Error(
+        "createAgent() does not accept environment. Set a client default or pass environment to resumeSession()/createSession().",
+      );
+    }
+
+    validateCreateAgentOptions(options);
+
+    if (this.backend === "remote") {
+      const session = new AppServerSession(this.remoteOptions(), {
+        kind: "create-agent",
+        options,
+      });
+      const initMsg = await session.initialize();
+      session.close();
+      return initMsg.agentId;
+    }
+    if (this.backend === "cloud") {
+      if (!hasExplicitCreateAgentModel(options)) {
+        throw new Error(
+          'Constellation createAgent() requires an explicit model. Pass model in createAgent({ model: "provider/model" }).',
+        );
+      }
+      return createCloudAgent(this.cloudOptions(), options);
+    }
+    return this.createLocalAgent(options);
+  }
+
+  /**
+   * Create a new conversation/session.
+   *
+   * Without an agent id, this uses the default/LRU agent, matching the legacy
+   * top-level createSession() helper.
+   */
+  createSession(
+    agentIdOrOptions?: string | LettaCodeClientSessionOptions,
+    options: LettaCodeClientSessionOptions = {},
+  ): LettaCodeSession {
+    const agentId =
+      typeof agentIdOrOptions === "string" ? agentIdOrOptions : undefined;
+    const resolvedOptions =
+      typeof agentIdOrOptions === "string" ? options : (agentIdOrOptions ?? {});
+
+    this.assertSessionBackend("createSession", resolvedOptions);
+    const sessionOptions = stripCloudExecutionOptions(resolvedOptions);
+    validateCreateSessionOptions(sessionOptions);
+
+    if (this.backend === "remote") {
+      if (!agentId) {
+        throw new Error(
+          "App-server createSession() requires an agent id. Call createAgent() first or pass an agent id.",
+        );
+      }
+      return new AppServerSession(this.remoteOptions(), {
+        kind: "session",
+        agentId,
+        newConversation: true,
+        options: resolvedOptions,
+      });
+    }
+    if (this.backend === "cloud") {
+      if (!agentId) {
+        throw new Error(
+          "Constellation createSession() requires an agent id. Call createAgent() first or pass an agent id.",
+        );
+      }
+      return new CloudEnvironmentSession(this.cloudOptions(), {
+        kind: "session",
+        agentId,
+        newConversation: true,
+        options: resolvedOptions,
+      });
+    }
+    return this.createLocalSession(agentId, resolvedOptions, sessionOptions);
+  }
+
+  /**
+   * Resume an existing agent default conversation or a specific conversation.
+   *
+   * `options.environment` overrides the client's default execution target for
+   * Constellation sessions. Remote app-server URLs already select the runtime.
+   */
+  resumeSession(
+    id: string,
+    options: LettaCodeClientSessionOptions = {},
+  ): LettaCodeSession {
+    this.assertSessionBackend("resumeSession", options);
+    const sessionOptions = stripCloudExecutionOptions(options);
+    validateCreateSessionOptions(sessionOptions);
+
+    if (this.backend === "remote") {
+      if (looksLikeConversationId(id)) {
+        return new AppServerSession(this.remoteOptions(), {
+          kind: "session",
+          conversationId: id,
+          options,
+        });
+      }
+      return new AppServerSession(this.remoteOptions(), {
+        kind: "session",
+        agentId: id,
+        defaultConversation: true,
+        options,
+      });
+    }
+    if (this.backend === "cloud") {
+      if (looksLikeConversationId(id)) {
+        return new CloudEnvironmentSession(this.cloudOptions(), {
+          kind: "session",
+          conversationId: id,
+          options,
+        });
+      }
+      return new CloudEnvironmentSession(this.cloudOptions(), {
+        kind: "session",
+        agentId: id,
+        defaultConversation: true,
+        options,
+      });
+    }
+    return this.resumeLocalSession(id, options, sessionOptions);
+  }
+
+  /** One-shot prompt convenience helper using a new conversation. */
+  async prompt(
+    message: SendMessage,
+    agentId?: string,
+    options: LettaCodeClientSessionOptions = {},
+  ): Promise<SDKResultMessage> {
+    const session = agentId
+      ? this.createSession(agentId, options)
+      : this.createSession(options);
+
+    try {
+      return await (session as TurnSession).runTurn(message);
+    } finally {
+      session.close();
+    }
+  }
+
+  private assertSessionBackend(
+    action: string,
+    options: LettaCodeClientSessionOptions,
+  ): void {
+    const effectiveEnvironment = options.environment ?? this.environment;
+    if (this.backend === "local") {
+      if (effectiveEnvironment !== undefined) {
+        throw new Error(
+          `${action}() environment overrides are only valid with backend: "cloud".`,
+        );
+      }
+      if (options.sandbox !== undefined) {
+        throw new Error(`${action}() sandbox options are only valid with backend: "cloud".`);
+      }
+      if (hasRepositoryResources(options)) {
+        throw new Error(`${action}() repository resources are only valid with backend: "cloud".`);
+      }
+      if (!this.useLegacyLocalStdio()) {
+        assertRemoteSessionOptionsSupported(action, options);
+      }
+      return;
+    }
+
+    if (this.backend === "remote") {
+      if (options.environment !== undefined) {
+        throw new Error(
+          `${action}() environment overrides are only valid with backend: "cloud"; remote url selects the app-server runtime.`,
+        );
+      }
+      if (options.sandbox !== undefined) {
+        throw new Error(`${action}() sandbox options are only valid with backend: "cloud"; remote url selects the app-server runtime.`);
+      }
+      if (hasRepositoryResources(options)) {
+        throw new Error(`${action}() repository resources are only valid with backend: "cloud".`);
+      }
+      assertRemoteSessionOptionsSupported(action, options);
+      return;
+    }
+    if (this.backend === "cloud") {
+      const cloudOptions = this.cloudOptions();
+      if (cloudOptions.environment !== undefined && options.sandbox !== undefined) {
+        throw new Error(`Constellation ${action}() cannot specify sandbox options when the client has a default environment.`);
+      }
+      if (cloudOptions.sandbox !== undefined && options.environment !== undefined) {
+        throw new Error(`Constellation ${action}() cannot specify an environment when the client has default sandbox options.`);
+      }
+      assertCloudSessionOptionsSupported(action, options);
+      return;
+    }
+    throw new Error(
+      `LettaAgentClient backend '${this.backend}' is not implemented yet. ${action} currently supports backend 'local' only.`,
+    );
+  }
+
+  protected useLegacyLocalStdio(): boolean {
+    return (this.options as LettaCodeLocalClientOptions).transport === "stdio";
+  }
+
+  protected createLocalAgent(_options: CreateAgentOptions): Promise<string> {
+    throw this.localBackendUnavailableError();
+  }
+
+  protected createLocalSession(
+    _agentId: string | undefined,
+    _options: LettaCodeClientSessionOptions,
+    _sessionOptions: CreateSessionOptions,
+  ): LettaCodeSession {
+    throw this.localBackendUnavailableError();
+  }
+
+  protected resumeLocalSession(
+    _id: string,
+    _options: LettaCodeClientSessionOptions,
+    _sessionOptions: CreateSessionOptions,
+  ): LettaCodeSession {
+    throw this.localBackendUnavailableError();
+  }
+
+  protected localBackendUnavailableError(): Error {
+    return new Error(
+      'The portable "@letta-ai/letta-agent-sdk/client" entry point supports backend: "remote" and backend: "cloud" only. Import from "@letta-ai/letta-agent-sdk" for local execution.',
+    );
+  }
+
+  private remoteOptions(): LettaCodeRemoteClientOptions {
+    if (this.backend !== "remote") {
+      throw new Error("Remote options requested for non-remote backend.");
+    }
+    return this.options as LettaCodeRemoteClientOptions;
+  }
+
+  private getRepositoriesClient(): RepositoriesClient {
+    if (this.backend !== "cloud") {
+      throw new Error('client.repositories is only available with backend: "cloud".');
+    }
+    this.repositoriesClient ??= new RepositoriesClient(this.cloudOptions());
+    return this.repositoriesClient;
+  }
+
+  private cloudOptions(): LettaCodeCloudClientOptions {
+    if (this.backend !== "cloud") {
+      throw new Error('Constellation options requested for non-"cloud" backend.');
+    }
+    return this.options as LettaCodeCloudClientOptions;
+  }
+}

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -64,10 +64,6 @@ function hasCreateAgentEnvironment(options: CreateAgentOptions): boolean {
   return "environment" in (options as Record<string, unknown>);
 }
 
-function hasExplicitCreateAgentModel(options: CreateAgentOptions): boolean {
-  return typeof options.model === "string" && options.model.trim().length > 0;
-}
-
 function looksLikeConversationId(id: string): boolean {
   return id.startsWith("conv-") || id.startsWith("local-conv-");
 }
@@ -189,11 +185,6 @@ export class LettaAgentClientBase {
       return initMsg.agentId;
     }
     if (this.backend === "cloud") {
-      if (!hasExplicitCreateAgentModel(options)) {
-        throw new Error(
-          'Constellation createAgent() requires an explicit model. Pass model in createAgent({ model: "provider/model" }).',
-        );
-      }
       return createCloudAgent(this.cloudOptions(), options);
     }
     return this.createLocalAgent(options);

--- a/src/client-entry.ts
+++ b/src/client-entry.ts
@@ -1,0 +1,30 @@
+import { LettaAgentClientBase } from "./client-base.js";
+import type {
+  LettaCodeCloudClientOptions,
+  LettaCodeRemoteClientOptions,
+} from "./types.js";
+
+export type PortableLettaAgentClientOptions =
+  | LettaCodeRemoteClientOptions
+  | LettaCodeCloudClientOptions;
+
+/**
+ * Portable Letta Agent SDK client for browsers and React Native.
+ *
+ * This entry point intentionally excludes local process execution. Use the
+ * package root from Node.js when `backend: "local"` is required.
+ */
+export class LettaAgentClient extends LettaAgentClientBase {
+  constructor(options: PortableLettaAgentClientOptions) {
+    super(options);
+    if (this.backend === "local") {
+      throw this.localBackendUnavailableError();
+    }
+  }
+}
+
+export { CloudManagedSandboxExpiredError } from "./cloud-session.js";
+export { RepositoriesClient } from "./repositories.js";
+export { extractStreamTextDelta } from "./stream-events.js";
+export { createReactNativeWebSocketConstructor } from "./websocket.js";
+export type * from "./types.js";

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,205 +1,21 @@
+import { LettaAgentClientBase } from "./client-base.js";
+import { createLocalAppServerSession } from "./local-app-server-session.js";
 import { Session } from "./session.js";
-import { RepositoriesClient } from "./repositories.js";
-import {
-  AppServerSession,
-  assertRemoteSessionOptionsSupported,
-} from "./app-server-session.js";
-import {
-  CloudEnvironmentSession,
-  assertCloudSessionOptionsSupported,
-  createCloudAgent,
-  validateCloudClientOptions,
-} from "./cloud-session.js";
 import type {
   CreateAgentOptions,
   CreateSessionOptions,
-  LettaCodeBackend,
-  LettaCodeClientOptions,
   LettaCodeClientSessionOptions,
-  LettaCodeEnvironment,
-  LettaCodeRemoteClientOptions,
   LettaCodeLocalClientOptions,
-  LettaCodeCloudClientOptions,
   LettaCodeSession,
-  SDKResultMessage,
-  SendMessage,
 } from "./types.js";
-import {
-  validateCreateAgentOptions,
-  validateCreateSessionOptions,
-} from "./validation.js";
 
-const VALID_BACKENDS = new Set<LettaCodeBackend>([
-  "local",
-  "remote",
-  "cloud",
-]);
-
-function isLettaCodeBackend(value: string): value is LettaCodeBackend {
-  return VALID_BACKENDS.has(value as LettaCodeBackend);
-}
-
-function getOptionsEnvironment(
-  options: LettaCodeClientOptions,
-): LettaCodeEnvironment | undefined {
-  if ("environment" in options) {
-    return options.environment;
-  }
-  return undefined;
-}
-
-function stripCloudExecutionOptions(
-  options: LettaCodeClientSessionOptions,
-): CreateSessionOptions {
-  const sessionOptions = { ...options };
-  delete sessionOptions.environment;
-  delete sessionOptions.sandbox;
-  return sessionOptions;
-}
-
-function hasRepositoryResources(options: LettaCodeClientSessionOptions): boolean {
-  return options.resources !== undefined && options.resources.length > 0;
-}
-
-function hasCreateAgentEnvironment(options: CreateAgentOptions): boolean {
-  return "environment" in (options as Record<string, unknown>);
-}
-
-function hasExplicitCreateAgentModel(options: CreateAgentOptions): boolean {
-  return typeof options.model === "string" && options.model.trim().length > 0;
-}
-
-function looksLikeConversationId(id: string): boolean {
-  return id.startsWith("conv-") || id.startsWith("local-conv-");
-}
-
-type TurnSession = LettaCodeSession & {
-  runTurn(message: SendMessage): Promise<SDKResultMessage>;
-};
-
-/**
- * Top-level Letta Agent SDK client.
- *
- * `backend` selects how the SDK reaches or runs the Letta Code harness.
- * `local` spawns an SDK-owned Letta Code app-server and speaks the websocket
- * protocol by default, with an explicit stdio fallback for legacy flows.
- * `remote` connects to a user-managed Letta Code app-server websocket endpoint.
- * `cloud` uses agents hosted on Constellation, with an explicit remote
- * environment or SDK-managed sandbox.
- */
-export class LettaAgentClient {
-  readonly backend: LettaCodeBackend;
-  readonly environment: LettaCodeEnvironment | undefined;
-  private readonly options: LettaCodeClientOptions;
-  private repositoriesClient: RepositoriesClient | null = null;
-
-  constructor(options: LettaCodeClientOptions = {}) {
-    const backend = options.backend ?? "local";
-    if (!isLettaCodeBackend(backend)) {
-      throw new Error(
-        `Invalid Letta Code backend '${String(backend)}'. Valid values: local, remote, cloud.`,
-      );
-    }
-
-    this.backend = backend;
-    this.environment = getOptionsEnvironment(options);
-    this.options = options;
-
-    if (this.backend === "local" && this.environment !== undefined) {
-      throw new Error(
-        'LettaAgentClient environment is only valid with backend: "cloud".',
-      );
-    }
-    if (this.backend === "remote" && this.environment !== undefined) {
-      throw new Error(
-        'LettaAgentClient environment is only valid with backend: "cloud"; remote url selects the app-server runtime.',
-      );
-    }
-    if (this.backend !== "cloud" && (options as { sandbox?: unknown }).sandbox !== undefined) {
-      throw new Error('LettaAgentClient sandbox options are only valid with backend: "cloud".');
-    }
-
-    if (this.backend === "local") {
-      const localOptions = options as LettaCodeLocalClientOptions;
-      if (
-        localOptions.transport !== undefined &&
-        localOptions.transport !== "app-server" &&
-        localOptions.transport !== "stdio"
-      ) {
-        throw new Error("Invalid local transport. Valid values: app-server, stdio.");
-      }
-      const requestTimeoutMs = localOptions.appServer?.requestTimeoutMs;
-      if (
-        requestTimeoutMs !== undefined &&
-        (!Number.isInteger(requestTimeoutMs) || requestTimeoutMs <= 0)
-      ) {
-        throw new Error("Invalid appServer.requestTimeoutMs. Expected a positive integer.");
-      }
-      const startupTimeoutMs = localOptions.appServer?.startupTimeoutMs;
-      if (
-        startupTimeoutMs !== undefined &&
-        (!Number.isInteger(startupTimeoutMs) || startupTimeoutMs <= 0)
-      ) {
-        throw new Error("Invalid appServer.startupTimeoutMs. Expected a positive integer.");
-      }
-    }
-
-    if (this.backend === "remote") {
-      if (!("url" in options) || typeof options.url !== "string" || options.url.length === 0) {
-        throw new Error("LettaAgentClient remote backend requires a non-empty url.");
-      }
-      if (
-        options.requestTimeoutMs !== undefined &&
-        (!Number.isInteger(options.requestTimeoutMs) || options.requestTimeoutMs <= 0)
-      ) {
-        throw new Error("Invalid requestTimeoutMs. Expected a positive integer.");
-      }
-    }
-
-    if (this.backend === "cloud") {
-      validateCloudClientOptions(options as LettaCodeCloudClientOptions);
-    }
-  }
-
-  /**
-   * Create a new Letta Code agent with a default conversation.
-   *
-   * Environment/device selection is intentionally not part of the agent payload;
-   * it belongs to the client/session execution context.
-   */
-  get repositories(): RepositoriesClient {
-    return this.getRepositoriesClient();
-  }
-
-  async createAgent(options: CreateAgentOptions = {}): Promise<string> {
-    if (hasCreateAgentEnvironment(options)) {
-      throw new Error(
-        "createAgent() does not accept environment. Set a client default or pass environment to resumeSession()/createSession().",
-      );
-    }
-
-    validateCreateAgentOptions(options);
-
-    if (this.backend === "remote") {
-      const session = new AppServerSession(this.remoteOptions(), {
-        kind: "create-agent",
-        options,
-      });
-      const initMsg = await session.initialize();
-      session.close();
-      return initMsg.agentId;
-    }
-    if (this.backend === "cloud") {
-      if (!hasExplicitCreateAgentModel(options)) {
-        throw new Error(
-          'Constellation createAgent() requires an explicit model. Pass model in createAgent({ model: "provider/model" }).',
-        );
-      }
-      return createCloudAgent(this.cloudOptions(), options);
-    }
-    this.assertLocalBackend("createAgent");
+export class LettaAgentClient extends LettaAgentClientBase {
+  protected override async createLocalAgent(
+    options: CreateAgentOptions,
+  ): Promise<string> {
     if (!this.useLegacyLocalStdio()) {
-      const session = new AppServerSession(this.localAppServerOptions(), {
+      const localOptions = this.options as LettaCodeLocalClientOptions;
+      const session = createLocalAppServerSession(localOptions.appServer, {
         kind: "create-agent",
         options,
       });
@@ -207,63 +23,25 @@ export class LettaAgentClient {
       session.close();
       return initMsg.agentId;
     }
+
     const session = new Session({ ...options, createOnly: true });
     const initMsg = await session.initialize();
     session.close();
     return initMsg.agentId;
   }
 
-  /**
-   * Create a new conversation/session.
-   *
-   * Without an agent id, this uses the default/LRU agent, matching the legacy
-   * top-level createSession() helper.
-   */
-  createSession(
-    agentIdOrOptions?: string | LettaCodeClientSessionOptions,
-    options: LettaCodeClientSessionOptions = {},
+  protected override createLocalSession(
+    agentId: string | undefined,
+    options: LettaCodeClientSessionOptions,
+    sessionOptions: CreateSessionOptions,
   ): LettaCodeSession {
-    const agentId =
-      typeof agentIdOrOptions === "string" ? agentIdOrOptions : undefined;
-    const resolvedOptions =
-      typeof agentIdOrOptions === "string" ? options : (agentIdOrOptions ?? {});
-
-    this.assertSessionBackend("createSession", resolvedOptions);
-    const sessionOptions = stripCloudExecutionOptions(resolvedOptions);
-    validateCreateSessionOptions(sessionOptions);
-
-    if (this.backend === "remote") {
-      if (!agentId) {
-        throw new Error(
-          "App-server createSession() requires an agent id. Call createAgent() first or pass an agent id.",
-        );
-      }
-      return new AppServerSession(this.remoteOptions(), {
-        kind: "session",
-        agentId,
-        newConversation: true,
-        options: resolvedOptions,
-      });
-    }
-    if (this.backend === "cloud") {
-      if (!agentId) {
-        throw new Error(
-          "Constellation createSession() requires an agent id. Call createAgent() first or pass an agent id.",
-        );
-      }
-      return new CloudEnvironmentSession(this.cloudOptions(), {
-        kind: "session",
-        agentId,
-        newConversation: true,
-        options: resolvedOptions,
-      });
-    }
     if (!this.useLegacyLocalStdio() && agentId) {
-      return new AppServerSession(this.localAppServerOptions(), {
+      const localOptions = this.options as LettaCodeLocalClientOptions;
+      return createLocalAppServerSession(localOptions.appServer, {
         kind: "session",
         agentId,
         newConversation: true,
-        options: resolvedOptions,
+        options,
       });
     }
     if (agentId) {
@@ -272,59 +50,21 @@ export class LettaAgentClient {
     return new Session({ ...sessionOptions, newConversation: true });
   }
 
-  /**
-   * Resume an existing agent default conversation or a specific conversation.
-   *
-   * `options.environment` overrides the client's default execution target for
-   * Constellation sessions. Remote app-server URLs already select the runtime.
-   */
-  resumeSession(
+  protected override resumeLocalSession(
     id: string,
-    options: LettaCodeClientSessionOptions = {},
+    options: LettaCodeClientSessionOptions,
+    sessionOptions: CreateSessionOptions,
   ): LettaCodeSession {
-    this.assertSessionBackend("resumeSession", options);
-    const sessionOptions = stripCloudExecutionOptions(options);
-    validateCreateSessionOptions(sessionOptions);
-
-    if (this.backend === "remote") {
-      if (looksLikeConversationId(id)) {
-        return new AppServerSession(this.remoteOptions(), {
-          kind: "session",
-          conversationId: id,
-          options,
-        });
-      }
-      return new AppServerSession(this.remoteOptions(), {
-        kind: "session",
-        agentId: id,
-        defaultConversation: true,
-        options,
-      });
-    }
-    if (this.backend === "cloud") {
-      if (looksLikeConversationId(id)) {
-        return new CloudEnvironmentSession(this.cloudOptions(), {
-          kind: "session",
-          conversationId: id,
-          options,
-        });
-      }
-      return new CloudEnvironmentSession(this.cloudOptions(), {
-        kind: "session",
-        agentId: id,
-        defaultConversation: true,
-        options,
-      });
-    }
     if (!this.useLegacyLocalStdio()) {
+      const localOptions = this.options as LettaCodeLocalClientOptions;
       if (looksLikeConversationId(id)) {
-        return new AppServerSession(this.localAppServerOptions(), {
+        return createLocalAppServerSession(localOptions.appServer, {
           kind: "session",
           conversationId: id,
           options,
         });
       }
-      return new AppServerSession(this.localAppServerOptions(), {
+      return createLocalAppServerSession(localOptions.appServer, {
         kind: "session",
         agentId: id,
         defaultConversation: true,
@@ -340,129 +80,8 @@ export class LettaAgentClient {
       defaultConversation: true,
     });
   }
+}
 
-  /** One-shot prompt convenience helper using a new conversation. */
-  async prompt(
-    message: SendMessage,
-    agentId?: string,
-    options: LettaCodeClientSessionOptions = {},
-  ): Promise<SDKResultMessage> {
-    const session = agentId
-      ? this.createSession(agentId, options)
-      : this.createSession(options);
-
-    try {
-      return await (session as TurnSession).runTurn(message);
-    } finally {
-      session.close();
-    }
-  }
-
-  private assertLocalBackend(action: string): void {
-    if (this.backend === "local") {
-      return;
-    }
-
-    throw new Error(
-      `LettaAgentClient backend '${this.backend}' is not implemented yet. ${action} currently supports backend 'local' only.`,
-    );
-  }
-
-  private assertSessionBackend(
-    action: string,
-    options: LettaCodeClientSessionOptions,
-  ): void {
-    const effectiveEnvironment = options.environment ?? this.environment;
-    if (this.backend === "local") {
-      if (effectiveEnvironment !== undefined) {
-        throw new Error(
-          `${action}() environment overrides are only valid with backend: "cloud".`,
-        );
-      }
-      if (options.sandbox !== undefined) {
-        throw new Error(`${action}() sandbox options are only valid with backend: "cloud".`);
-      }
-      if (hasRepositoryResources(options)) {
-        throw new Error(`${action}() repository resources are only valid with backend: "cloud".`);
-      }
-      if (!this.useLegacyLocalStdio()) {
-        assertRemoteSessionOptionsSupported(action, options);
-      }
-      return;
-    }
-
-    if (this.backend === "remote") {
-      if (options.environment !== undefined) {
-        throw new Error(
-          `${action}() environment overrides are only valid with backend: "cloud"; remote url selects the app-server runtime.`,
-        );
-      }
-      if (options.sandbox !== undefined) {
-        throw new Error(`${action}() sandbox options are only valid with backend: "cloud"; remote url selects the app-server runtime.`);
-      }
-      if (hasRepositoryResources(options)) {
-        throw new Error(`${action}() repository resources are only valid with backend: "cloud".`);
-      }
-      assertRemoteSessionOptionsSupported(action, options);
-      return;
-    }
-    if (this.backend === "cloud") {
-      const cloudOptions = this.cloudOptions();
-      if (cloudOptions.environment !== undefined && options.sandbox !== undefined) {
-        throw new Error(`Constellation ${action}() cannot specify sandbox options when the client has a default environment.`);
-      }
-      if (cloudOptions.sandbox !== undefined && options.environment !== undefined) {
-        throw new Error(`Constellation ${action}() cannot specify an environment when the client has default sandbox options.`);
-      }
-      assertCloudSessionOptionsSupported(action, options);
-      return;
-    }
-    throw new Error(
-      `LettaAgentClient backend '${this.backend}' is not implemented yet. ${action} currently supports backend 'local' only.`,
-    );
-  }
-
-  private useLegacyLocalStdio(): boolean {
-    return (this.options as LettaCodeLocalClientOptions).transport === "stdio";
-  }
-
-  private localAppServerOptions() {
-    const localOptions = this.options as LettaCodeLocalClientOptions;
-    const appServer = localOptions.appServer;
-    return {
-      local: appServer?.url === undefined,
-      localBackend: appServer?.harnessBackend ?? "local",
-      ...(appServer?.url !== undefined ? { url: appServer.url } : {}),
-      ...(appServer?.WebSocket !== undefined ? { WebSocket: appServer.WebSocket } : {}),
-      ...(appServer?.requestTimeoutMs !== undefined
-        ? { requestTimeoutMs: appServer.requestTimeoutMs }
-        : {}),
-      ...(appServer?.listen !== undefined ? { localListen: appServer.listen } : {}),
-      ...(appServer?.startupTimeoutMs !== undefined
-        ? { localStartupTimeoutMs: appServer.startupTimeoutMs }
-        : {}),
-    };
-  }
-
-  private remoteOptions(): LettaCodeRemoteClientOptions {
-    if (this.backend !== "remote") {
-      throw new Error("Remote options requested for non-remote backend.");
-    }
-    return this.options as LettaCodeRemoteClientOptions;
-  }
-
-  private getRepositoriesClient(): RepositoriesClient {
-    if (this.backend !== "cloud") {
-      throw new Error('client.repositories is only available with backend: "cloud".');
-    }
-    this.repositoriesClient ??= new RepositoriesClient(this.cloudOptions());
-    return this.repositoriesClient;
-  }
-
-  private cloudOptions(): LettaCodeCloudClientOptions {
-    if (this.backend !== "cloud") {
-      throw new Error('Constellation options requested for non-"cloud" backend.');
-    }
-    return this.options as LettaCodeCloudClientOptions;
-  }
+function looksLikeConversationId(id: string): boolean {
+  return id.startsWith("conv-") || id.startsWith("local-conv-");
 }

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -48,7 +48,6 @@ const DEFAULT_SANDBOX_READY_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_REPOSITORY_ATTACH_TIMEOUT_MS = 10_000;
 const DEFAULT_REPOSITORY_ATTACH_POLL_INTERVAL_MS = 250;
 const SDK_AGENT_ORIGIN = "@letta-ai/letta-agent-sdk";
-const GIT_MEMORY_ENABLED_TAG = "git-memory-enabled";
 
 type FetchLike = typeof fetch;
 
@@ -631,16 +630,7 @@ export async function createCloudAgent(
   clientOptions: LettaCodeCloudClientOptions,
   agentOptions: CreateAgentOptions,
 ): Promise<string> {
-  const body = createAgentBody(agentOptions);
-  if (agentOptions.memfs !== false) {
-    const tags = Array.isArray(body.tags)
-      ? body.tags.filter((tag): tag is string => typeof tag === "string")
-      : [];
-    if (!tags.includes(GIT_MEMORY_ENABLED_TAG)) {
-      tags.push(GIT_MEMORY_ENABLED_TAG);
-    }
-    body.tags = tags;
-  }
+  const body = await createAgentBody(agentOptions);
 
   const response = await getFetch(clientOptions.fetch)(
     `${normalizeCloudApiBaseUrl(clientOptions.apiBaseUrl)}/v1/agents/`,

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -7,12 +7,11 @@ import {
 } from "@letta-ai/letta-code/app-server-client";
 import {
   AppServerRuntimeController,
-  AppServerSession,
   agentToolNames,
+  createAgentBody,
   createExternalToolCallHandler,
   externalToolGroups,
   registerAppServerControlRequestHandler,
-  type AppServerSessionOptions,
 } from "./app-server-session.js";
 import {
   RemoteEnvironmentClient,
@@ -49,6 +48,7 @@ const DEFAULT_SANDBOX_READY_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_REPOSITORY_ATTACH_TIMEOUT_MS = 10_000;
 const DEFAULT_REPOSITORY_ATTACH_POLL_INTERVAL_MS = 250;
 const SDK_AGENT_ORIGIN = "@letta-ai/letta-agent-sdk";
+const GIT_MEMORY_ENABLED_TAG = "git-memory-enabled";
 
 type FetchLike = typeof fetch;
 
@@ -293,8 +293,6 @@ function validateCloudSandboxOptions(
 
 export function validateCloudClientOptions(options: LettaCodeCloudClientOptions): void {
   validatePositiveInteger(options.requestTimeoutMs, "requestTimeoutMs");
-  validatePositiveInteger(options.appServer?.requestTimeoutMs, "appServer.requestTimeoutMs");
-  validatePositiveInteger(options.appServer?.startupTimeoutMs, "appServer.startupTimeoutMs");
   validateCloudSandboxOptions(options.sandbox, "sandbox");
   if (options.environment !== undefined && options.sandbox !== undefined) {
     throw new Error("Constellation sessions cannot specify both environment and sandbox options.");
@@ -629,44 +627,39 @@ function externalToolsByName(tools: AnyAgentTool[] | undefined): Map<string, Any
   return result;
 }
 
-function cloudHarnessAppServerOptions(
-  clientOptions: LettaCodeCloudClientOptions,
-): AppServerSessionOptions {
-  const appServer = clientOptions.appServer;
-  const apiKey = getCloudApiKey(clientOptions);
-  const localEnv: Record<string, string | undefined> = {
-    ...(apiKey ? { LETTA_API_KEY: apiKey } : {}),
-    ...(clientOptions.apiBaseUrl
-      ? { LETTA_BASE_URL: normalizeCloudApiBaseUrl(clientOptions.apiBaseUrl) }
-      : {}),
-  };
-  return {
-    local: appServer?.url === undefined,
-    localBackend: "api",
-    ...(appServer?.url !== undefined ? { url: appServer.url } : {}),
-    ...(appServer?.WebSocket !== undefined ? { WebSocket: appServer.WebSocket } : {}),
-    ...(clientOptions.requestTimeoutMs !== undefined || appServer?.requestTimeoutMs !== undefined
-      ? { requestTimeoutMs: appServer?.requestTimeoutMs ?? clientOptions.requestTimeoutMs }
-      : {}),
-    ...(appServer?.listen !== undefined ? { localListen: appServer.listen } : {}),
-    ...(appServer?.startupTimeoutMs !== undefined
-      ? { localStartupTimeoutMs: appServer.startupTimeoutMs }
-      : {}),
-    ...(Object.keys(localEnv).length > 0 ? { localEnv } : {}),
-  };
-}
-
 export async function createCloudAgent(
   clientOptions: LettaCodeCloudClientOptions,
   agentOptions: CreateAgentOptions,
 ): Promise<string> {
-  const session = new AppServerSession(cloudHarnessAppServerOptions(clientOptions), {
-    kind: "create-agent",
-    options: agentOptions,
-  });
-  const initMsg = await session.initialize();
-  session.close();
-  return initMsg.agentId;
+  const body = createAgentBody(agentOptions);
+  if (agentOptions.memfs !== false) {
+    const tags = Array.isArray(body.tags)
+      ? body.tags.filter((tag): tag is string => typeof tag === "string")
+      : [];
+    if (!tags.includes(GIT_MEMORY_ENABLED_TAG)) {
+      tags.push(GIT_MEMORY_ENABLED_TAG);
+    }
+    body.tags = tags;
+  }
+
+  const response = await getFetch(clientOptions.fetch)(
+    `${normalizeCloudApiBaseUrl(clientOptions.apiBaseUrl)}/v1/agents/`,
+    {
+      method: "POST",
+      headers: cloudHeaders(clientOptions),
+      body: JSON.stringify(body),
+    },
+  );
+  const responseBody = await parseJsonResponse(response);
+  assertOkResponse(response, responseBody, "Cloud create agent");
+  const agentId =
+    responseBody && typeof responseBody === "object"
+      ? (responseBody as { id?: unknown }).id
+      : undefined;
+  if (typeof agentId !== "string" || agentId.length === 0) {
+    throw new Error("Cloud create agent response did not include an agent id.");
+  }
+  return agentId;
 }
 
 export function assertCloudSessionOptionsSupported(

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export type {
   LettaCodeSession,
   LettaCodeSocketLike,
   LettaCodeSocketConstructor,
+  LettaCodeReactNativeSocketConstructor,
   SDKMessage,
   SDKInitMessage,
   SDKAssistantMessage,
@@ -138,6 +139,7 @@ export { Session } from "./session.js";
 export { RepositoriesClient } from "./repositories.js";
 export { LettaAgentClient } from "./client.js";
 export { CloudManagedSandboxExpiredError } from "./cloud-session.js";
+export { createReactNativeWebSocketConstructor } from "./websocket.js";
 
 export { extractStreamTextDelta } from "./stream-events.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import { validateCreateSessionOptions, validateCreateAgentOptions } from "./vali
 export type {
   CreateSessionOptions,
   CreateAgentOptions,
+  LettaCodePersonalityId,
   LettaCodeBackend,
   LettaCodeEnvironment,
   LettaCodeLocalClientOptions,

--- a/src/local-app-server-session.ts
+++ b/src/local-app-server-session.ts
@@ -1,0 +1,34 @@
+import {
+  AppServerSession,
+  type AppServerSessionMode,
+  type AppServerSessionOptions,
+} from "./app-server-session.js";
+import { startLocalAppServer } from "./local-app-server.js";
+import type { LettaCodeLocalAppServerOptions } from "./types.js";
+
+export function createLocalAppServerSession(
+  options: LettaCodeLocalAppServerOptions | undefined,
+  mode: AppServerSessionMode,
+): AppServerSession {
+  const appServer = options ?? {};
+  const sessionOptions: AppServerSessionOptions = {
+    ...(appServer.url !== undefined
+      ? { url: appServer.url }
+      : {
+          connect: (sessionEnv?: Record<string, string>) =>
+            startLocalAppServer({
+              listen: appServer.listen,
+              backend: appServer.harnessBackend ?? "local",
+              startupTimeoutMs: appServer.startupTimeoutMs,
+              env: sessionEnv,
+            }),
+        }),
+    ...(appServer.WebSocket !== undefined
+      ? { WebSocket: appServer.WebSocket }
+      : {}),
+    ...(appServer.requestTimeoutMs !== undefined
+      ? { requestTimeoutMs: appServer.requestTimeoutMs }
+      : {}),
+  };
+  return new AppServerSession(sessionOptions, mode);
+}

--- a/src/tests/app-server-session.test.ts
+++ b/src/tests/app-server-session.test.ts
@@ -1,19 +1,24 @@
 import { describe, expect, test } from "bun:test";
+import { buildCreateAgentRequestForPersonality } from "@letta-ai/letta-code/agent-presets";
 import { createAgentBody } from "../app-server-session.js";
 
 describe("createAgentBody", () => {
-  test("uses an empty prompt when systemPrompt is omitted", () => {
-    const body = createAgentBody({ model: "openai/gpt-5.2" });
+  test("is byte-for-byte identical to the centralized Letta Code payload by default", async () => {
+    const body = await createAgentBody({ model: "openai/gpt-5.2" });
+    const expected = await buildCreateAgentRequestForPersonality({
+      personalityId: "memo",
+      model: "openai/gpt-5.2",
+    });
 
-    expect(body.system).toBe("");
+    expect(body).toEqual(expected as unknown as Record<string, unknown>);
   });
 
-  test("preserves custom prompts", () => {
+  test("preserves custom prompts", async () => {
     expect(
-      createAgentBody({
+      (await createAgentBody({
         model: "openai/gpt-5.2",
         systemPrompt: "You are a focused research assistant.",
-      }).system,
+      })).system,
     ).toBe("You are a focused research assistant.");
   });
 });

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -970,10 +970,10 @@ describe("LettaAgentClient", () => {
       create_agent: {
         body: {
           model: "anthropic/claude-sonnet-4",
-          tags: ["sdk-test", "origin:letta-code"],
-          memory_blocks: [
+          tags: ["origin:letta-code", "git-memory-enabled", "sdk-test"],
+          memory_blocks: expect.arrayContaining([
             { label: "persona", value: "Helpful TypeScript assistant" },
-          ],
+          ]),
         },
       },
     });

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1324,13 +1324,15 @@ describe("CloudEnvironmentSession", () => {
       body: {
         model: "anthropic/claude-sonnet-4",
         system: "You are a repo assistant.",
-        memory_blocks: [{ label: "project", value: "Use Bun." }],
+        memory_blocks: expect.arrayContaining([
+          expect.objectContaining({ label: "project", value: "Use Bun." }),
+        ]),
       },
     });
     expect((requests[0]!.body as { tags: string[] }).tags).toEqual([
-      "team:sdk",
       "origin:letta-code",
       "git-memory-enabled",
+      "team:sdk",
     ]);
 
     await expect(client.createAgent({
@@ -1341,7 +1343,7 @@ describe("CloudEnvironmentSession", () => {
     );
   });
 
-  test("rejects Cloud createAgent without an explicit model", async () => {
+  test("uses the Letta Code default model for Cloud createAgent", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
@@ -1352,14 +1354,14 @@ describe("CloudEnvironmentSession", () => {
       WebSocket: FakeCloudSocket,
     });
 
-    await expect(client.createAgent({
-      systemPrompt: "You are a repo assistant.",
-    })).rejects.toThrow("Constellation createAgent() requires an explicit model");
+    await expect(client.createAgent()).resolves.toBe("agent-created");
+    expect(requests[0]?.body).toMatchObject({ model: "letta/auto" });
+
     await expect(client.createAgent({
       model: "   ",
-    })).rejects.toThrow("Constellation createAgent() requires an explicit model");
+    })).rejects.toThrow('Unknown model:');
 
-    expect(requests).toHaveLength(0);
+    expect(requests).toHaveLength(1);
   });
 
   test("responds to Remote Client approval requests through canUseTool", async () => {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -522,77 +522,6 @@ function resetFakeCloud(): void {
   FakeCloudSocket.syncSucceeds = true;
 }
 
-class FakeAppServerSocket {
-  static instances: FakeAppServerSocket[] = [];
-  readyState = 0;
-  sent: Array<Record<string, unknown>> = [];
-  private listeners = new Map<string, Set<Listener>>();
-
-  constructor(readonly url: string) {
-    FakeAppServerSocket.instances.push(this);
-    queueMicrotask(() => {
-      this.readyState = 1;
-      this.emit("open", {});
-    });
-  }
-
-  send(data: string): void {
-    const command = JSON.parse(data) as Record<string, unknown>;
-    this.sent.push(command);
-
-    if (command.type === "runtime_start") {
-      this.serverMessage({
-        type: "runtime_start_response",
-        request_id: command.request_id,
-        success: true,
-        runtime: { agent_id: "agent-created", conversation_id: "conv-created" },
-        agent: { id: "agent-created", model: "anthropic/claude-sonnet-4" },
-        conversation: { id: "conv-created", agent_id: "agent-created" },
-      });
-    }
-
-    if (command.type === "enable_memfs") {
-      this.serverMessage({
-        type: "enable_memfs_response",
-        request_id: command.request_id,
-        success: true,
-      });
-    }
-  }
-
-  close(): void {
-    this.readyState = 3;
-    this.emit("close", {});
-  }
-
-  addEventListener(type: string, listener: Listener): void {
-    let listeners = this.listeners.get(type);
-    if (!listeners) {
-      listeners = new Set();
-      this.listeners.set(type, listeners);
-    }
-    listeners.add(listener);
-  }
-
-  removeEventListener(type: string, listener: Listener): void {
-    this.listeners.get(type)?.delete(listener);
-  }
-
-  private serverMessage(message: unknown): void {
-    this.emit("message", { data: JSON.stringify(message) });
-  }
-
-  private emit(type: string, event: unknown): void {
-    for (const listener of this.listeners.get(type) ?? []) {
-      listener(event);
-    }
-  }
-}
-
-function resetFakeAppServer(): void {
-  FakeAppServerSocket.instances = [];
-}
-
 describe("CloudEnvironmentSession", () => {
   test("creates, refreshes, and cleans up a managed Cloud sandbox with terminateOnClose", async () => {
     resetFakeCloud();
@@ -1366,9 +1295,8 @@ describe("CloudEnvironmentSession", () => {
     session.close();
   });
 
-  test("creates Cloud agents through the local app-server harness", async () => {
+  test("creates Cloud agents directly through the REST API", async () => {
     resetFakeCloud();
-    resetFakeAppServer();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
       backend: "cloud",
@@ -1376,11 +1304,6 @@ describe("CloudEnvironmentSession", () => {
       apiKey: "sk-test",
       fetch: createCloudFetchMock(requests),
       WebSocket: FakeCloudSocket,
-      appServer: {
-        url: "ws://app-server.test/ws",
-        WebSocket: FakeAppServerSocket,
-        requestTimeoutMs: 1_000,
-      },
     });
 
     await expect(client.createAgent({
@@ -1390,24 +1313,25 @@ describe("CloudEnvironmentSession", () => {
       tags: ["team:sdk"],
     })).resolves.toBe("agent-created");
 
-    expect(requests).toHaveLength(0);
-    const controlSocket = FakeAppServerSocket.instances.find((socket) => new URL(socket.url).searchParams.get("channel") === "control")!;
-    const runtimeStart = controlSocket.sent.find((command) => command.type === "runtime_start")!;
-    expect(runtimeStart).toMatchObject({
-      create_agent: {
-        pin_global: true,
-        body: {
-          model: "anthropic/claude-sonnet-4",
-          system: "You are a repo assistant.",
-          memory_blocks: [{ label: "project", value: "Use Bun." }],
-        },
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      url: "https://api.test/v1/agents/",
+      method: "POST",
+      headers: {
+        authorization: "Bearer sk-test",
+        "content-type": "application/json",
+      },
+      body: {
+        model: "anthropic/claude-sonnet-4",
+        system: "You are a repo assistant.",
+        memory_blocks: [{ label: "project", value: "Use Bun." }],
       },
     });
-    expect((runtimeStart.create_agent as { body: Record<string, unknown> }).body.tags).toEqual([
+    expect((requests[0]!.body as { tags: string[] }).tags).toEqual([
       "team:sdk",
       "origin:letta-code",
+      "git-memory-enabled",
     ]);
-    expect(controlSocket.sent).toContainEqual(expect.objectContaining({ type: "enable_memfs" }));
 
     await expect(client.createAgent({
       model: "anthropic/claude-sonnet-4",
@@ -1419,7 +1343,6 @@ describe("CloudEnvironmentSession", () => {
 
   test("rejects Cloud createAgent without an explicit model", async () => {
     resetFakeCloud();
-    resetFakeAppServer();
     const requests: RecordedRequest[] = [];
     const client = new LettaAgentClient({
       backend: "cloud",
@@ -1427,10 +1350,6 @@ describe("CloudEnvironmentSession", () => {
       apiKey: "sk-test",
       fetch: createCloudFetchMock(requests),
       WebSocket: FakeCloudSocket,
-      appServer: {
-        url: "ws://app-server.test/ws",
-        WebSocket: FakeAppServerSocket,
-      },
     });
 
     await expect(client.createAgent({
@@ -1441,7 +1360,6 @@ describe("CloudEnvironmentSession", () => {
     })).rejects.toThrow("Constellation createAgent() requires an explicit model");
 
     expect(requests).toHaveLength(0);
-    expect(FakeAppServerSocket.instances).toHaveLength(0);
   });
 
   test("responds to Remote Client approval requests through canUseTool", async () => {

--- a/src/tests/portable-client.test.ts
+++ b/src/tests/portable-client.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LettaAgentClient,
+  createReactNativeWebSocketConstructor,
+  type LettaCodeReactNativeSocketConstructor,
+  type LettaCodeSocketOptions,
+} from "../client-entry.js";
+
+describe("portable client entry", () => {
+  test("rejects local execution", () => {
+    expect(
+      () =>
+        new LettaAgentClient(
+          { backend: "local" } as never,
+        ),
+    ).toThrow('supports backend: "remote" and backend: "cloud" only');
+  });
+
+  test("creates a Cloud agent without a local runtime", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchMock = (async (
+      input: Parameters<typeof fetch>[0] | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      requests.push({ url: String(input), init });
+      return new Response(JSON.stringify({ id: "agent-portable" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: fetchMock,
+    });
+
+    await expect(
+      client.createAgent({
+        model: "anthropic/claude-sonnet-4",
+        memfs: false,
+      }),
+    ).resolves.toBe("agent-portable");
+
+    expect(requests).toHaveLength(1);
+    const body = JSON.parse(String(requests[0]!.init?.body)) as {
+      tags: string[];
+    };
+    expect(body.tags).toEqual(["origin:letta-code"]);
+  });
+
+  test("adapts React Native websocket headers to the third argument", () => {
+    let received:
+      | { url: string; protocols: string | string[] | null | undefined; options?: LettaCodeSocketOptions }
+      | undefined;
+
+    class ReactNativeSocket {
+      readyState = 1;
+
+      constructor(
+        url: string,
+        protocols?: string | string[] | null,
+        options?: LettaCodeSocketOptions,
+      ) {
+        received = { url, protocols, options };
+      }
+
+      send(): void {}
+      close(): void {}
+    }
+
+    const WebSocket = createReactNativeWebSocketConstructor(
+      ReactNativeSocket as LettaCodeReactNativeSocketConstructor,
+    );
+    const socket = new WebSocket("ws://example.test", {
+      headers: { Authorization: "Bearer token" },
+    });
+
+    expect(socket).toBeInstanceOf(ReactNativeSocket);
+    expect(received).toEqual({
+      url: "ws://example.test",
+      protocols: undefined,
+      options: { headers: { Authorization: "Bearer token" } },
+    });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,16 @@ export type LettaCodeSocketConstructor = new (
   options?: LettaCodeSocketOptions,
 ) => LettaCodeSocketLike;
 
+/**
+ * React Native's WebSocket constructor accepts request headers as its third
+ * argument, unlike the Node-style constructor used by the SDK protocol layer.
+ */
+export type LettaCodeReactNativeSocketConstructor = new (
+  url: string,
+  protocols?: string | string[] | null,
+  options?: LettaCodeSocketOptions,
+) => LettaCodeSocketLike;
+
 // ═══════════════════════════════════════════════════════════════
 // MESSAGE CONTENT TYPES (for multimodal support)
 // ═══════════════════════════════════════════════════════════════
@@ -368,11 +378,6 @@ export interface LettaCodeCloudClientOptions {
   webSocketAuth?: "header" | "query";
   /** Heartbeat interval for the Cloud status websocket. Defaults to 30s. */
   pingIntervalMs?: number;
-  /**
-   * Advanced local app-server overrides used by cloud createAgent().
-   * Omit to let the SDK spawn a bundled local app-server authenticated to Cloud.
-   */
-  appServer?: LettaCodeLocalAppServerOptions;
   /**
    * Execution target for Constellation sessions. If omitted, the SDK creates
    * and owns a sandbox for the session.

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,10 @@ export type {
 
 // Import types for use in this file
 import type { CreateBlock, CanUseToolResponse } from "./protocol.js";
+import type { PersonalityId } from "@letta-ai/letta-code/agent-presets";
+
+/** Letta Code personality preset used to seed a new agent. */
+export type LettaCodePersonalityId = PersonalityId;
 
 export interface LettaCodeSocketLike {
   readyState: number;
@@ -740,6 +744,12 @@ export interface LettaCodeSession extends AsyncDisposable {
  * Options for createAgent() - full control over agent creation.
  */
 export interface CreateAgentOptions {
+  /**
+   * Letta Code personality preset. Defaults to "memo". The creation payload
+   * is built by `@letta-ai/letta-code/agent-presets`, matching Chat/Desktop.
+   */
+  personality?: LettaCodePersonalityId;
+
   /** Model to use (e.g., "claude-sonnet-4-20250514") */
   model?: string;
 

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -1,0 +1,22 @@
+import type {
+  LettaCodeReactNativeSocketConstructor,
+  LettaCodeSocketConstructor,
+  LettaCodeSocketOptions,
+} from "./types.js";
+
+/**
+ * Adapt React Native's three-argument WebSocket constructor to the SDK's
+ * Node-compatible constructor shape. This is only needed when a remote
+ * app-server authenticates its websocket upgrade with headers. Cloud clients
+ * should prefer `webSocketAuth: "query"`.
+ */
+export function createReactNativeWebSocketConstructor(
+  WebSocket: LettaCodeReactNativeSocketConstructor,
+): LettaCodeSocketConstructor {
+  class ReactNativeWebSocketAdapter {
+    constructor(url: string, options?: LettaCodeSocketOptions) {
+      return new WebSocket(url, undefined, options);
+    }
+  }
+  return ReactNativeWebSocketAdapter as unknown as LettaCodeSocketConstructor;
+}


### PR DESCRIPTION
## Summary

- add `@letta-ai/letta-agent-sdk/client`, a browser-targeted remote/Cloud entry with no Node builtin imports
- keep local process execution behind the existing Node package root
- create Cloud agents directly through `POST /v1/agents/` instead of spawning a local app-server
- build agent payloads with the same browser-safe `@letta-ai/letta-code/agent-presets` helper used by Chat/Desktop; SDK-specific overrides layer on top
- preserve Letta Code personality defaults for agent type, system prompt, memory, tools, model resolution, compaction, and memfs/origin tags
- add a React Native WebSocket constructor adapter for authenticated remote app-servers
- add a browser build and fail the build if Node builtin imports leak into the portable bundle
- document Expo/React Native usage

This is the focused SDK portability foundation for [LET-10209](https://linear.app/letta/issue/LET-10209/make-an-example-mobile-app-repo). It deliberately does not add the example mobile app in this repository.

## Verification

- `bun run build`
- `bun run check`
- `bun test` (305 pass, 9 skipped)
- exact payload parity test against `buildCreateAgentRequestForPersonality()`
- package self-import with Node browser conditions
- `npm pack --dry-run --json`