### PR TITLE
feat: allow app-server clients to create unpinned agents

### DIFF
--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -125,8 +125,6 @@ export type AppServerSessionOptions = Partial<LettaCodeRemoteClientOptions> & {
   connect?: (
     sessionEnv?: Record<string, string>,
   ) => Promise<{ url: string; close(): void }>;
-  /** Whether create-agent runtime_start should pin the created agent globally. */
-  pinGlobalAgent?: boolean;
   /** Whether SDK create-agent payloads should add the origin tag automatically. */
   includeSdkOriginTag?: boolean;
 };

--- a/src/local-app-server-session.ts
+++ b/src/local-app-server-session.ts
@@ -29,6 +29,9 @@ export function createLocalAppServerSession(
     ...(appServer.requestTimeoutMs !== undefined
       ? { requestTimeoutMs: appServer.requestTimeoutMs }
       : {}),
+    ...(appServer.pinGlobalAgent !== undefined
+      ? { pinGlobalAgent: appServer.pinGlobalAgent }
+      : {}),
   };
   return new AppServerSession(sessionOptions, mode);
 }

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1077,6 +1077,7 @@ describe("LettaAgentClient", () => {
     expect(fakeControlSocket().sent[0]).toMatchObject({
       type: "runtime_start",
       create_agent: {
+        pin_global: true,
         body: {
           model: "anthropic/claude-sonnet-4",
           tags: ["origin:letta-code", "git-memory-enabled", "sdk-test"],
@@ -1085,6 +1086,60 @@ describe("LettaAgentClient", () => {
           ]),
         },
       },
+    });
+  });
+
+  test("creates remote app-server agents with an explicit pinning preference", async () => {
+    for (const pinGlobalAgent of [true, false]) {
+      FakeAppServerSocket.instances = [];
+      const client = new LettaAgentClient({
+        backend: "remote",
+        url: "ws://127.0.0.1:4500/ws",
+        WebSocket: FakeAppServerSocket,
+        pinGlobalAgent,
+      });
+
+      await client.createAgent();
+
+      expect(fakeControlSocket().sent[0]).toMatchObject({
+        type: "runtime_start",
+        create_agent: { pin_global: pinGlobalAgent },
+      });
+    }
+  });
+
+  test("hidden remote app-server agents default to unpinned", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    await client.createAgent({ hidden: true });
+
+    expect(fakeControlSocket().sent[0]).toMatchObject({
+      type: "runtime_start",
+      create_agent: { pin_global: false },
+    });
+  });
+
+  test("forwards local app-server agent pinning preferences", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "local",
+      appServer: {
+        url: "ws://127.0.0.1:4500/ws",
+        WebSocket: FakeAppServerSocket,
+        pinGlobalAgent: false,
+      },
+    });
+
+    await client.createAgent();
+
+    expect(fakeControlSocket().sent[0]).toMatchObject({
+      type: "runtime_start",
+      create_agent: { pin_global: false },
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -314,6 +314,8 @@ export interface LettaCodeLocalAppServerOptions {
   WebSocket?: LettaCodeSocketConstructor;
   /** Timeout for websocket protocol request/turn correlation. */
   requestTimeoutMs?: number;
+  /** Whether agents created through this app-server are added to Letta Code's global pinned-agent list. */
+  pinGlobalAgent?: boolean;
   /** Local app-server listen URL when the SDK spawns it. Defaults to ws://127.0.0.1:0. */
   listen?: string;
   /** Timeout waiting for the spawned app-server to print its listening URL. */
@@ -338,6 +340,8 @@ export interface LettaCodeRemoteClientOptions {
   WebSocket?: LettaCodeSocketConstructor;
   /** Timeout for websocket protocol request/turn correlation. */
   requestTimeoutMs?: number;
+  /** Whether agents created through this app-server are added to Letta Code's global pinned-agent list. */
+  pinGlobalAgent?: boolean;
 }
 
 export interface LettaCodeCloudSandboxOptions {


### PR DESCRIPTION
## Summary

- expose `pinGlobalAgent` for SDK-owned local and user-managed remote app-server clients
- forward local app-server preferences into the existing Letta Code `runtime_start.create_agent.pin_global` control
- preserve the current defaults when omitted: visible agents are pinned and hidden worker agents are unpinned
- keep the option app-server-specific instead of adding a Cloud-irrelevant field to portable `CreateAgentOptions`

This lets integrations create visible, discoverable agents without modifying the user's global pinned-agent list. Letta Code's app-server remains authoritative for agent-creation behavior; the SDK only forwards the preference.

```ts
const localClient = new LettaAgentClient({
  backend: "local",
  appServer: { pinGlobalAgent: false },
});

const remoteClient = new LettaAgentClient({
  backend: "remote",
  url: "ws://127.0.0.1:4500",
  pinGlobalAgent: false,
});
```

The option is backward-compatible: callers that omit it retain the existing visible/hidden defaults.

## Test plan

- [x] rebased onto current `main`, including #210–#212
- [x] `bun run check`
- [x] `bun test` — 244 pass / 11 live-integration tests skipped / 0 fail
- [x] `bun run build`
- [x] coverage for explicit `true`, explicit `false`, omitted visible-agent behavior, hidden-agent behavior, and local app-server forwarding

Fixes #203

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)
