### PR TITLE
feat: add portable agent and conversation management

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,43 @@ Native, pass the platform WebSocket through
 Native's third constructor argument. Cloud clients should prefer query
 authentication as shown above.
 
+### Agent and conversation management
+
+The same management API works with Cloud REST and the Letta Code app-server
+protocol, including from the portable `/client` entry:
+
+```ts
+const agents = await client.agents.list({
+  query: "support",
+  tags: ["mobile"],
+});
+const agent = await client.agents.retrieve(agents[0].id);
+await client.agents.update(agent.id, { name: "Mobile support" });
+
+const conversations = await client.conversations.list({
+  agentId: agent.id,
+  orderBy: "lastMessageAt",
+  order: "desc",
+});
+const conversation = await client.conversations.create({
+  agentId: agent.id,
+  summary: "New mobile thread",
+});
+await client.conversations.update(conversation.id, {
+  summary: "Onboarding question",
+});
+const history = await client.conversations.listMessages(conversation.id, {
+  limit: 50,
+  order: "desc",
+});
+```
+
+Agent creation intentionally remains the high-level
+`client.createAgent(options)` method. It uses Letta Code's centralized
+personality, memory-filesystem, origin-tag, and preset logic on every backend.
+For an active session, `session.listMessages()` remains the convenient
+conversation-scoped form of `client.conversations.listMessages()`.
+
 ### Persistent agent with multi-turn conversations
 
 ```ts

--- a/src/app-server-management.ts
+++ b/src/app-server-management.ts
@@ -1,0 +1,234 @@
+import {
+  createAppServerClient,
+  type AppServerClient,
+  type AppServerRequestCommandWithId,
+  type AppServerSocketConstructor,
+} from "@letta-ai/letta-code/app-server-client";
+import type {
+  ManagementQuery,
+  ManagementTransport,
+} from "./management.js";
+import type {
+  ConversationMessagesResult,
+  LettaAgent,
+  LettaConversation,
+} from "./management-types.js";
+import type { LettaCodeRemoteClientOptions } from "./types.js";
+
+type OwnedConnection = { url: string; close(): void };
+
+type ManagementResponse = {
+  type: string;
+  success: boolean;
+  error?: string;
+};
+
+type AgentListResponse = ManagementResponse & {
+  agents: LettaAgent[];
+};
+
+type AgentResponse = ManagementResponse & {
+  agent: LettaAgent | null;
+};
+
+type ConversationListResponse = ManagementResponse & {
+  conversations: LettaConversation[];
+};
+
+type ConversationResponse = ManagementResponse & {
+  conversation: LettaConversation | null;
+};
+
+type ConversationMessagesResponse = ManagementResponse & {
+  messages: Record<string, unknown>[];
+};
+
+export type AppServerManagementOptions =
+  Partial<LettaCodeRemoteClientOptions> & {
+    url?: string;
+    connect?: () => Promise<OwnedConnection>;
+  };
+
+function ensureResponse<T>(
+  response: { success: boolean; error?: string },
+  value: T | null | undefined,
+  fallback: string,
+): T {
+  if (!response.success || value == null) {
+    throw new Error(response.error ?? fallback);
+  }
+  return value;
+}
+
+export class AppServerManagementTransport
+  implements ManagementTransport
+{
+  constructor(private readonly options: AppServerManagementOptions) {}
+
+  async listAgents(query: ManagementQuery): Promise<LettaAgent[]> {
+    const response = await this.request<AgentListResponse>(
+      "agent_list",
+      { query },
+      "agent_list_response",
+    );
+    if (!response.success) {
+      throw new Error(response.error ?? "Failed to list agents.");
+    }
+    return response.agents;
+  }
+
+  async retrieveAgent(agentId: string): Promise<LettaAgent> {
+    const response = await this.request<AgentResponse>(
+      "agent_retrieve",
+      { agent_id: agentId },
+      "agent_retrieve_response",
+    );
+    return ensureResponse(
+      response,
+      response.agent,
+      `Failed to retrieve agent ${agentId}.`,
+    );
+  }
+
+  async updateAgent(
+    agentId: string,
+    body: Record<string, unknown>,
+  ): Promise<LettaAgent> {
+    const response = await this.request<AgentResponse>(
+      "agent_update",
+      { agent_id: agentId, body },
+      "agent_update_response",
+    );
+    return ensureResponse(
+      response,
+      response.agent,
+      `Failed to update agent ${agentId}.`,
+    );
+  }
+
+  async listConversations(
+    query: ManagementQuery,
+  ): Promise<LettaConversation[]> {
+    const response = await this.request<ConversationListResponse>(
+      "conversation_list",
+      { query },
+      "conversation_list_response",
+    );
+    if (!response.success) {
+      throw new Error(response.error ?? "Failed to list conversations.");
+    }
+    return response.conversations;
+  }
+
+  async retrieveConversation(
+    conversationId: string,
+  ): Promise<LettaConversation> {
+    const response = await this.request<ConversationResponse>(
+      "conversation_retrieve",
+      { conversation_id: conversationId },
+      "conversation_retrieve_response",
+    );
+    return ensureResponse(
+      response,
+      response.conversation,
+      `Failed to retrieve conversation ${conversationId}.`,
+    );
+  }
+
+  async createConversation(
+    body: Record<string, unknown>,
+  ): Promise<LettaConversation> {
+    const response = await this.request<ConversationResponse>(
+      "conversation_create",
+      { body },
+      "conversation_create_response",
+    );
+    return ensureResponse(
+      response,
+      response.conversation,
+      "Failed to create conversation.",
+    );
+  }
+
+  async updateConversation(
+    conversationId: string,
+    body: Record<string, unknown>,
+  ): Promise<LettaConversation> {
+    const response = await this.request<ConversationResponse>(
+      "conversation_update",
+      { conversation_id: conversationId, body },
+      "conversation_update_response",
+    );
+    return ensureResponse(
+      response,
+      response.conversation,
+      `Failed to update conversation ${conversationId}.`,
+    );
+  }
+
+  async listConversationMessages(
+    conversationId: string,
+    query: ManagementQuery,
+  ): Promise<ConversationMessagesResult> {
+    const response =
+      await this.request<ConversationMessagesResponse>(
+        "conversation_messages_list",
+        { conversation_id: conversationId, query },
+        "conversation_messages_list_response",
+      );
+    if (!response.success) {
+      throw new Error(
+        response.error ??
+          `Failed to list messages for conversation ${conversationId}.`,
+      );
+    }
+    return { messages: response.messages };
+  }
+
+  private async request<TResponse extends { type: string }>(
+    type: string,
+    body: Record<string, unknown>,
+    responseType: string,
+  ): Promise<TResponse> {
+    const ownedConnection = this.options.url
+      ? null
+      : await this.options.connect?.();
+    const url = this.options.url ?? ownedConnection?.url;
+    if (!url) {
+      throw new Error("App-server management requires a url or connect hook.");
+    }
+
+    let client: AppServerClient | null = null;
+    try {
+      client = createAppServerClient({
+        url,
+        ...(this.options.authToken !== undefined
+          ? { authToken: this.options.authToken }
+          : {}),
+        ...(this.options.WebSocket
+          ? {
+              WebSocket:
+                this.options.WebSocket as AppServerSocketConstructor,
+            }
+          : {}),
+        ...(this.options.requestTimeoutMs !== undefined
+          ? { requestTimeoutMs: this.options.requestTimeoutMs }
+          : {}),
+      });
+      await client.connect();
+      const command = {
+        type,
+        request_id: client.nextRequestId(type),
+        ...body,
+      } as AppServerRequestCommandWithId;
+      const response = await client.request(command, {
+        predicate: (message): message is typeof message =>
+          message.type === responseType,
+      });
+      return response as unknown as TResponse;
+    } finally {
+      client?.close();
+      ownedConnection?.close();
+    }
+  }
+}

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -1,14 +1,25 @@
 import { RepositoriesClient } from "./repositories.js";
+import { AppServerManagementTransport } from "./app-server-management.js";
 import {
   AppServerSession,
   assertRemoteSessionOptionsSupported,
 } from "./app-server-session.js";
+import { CloudManagementTransport } from "./cloud-management.js";
 import {
   CloudEnvironmentSession,
   assertCloudSessionOptionsSupported,
   createCloudAgent,
   validateCloudClientOptions,
 } from "./cloud-session.js";
+import {
+  createAgentsClient,
+  createConversationsClient,
+  type ManagementTransport,
+} from "./management.js";
+import type {
+  AgentsClient,
+  ConversationsClient,
+} from "./management-types.js";
 import type {
   CreateAgentOptions,
   CreateSessionOptions,
@@ -85,8 +96,11 @@ type TurnSession = LettaCodeSession & {
 export class LettaAgentClientBase {
   readonly backend: LettaCodeBackend;
   readonly environment: LettaCodeEnvironment | undefined;
+  readonly agents: AgentsClient;
+  readonly conversations: ConversationsClient;
   protected readonly options: LettaCodeClientOptions;
   private repositoriesClient: RepositoriesClient | null = null;
+  private managementTransport: ManagementTransport | null = null;
 
   constructor(options: LettaCodeClientOptions = {}) {
     const backend = options.backend ?? "local";
@@ -99,6 +113,10 @@ export class LettaAgentClientBase {
     this.backend = backend;
     this.environment = getOptionsEnvironment(options);
     this.options = options;
+    this.agents = createAgentsClient(() => this.getManagementTransport());
+    this.conversations = createConversationsClient(
+      () => this.getManagementTransport(),
+    );
 
     if (this.backend === "local" && this.environment !== undefined) {
       throw new Error(
@@ -386,6 +404,10 @@ export class LettaAgentClientBase {
     );
   }
 
+  protected createLocalManagementTransport(): ManagementTransport {
+    throw this.localBackendUnavailableError();
+  }
+
   private remoteOptions(): LettaCodeRemoteClientOptions {
     if (this.backend !== "remote") {
       throw new Error("Remote options requested for non-remote backend.");
@@ -399,6 +421,22 @@ export class LettaAgentClientBase {
     }
     this.repositoriesClient ??= new RepositoriesClient(this.cloudOptions());
     return this.repositoriesClient;
+  }
+
+  private getManagementTransport(): ManagementTransport {
+    if (this.managementTransport) return this.managementTransport;
+    if (this.backend === "remote") {
+      this.managementTransport = new AppServerManagementTransport(
+        this.remoteOptions(),
+      );
+    } else if (this.backend === "cloud") {
+      this.managementTransport = new CloudManagementTransport(
+        this.cloudOptions(),
+      );
+    } else {
+      this.managementTransport = this.createLocalManagementTransport();
+    }
+    return this.managementTransport;
   }
 
   private cloudOptions(): LettaCodeCloudClientOptions {

--- a/src/client-entry.ts
+++ b/src/client-entry.ts
@@ -25,6 +25,7 @@ export class LettaAgentClient extends LettaAgentClientBase {
 
 export { CloudManagedSandboxExpiredError } from "./cloud-session.js";
 export { RepositoriesClient } from "./repositories.js";
+export type * from "./management-types.js";
 export { extractStreamTextDelta } from "./stream-events.js";
 export { createReactNativeWebSocketConstructor } from "./websocket.js";
 export type * from "./types.js";

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,8 @@
 import { LettaAgentClientBase } from "./client-base.js";
+import { AppServerManagementTransport } from "./app-server-management.js";
+import type { ManagementTransport } from "./management.js";
 import { createLocalAppServerSession } from "./local-app-server-session.js";
+import { startLocalAppServer } from "./local-app-server.js";
 import { Session } from "./session.js";
 import type {
   CreateAgentOptions,
@@ -10,6 +13,35 @@ import type {
 } from "./types.js";
 
 export class LettaAgentClient extends LettaAgentClientBase {
+  protected override createLocalManagementTransport(): ManagementTransport {
+    if (this.useLegacyLocalStdio()) {
+      throw new Error(
+        'client.agents and client.conversations require the local "app-server" transport.',
+      );
+    }
+    const localOptions = (
+      this.options as LettaCodeLocalClientOptions
+    ).appServer;
+    return new AppServerManagementTransport({
+      ...(localOptions?.url !== undefined
+        ? { url: localOptions.url }
+        : {
+            connect: () =>
+              startLocalAppServer({
+                listen: localOptions?.listen,
+                backend: localOptions?.harnessBackend ?? "local",
+                startupTimeoutMs: localOptions?.startupTimeoutMs,
+              }),
+          }),
+      ...(localOptions?.WebSocket !== undefined
+        ? { WebSocket: localOptions.WebSocket }
+        : {}),
+      ...(localOptions?.requestTimeoutMs !== undefined
+        ? { requestTimeoutMs: localOptions.requestTimeoutMs }
+        : {}),
+    });
+  }
+
   protected override async createLocalAgent(
     options: CreateAgentOptions,
   ): Promise<string> {

--- a/src/cloud-management.ts
+++ b/src/cloud-management.ts
@@ -1,0 +1,299 @@
+import type {
+  ManagementQuery,
+  ManagementTransport,
+} from "./management.js";
+import type {
+  ConversationMessagesResult,
+  LettaAgent,
+  LettaConversation,
+} from "./management-types.js";
+import type { LettaCodeCloudClientOptions } from "./types.js";
+
+const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
+
+function defaultApiKey(): string | undefined {
+  const env = (
+    globalThis as {
+      process?: { env?: Record<string, string | undefined> };
+    }
+  ).process?.env;
+  return env?.LETTA_API_KEY ?? env?.LETTA_CLOUD_API_KEY;
+}
+
+function bearerToken(
+  headers: Record<string, string> | undefined,
+): string | undefined {
+  const authorization = headers?.Authorization ?? headers?.authorization;
+  return authorization?.match(/^Bearer\s+(.+)$/i)?.[1];
+}
+
+function apiBaseUrl(value: string | undefined): string {
+  const url = new URL(value ?? DEFAULT_CLOUD_API_BASE_URL);
+  url.pathname = url.pathname.replace(/\/+$/, "");
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}
+
+function requestHeaders(
+  options: LettaCodeCloudClientOptions,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers ?? {}),
+  };
+  const apiKey =
+    options.apiKey ?? bearerToken(options.headers) ?? defaultApiKey();
+  if (apiKey && !headers.Authorization && !headers.authorization) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  return headers;
+}
+
+function appendQuery(url: URL, query: ManagementQuery): void {
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) url.searchParams.append(key, item);
+    } else {
+      url.searchParams.set(key, String(value));
+    }
+  }
+}
+
+async function parseResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function responseErrorMessage(body: unknown, fallback: string): string {
+  if (body && typeof body === "object") {
+    const record = body as Record<string, unknown>;
+    const message = record.message ?? record.error ?? record.detail;
+    if (typeof message === "string" && message.length > 0) return message;
+  }
+  return fallback;
+}
+
+function cloudRequestError(
+  response: Response,
+  body: unknown,
+  action: string,
+  url: URL,
+  options: LettaCodeCloudClientOptions,
+): Error {
+  const parts = [
+    `${action} failed`,
+    responseErrorMessage(body, `HTTP ${response.status}`),
+    `URL: ${url.toString()}`,
+  ];
+  if (response.status === 401 || response.status === 403) {
+    const hasApiKey = Boolean(
+      options.apiKey ??
+        bearerToken(options.headers) ??
+        defaultApiKey(),
+    );
+    parts.push(
+      hasApiKey
+        ? "Authentication failed — the API key may be invalid or lack permissions for this resource."
+        : "No API key found. Set LETTA_API_KEY (or pass apiKey in client options).",
+    );
+  }
+  return new Error(parts.join(" — "));
+}
+
+function asObject<T>(body: unknown, action: string): T {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error(`${action} response did not include an object.`);
+  }
+  return body as T;
+}
+
+function asArray<T>(body: unknown, action: string): T[] {
+  if (!Array.isArray(body)) {
+    throw new Error(`${action} response did not include an array.`);
+  }
+  return body as T[];
+}
+
+export class CloudManagementTransport implements ManagementTransport {
+  constructor(private readonly options: LettaCodeCloudClientOptions) {}
+
+  listAgents(query: ManagementQuery): Promise<LettaAgent[]> {
+    return this.getArray("/v1/agents/", query, "Cloud list agents");
+  }
+
+  retrieveAgent(agentId: string): Promise<LettaAgent> {
+    return this.getObject(
+      `/v1/agents/${encodeURIComponent(agentId)}`,
+      {},
+      "Cloud retrieve agent",
+    );
+  }
+
+  updateAgent(
+    agentId: string,
+    body: Record<string, unknown>,
+  ): Promise<LettaAgent> {
+    return this.requestObject(
+      `/v1/agents/${encodeURIComponent(agentId)}`,
+      "PATCH",
+      body,
+      "Cloud update agent",
+    );
+  }
+
+  listConversations(
+    query: ManagementQuery,
+  ): Promise<LettaConversation[]> {
+    return this.getArray(
+      "/v1/conversations/",
+      query,
+      "Cloud list conversations",
+    );
+  }
+
+  retrieveConversation(
+    conversationId: string,
+  ): Promise<LettaConversation> {
+    return this.getObject(
+      `/v1/conversations/${encodeURIComponent(conversationId)}`,
+      {},
+      "Cloud retrieve conversation",
+    );
+  }
+
+  createConversation(
+    body: Record<string, unknown>,
+  ): Promise<LettaConversation> {
+    const { agent_id: agentId, ...requestBody } = body;
+    if (typeof agentId !== "string" || agentId.length === 0) {
+      throw new Error("createConversation() requires a non-empty agentId.");
+    }
+    const url = this.url("/v1/conversations/");
+    url.searchParams.set("agent_id", agentId);
+    return this.requestUrlObject(
+      url,
+      "POST",
+      requestBody,
+      "Cloud create conversation",
+    );
+  }
+
+  updateConversation(
+    conversationId: string,
+    body: Record<string, unknown>,
+  ): Promise<LettaConversation> {
+    return this.requestObject(
+      `/v1/conversations/${encodeURIComponent(conversationId)}`,
+      "PATCH",
+      body,
+      "Cloud update conversation",
+    );
+  }
+
+  async listConversationMessages(
+    conversationId: string,
+    query: ManagementQuery,
+  ): Promise<ConversationMessagesResult> {
+    const messages = await this.getArray<Record<string, unknown>>(
+      `/v1/conversations/${encodeURIComponent(conversationId)}/messages`,
+      query,
+      "Cloud list conversation messages",
+    );
+    return { messages };
+  }
+
+  private async getArray<T>(
+    path: string,
+    query: ManagementQuery,
+    action: string,
+  ): Promise<T[]> {
+    const body = await this.get(path, query, action);
+    return asArray<T>(body, action);
+  }
+
+  private async getObject<T>(
+    path: string,
+    query: ManagementQuery,
+    action: string,
+  ): Promise<T> {
+    const body = await this.get(path, query, action);
+    return asObject<T>(body, action);
+  }
+
+  private get(
+    path: string,
+    query: ManagementQuery,
+    action: string,
+  ): Promise<unknown> {
+    const url = this.url(path);
+    appendQuery(url, query);
+    return this.requestUrl(url, "GET", undefined, action);
+  }
+
+  private requestObject<T>(
+    path: string,
+    method: string,
+    body: Record<string, unknown>,
+    action: string,
+  ): Promise<T> {
+    return this.requestUrlObject(
+      this.url(path),
+      method,
+      body,
+      action,
+    );
+  }
+
+  private async requestUrlObject<T>(
+    url: URL,
+    method: string,
+    body: Record<string, unknown>,
+    action: string,
+  ): Promise<T> {
+    return asObject<T>(
+      await this.requestUrl(url, method, body, action),
+      action,
+    );
+  }
+
+  private async requestUrl(
+    url: URL,
+    method: string,
+    body: Record<string, unknown> | undefined,
+    action: string,
+  ): Promise<unknown> {
+    const fetchImpl = (this.options.fetch ?? globalThis.fetch)?.bind(
+      globalThis,
+    );
+    if (!fetchImpl) {
+      throw new Error("No fetch implementation available for cloud backend.");
+    }
+    const response = await fetchImpl(url, {
+      method,
+      headers: requestHeaders(this.options),
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    const responseBody = await parseResponse(response);
+    if (!response.ok) {
+      throw cloudRequestError(
+        response,
+        responseBody,
+        action,
+        url,
+        this.options,
+      );
+    }
+    return responseBody;
+  }
+
+  private url(path: string): URL {
+    return new URL(`${apiBaseUrl(this.options.apiBaseUrl)}${path}`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,20 @@ export type {
   AgentToolUpdateCallback,
   AnyAgentTool,
 } from "./types.js";
+export type {
+  AgentsClient,
+  ConversationsClient,
+  LettaAgent,
+  LettaConversation,
+  LettaConversationMessage,
+  ListAgentsOptions,
+  UpdateAgentOptions,
+  ListConversationsOptions,
+  CreateConversationOptions,
+  UpdateConversationOptions,
+  ConversationMessagesOptions,
+  ConversationMessagesResult,
+} from "./management-types.js";
 
 export { Session } from "./session.js";
 export { RepositoriesClient } from "./repositories.js";

--- a/src/management-types.ts
+++ b/src/management-types.ts
@@ -1,0 +1,122 @@
+import type { ListMessagesResult } from "./types.js";
+
+/** Agent state returned by either the Cloud API or Letta Code app-server. */
+export type LettaAgent = Record<string, unknown> & {
+  id: string;
+  name: string;
+  description?: string | null;
+  model?: string | null;
+  model_settings?: Record<string, unknown> | null;
+  tags?: string[];
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
+/** Conversation state returned by either the Cloud API or Letta Code app-server. */
+export type LettaConversation = Record<string, unknown> & {
+  id: string;
+  agent_id: string;
+  summary?: string | null;
+  description?: string | null;
+  model?: string | null;
+  model_settings?: Record<string, unknown> | null;
+  archived?: boolean;
+  created_at?: string | null;
+  updated_at?: string | null;
+  last_message_at?: string | null;
+};
+
+/** Raw Letta API message returned from conversation history. */
+export type LettaConversationMessage = Record<string, unknown>;
+
+export interface ListAgentsOptions {
+  before?: string;
+  after?: string;
+  limit?: number;
+  order?: "asc" | "desc";
+  orderBy?: "createdAt" | "lastRunCompletion";
+  /** Search agent names. */
+  query?: string;
+  /** Match one exact agent name. */
+  name?: string;
+  tags?: string[];
+  matchAllTags?: boolean;
+  /** Relationships to hydrate in each returned agent. */
+  include?: string[];
+}
+
+export interface UpdateAgentOptions {
+  name?: string | null;
+  description?: string | null;
+  model?: string | null;
+  modelSettings?: Record<string, unknown> | null;
+  system?: string | null;
+  tags?: string[] | null;
+  hidden?: boolean | null;
+  contextWindowLimit?: number | null;
+}
+
+export interface ListConversationsOptions {
+  agentId?: string;
+  after?: string;
+  limit?: number;
+  order?: "asc" | "desc";
+  orderBy?: "createdAt" | "lastRunCompletion" | "lastMessageAt";
+  archiveStatus?: "unarchived" | "archived" | "all";
+  summarySearch?: string;
+}
+
+export interface CreateConversationOptions {
+  agentId: string;
+  summary?: string | null;
+  description?: string | null;
+  model?: string | null;
+  modelSettings?: Record<string, unknown> | null;
+  contextWindowLimit?: number | null;
+  hidden?: boolean;
+}
+
+export interface UpdateConversationOptions {
+  summary?: string | null;
+  description?: string | null;
+  model?: string | null;
+  modelSettings?: Record<string, unknown> | null;
+  contextWindowLimit?: number | null;
+  archived?: boolean | null;
+}
+
+export interface ConversationMessagesOptions {
+  before?: string;
+  after?: string;
+  order?: "asc" | "desc";
+  limit?: number;
+}
+
+export type ConversationMessagesResult = ListMessagesResult & {
+  messages: LettaConversationMessage[];
+};
+
+export interface AgentsClient {
+  list(options?: ListAgentsOptions): Promise<LettaAgent[]>;
+  retrieve(agentId: string): Promise<LettaAgent>;
+  update(
+    agentId: string,
+    options: UpdateAgentOptions,
+  ): Promise<LettaAgent>;
+}
+
+export interface ConversationsClient {
+  list(
+    options?: ListConversationsOptions,
+  ): Promise<LettaConversation[]>;
+  retrieve(conversationId: string): Promise<LettaConversation>;
+  create(options: CreateConversationOptions): Promise<LettaConversation>;
+  update(
+    conversationId: string,
+    options: UpdateConversationOptions,
+  ): Promise<LettaConversation>;
+  listMessages(
+    conversationId: string,
+    options?: ConversationMessagesOptions,
+  ): Promise<ConversationMessagesResult>;
+}

--- a/src/management.ts
+++ b/src/management.ts
@@ -1,0 +1,177 @@
+import type {
+  AgentsClient,
+  ConversationsClient,
+  ConversationMessagesResult,
+  CreateConversationOptions,
+  LettaAgent,
+  LettaConversation,
+  ListAgentsOptions,
+  ListConversationsOptions,
+  UpdateAgentOptions,
+  UpdateConversationOptions,
+  ConversationMessagesOptions,
+} from "./management-types.js";
+
+export type ManagementQuery = Record<
+  string,
+  string | number | boolean | string[] | null | undefined
+>;
+
+export interface ManagementTransport {
+  listAgents(query: ManagementQuery): Promise<LettaAgent[]>;
+  retrieveAgent(agentId: string): Promise<LettaAgent>;
+  updateAgent(
+    agentId: string,
+    body: Record<string, unknown>,
+  ): Promise<LettaAgent>;
+  listConversations(
+    query: ManagementQuery,
+  ): Promise<LettaConversation[]>;
+  retrieveConversation(
+    conversationId: string,
+  ): Promise<LettaConversation>;
+  createConversation(
+    body: Record<string, unknown>,
+  ): Promise<LettaConversation>;
+  updateConversation(
+    conversationId: string,
+    body: Record<string, unknown>,
+  ): Promise<LettaConversation>;
+  listConversationMessages(
+    conversationId: string,
+    query: ManagementQuery,
+  ): Promise<ConversationMessagesResult>;
+}
+
+type TransportProvider = () => ManagementTransport;
+
+function definedEntries(
+  values: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(values).filter(([, value]) => value !== undefined),
+  );
+}
+
+function agentListQuery(options: ListAgentsOptions): ManagementQuery {
+  const orderBy = options.orderBy?.replace(
+    /[A-Z]/g,
+    (character) => `_${character.toLowerCase()}`,
+  );
+  return {
+    before: options.before,
+    after: options.after,
+    limit: options.limit,
+    order: options.order,
+    order_by: orderBy,
+    query_text: options.query,
+    name: options.name,
+    tags: options.tags,
+    match_all_tags: options.matchAllTags,
+    include: options.include,
+  };
+}
+
+function agentUpdateBody(options: UpdateAgentOptions): Record<string, unknown> {
+  return definedEntries({
+    name: options.name,
+    description: options.description,
+    model: options.model,
+    model_settings: options.modelSettings,
+    system: options.system,
+    tags: options.tags,
+    hidden: options.hidden,
+    context_window_limit: options.contextWindowLimit,
+  });
+}
+
+function conversationListQuery(
+  options: ListConversationsOptions,
+): ManagementQuery {
+  const orderBy = options.orderBy?.replace(
+    /[A-Z]/g,
+    (character) => `_${character.toLowerCase()}`,
+  );
+  return {
+    agent_id: options.agentId,
+    after: options.after,
+    limit: options.limit,
+    order: options.order,
+    order_by: orderBy,
+    archive_status: options.archiveStatus,
+    summary_search: options.summarySearch,
+  };
+}
+
+function conversationCreateBody(
+  options: CreateConversationOptions,
+): Record<string, unknown> {
+  return definedEntries({
+    agent_id: options.agentId,
+    summary: options.summary,
+    description: options.description,
+    model: options.model,
+    model_settings: options.modelSettings,
+    context_window_limit: options.contextWindowLimit,
+    hidden: options.hidden,
+  });
+}
+
+function conversationUpdateBody(
+  options: UpdateConversationOptions,
+): Record<string, unknown> {
+  return definedEntries({
+    summary: options.summary,
+    description: options.description,
+    model: options.model,
+    model_settings: options.modelSettings,
+    context_window_limit: options.contextWindowLimit,
+    archived: options.archived,
+  });
+}
+
+function conversationMessagesQuery(
+  options: ConversationMessagesOptions,
+): ManagementQuery {
+  return {
+    before: options.before,
+    after: options.after,
+    order: options.order,
+    limit: options.limit,
+  };
+}
+
+export function createAgentsClient(
+  transport: TransportProvider,
+): AgentsClient {
+  return {
+    list: (options = {}) =>
+      transport().listAgents(agentListQuery(options)),
+    retrieve: (agentId) => transport().retrieveAgent(agentId),
+    update: (agentId, options) =>
+      transport().updateAgent(agentId, agentUpdateBody(options)),
+  };
+}
+
+export function createConversationsClient(
+  transport: TransportProvider,
+): ConversationsClient {
+  return {
+    list: (options = {}) =>
+      transport().listConversations(conversationListQuery(options)),
+    retrieve: (conversationId) =>
+      transport().retrieveConversation(conversationId),
+    create: (options) =>
+      transport().createConversation(conversationCreateBody(options)),
+    update: (conversationId, options) =>
+      transport().updateConversation(
+        conversationId,
+        conversationUpdateBody(options),
+      ),
+    listMessages: (conversationId, options = {}) =>
+      transport().listConversationMessages(
+        conversationId,
+        conversationMessagesQuery(options),
+      ),
+  };
+}

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -1,0 +1,451 @@
+import { describe, expect, test } from "bun:test";
+import { LettaAgentClient as PortableLettaAgentClient } from "../client-entry.js";
+import { LettaAgentClient as NodeLettaAgentClient } from "../index.js";
+import type { LettaCodeSocketOptions } from "../types.js";
+
+type FetchInput = Parameters<typeof fetch>[0];
+type Listener = (event: unknown) => void;
+
+type RecordedRequest = {
+  url: URL;
+  method: string;
+  body?: unknown;
+};
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function requestBody(init?: RequestInit): unknown {
+  return init?.body ? JSON.parse(String(init.body)) : undefined;
+}
+
+function createManagementFetch(
+  requests: RecordedRequest[],
+): typeof fetch {
+  return (async (
+    input: FetchInput | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    const body = requestBody(init);
+    requests.push({ url, method, body });
+
+    if (url.pathname === "/v1/agents/" && method === "GET") {
+      return jsonResponse([{ id: "agent-1", name: "Memo" }]);
+    }
+    if (url.pathname === "/v1/agents/agent-1" && method === "GET") {
+      return jsonResponse({ id: "agent-1", name: "Memo" });
+    }
+    if (url.pathname === "/v1/agents/agent-1" && method === "PATCH") {
+      return jsonResponse({ id: "agent-1", name: "Renamed", ...body as object });
+    }
+    if (url.pathname === "/v1/conversations/" && method === "GET") {
+      return jsonResponse([
+        { id: "conv-1", agent_id: "agent-1", summary: "First" },
+      ]);
+    }
+    if (
+      url.pathname === "/v1/conversations/conv-1" &&
+      method === "GET"
+    ) {
+      return jsonResponse({
+        id: "conv-1",
+        agent_id: "agent-1",
+        summary: "First",
+      });
+    }
+    if (url.pathname === "/v1/conversations/" && method === "POST") {
+      return jsonResponse({
+        id: "conv-2",
+        agent_id: url.searchParams.get("agent_id"),
+        ...body as object,
+      });
+    }
+    if (
+      url.pathname === "/v1/conversations/conv-1" &&
+      method === "PATCH"
+    ) {
+      return jsonResponse({
+        id: "conv-1",
+        agent_id: "agent-1",
+        ...body as object,
+      });
+    }
+    if (
+      url.pathname === "/v1/conversations/conv-1/messages" &&
+      method === "GET"
+    ) {
+      return jsonResponse([{ id: "message-1", message_type: "user_message" }]);
+    }
+    return jsonResponse({ detail: "not found" }, { status: 404 });
+  }) as typeof fetch;
+}
+
+class ManagementSocket {
+  static instances: ManagementSocket[] = [];
+  readyState = 0;
+  readonly sent: Array<Record<string, unknown>> = [];
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  constructor(
+    readonly url: string,
+    readonly options?: LettaCodeSocketOptions,
+  ) {
+    ManagementSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = 1;
+      this.emit("open", {});
+    });
+  }
+
+  send(data: string): void {
+    const command = JSON.parse(data) as Record<string, unknown>;
+    this.sent.push(command);
+    this.respond(command);
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.emit("close", {});
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? new Set<Listener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: Listener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  private respond(command: Record<string, unknown>): void {
+    const responses: Record<string, Record<string, unknown>> = {
+      agent_list: {
+        agents: [{ id: "agent-1", name: "Memo" }],
+      },
+      agent_retrieve: {
+        agent: { id: command.agent_id, name: "Memo" },
+      },
+      agent_update: {
+        agent: {
+          id: command.agent_id,
+          ...(command.body as object),
+        },
+      },
+      conversation_list: {
+        conversations: [
+          { id: "conv-1", agent_id: "agent-1", summary: "First" },
+        ],
+      },
+      conversation_retrieve: {
+        conversation: {
+          id: command.conversation_id,
+          agent_id: "agent-1",
+          summary: "First",
+        },
+      },
+      conversation_create: {
+        conversation: {
+          id: "conv-2",
+          ...(command.body as object),
+        },
+      },
+      conversation_update: {
+        conversation: {
+          id: command.conversation_id,
+          agent_id: "agent-1",
+          ...(command.body as object),
+        },
+      },
+      conversation_messages_list: {
+        messages: [{ id: "message-1", message_type: "user_message" }],
+      },
+    };
+    const type = String(command.type);
+    const payload = responses[type];
+    if (!payload) throw new Error(`Unexpected management command ${type}`);
+    queueMicrotask(() => {
+      this.emit("message", {
+        data: JSON.stringify({
+          type: `${type}_response`,
+          request_id: command.request_id,
+          success: true,
+          ...payload,
+        }),
+      });
+    });
+  }
+
+  protected emit(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+async function exerciseManagementApi(
+  client: PortableLettaAgentClient,
+): Promise<void> {
+  await expect(
+    client.agents.list({
+      query: "memo",
+      tags: ["mobile", "example"],
+      matchAllTags: true,
+      limit: 20,
+      orderBy: "lastRunCompletion",
+    }),
+  ).resolves.toEqual([{ id: "agent-1", name: "Memo" }]);
+  await expect(client.agents.retrieve("agent-1")).resolves.toMatchObject({
+    id: "agent-1",
+  });
+  await expect(
+    client.agents.update("agent-1", {
+      name: "Renamed",
+      contextWindowLimit: 32_000,
+    }),
+  ).resolves.toMatchObject({ id: "agent-1", name: "Renamed" });
+
+  await expect(
+    client.conversations.list({
+      agentId: "agent-1",
+      summarySearch: "first",
+      orderBy: "lastMessageAt",
+      order: "desc",
+    }),
+  ).resolves.toHaveLength(1);
+  await expect(
+    client.conversations.retrieve("conv-1"),
+  ).resolves.toMatchObject({ id: "conv-1", agent_id: "agent-1" });
+  await expect(
+    client.conversations.create({
+      agentId: "agent-1",
+      summary: "Mobile thread",
+      model: "openai/gpt-5.6",
+    }),
+  ).resolves.toMatchObject({
+    id: "conv-2",
+    agent_id: "agent-1",
+    summary: "Mobile thread",
+  });
+  await expect(
+    client.conversations.update("conv-1", {
+      summary: "Renamed thread",
+      archived: false,
+    }),
+  ).resolves.toMatchObject({
+    id: "conv-1",
+    summary: "Renamed thread",
+  });
+  await expect(
+    client.conversations.listMessages("conv-1", {
+      before: "message-2",
+      limit: 50,
+      order: "desc",
+    }),
+  ).resolves.toEqual({
+    messages: [{ id: "message-1", message_type: "user_message" }],
+  });
+}
+
+describe("portable management namespaces", () => {
+  test("map the portable API to Cloud REST", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = new PortableLettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createManagementFetch(requests),
+    });
+
+    await exerciseManagementApi(client);
+
+    expect(requests.map(({ url, method, body }) => ({
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      method,
+      body,
+    }))).toEqual([
+      {
+        path: "/v1/agents/",
+        query: {
+          query_text: "memo",
+          tags: "example",
+          match_all_tags: "true",
+          limit: "20",
+          order_by: "last_run_completion",
+        },
+        method: "GET",
+        body: undefined,
+      },
+      {
+        path: "/v1/agents/agent-1",
+        query: {},
+        method: "GET",
+        body: undefined,
+      },
+      {
+        path: "/v1/agents/agent-1",
+        query: {},
+        method: "PATCH",
+        body: { name: "Renamed", context_window_limit: 32_000 },
+      },
+      {
+        path: "/v1/conversations/",
+        query: {
+          agent_id: "agent-1",
+          order: "desc",
+          order_by: "last_message_at",
+          summary_search: "first",
+        },
+        method: "GET",
+        body: undefined,
+      },
+      {
+        path: "/v1/conversations/conv-1",
+        query: {},
+        method: "GET",
+        body: undefined,
+      },
+      {
+        path: "/v1/conversations/",
+        query: { agent_id: "agent-1" },
+        method: "POST",
+        body: { summary: "Mobile thread", model: "openai/gpt-5.6" },
+      },
+      {
+        path: "/v1/conversations/conv-1",
+        query: {},
+        method: "PATCH",
+        body: { summary: "Renamed thread", archived: false },
+      },
+      {
+        path: "/v1/conversations/conv-1/messages",
+        query: { before: "message-2", order: "desc", limit: "50" },
+        method: "GET",
+        body: undefined,
+      },
+    ]);
+    expect(requests[0]?.url.searchParams.getAll("tags")).toEqual([
+      "mobile",
+      "example",
+    ]);
+  });
+
+  test("maps the same API to app-server protocol commands", async () => {
+    ManagementSocket.instances = [];
+    const client = new PortableLettaAgentClient({
+      backend: "remote",
+      url: "ws://remote.test/ws",
+      authToken: "remote-token",
+      WebSocket: ManagementSocket,
+    });
+
+    await exerciseManagementApi(client);
+
+    const commands = ManagementSocket.instances.flatMap(
+      (socket) => socket.sent,
+    );
+    expect(commands.map(({ type }) => type)).toEqual([
+      "agent_list",
+      "agent_retrieve",
+      "agent_update",
+      "conversation_list",
+      "conversation_retrieve",
+      "conversation_create",
+      "conversation_update",
+      "conversation_messages_list",
+    ]);
+    expect(commands[0]).toMatchObject({
+      query: {
+        query_text: "memo",
+        tags: ["mobile", "example"],
+        match_all_tags: true,
+        limit: 20,
+        order_by: "last_run_completion",
+      },
+    });
+    expect(commands[5]).toMatchObject({
+      body: {
+        agent_id: "agent-1",
+        summary: "Mobile thread",
+        model: "openai/gpt-5.6",
+      },
+    });
+    expect(
+      ManagementSocket.instances.every(
+        (socket) =>
+          socket.options?.headers?.Authorization === "Bearer remote-token",
+      ),
+    ).toBe(true);
+  });
+
+  test("uses the app-server protocol for the Node local backend too", async () => {
+    ManagementSocket.instances = [];
+    const client = new NodeLettaAgentClient({
+      backend: "local",
+      appServer: {
+        url: "ws://127.0.0.1:4500/ws",
+        WebSocket: ManagementSocket,
+      },
+    });
+
+    await expect(client.agents.list()).resolves.toEqual([
+      { id: "agent-1", name: "Memo" },
+    ]);
+    expect(
+      ManagementSocket.instances.flatMap((socket) => socket.sent),
+    ).toEqual([
+      expect.objectContaining({ type: "agent_list", query: {} }),
+    ]);
+  });
+
+  test("surfaces backend failures instead of returning partial entities", async () => {
+    class FailingSocket extends ManagementSocket {
+      override send(data: string): void {
+        const command = JSON.parse(data) as Record<string, unknown>;
+        queueMicrotask(() => {
+          this.emit("message", {
+            data: JSON.stringify({
+              type: "agent_retrieve_response",
+              request_id: command.request_id,
+              success: false,
+              agent: null,
+              error: "agent is not visible",
+            }),
+          });
+        });
+      }
+    }
+    const client = new PortableLettaAgentClient({
+      backend: "remote",
+      url: "ws://remote.test/ws",
+      WebSocket: FailingSocket,
+    });
+
+    await expect(client.agents.retrieve("agent-private")).rejects.toThrow(
+      "agent is not visible",
+    );
+  });
+
+  test("includes Cloud action, URL, and authentication guidance in errors", async () => {
+    const client = new PortableLettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "invalid-key",
+      fetch: (async () =>
+        jsonResponse(
+          { detail: "Unauthorized" },
+          { status: 401 },
+        )) as unknown as typeof fetch,
+    });
+
+    await expect(client.agents.list()).rejects.toThrow(
+      "Cloud list agents failed — Unauthorized — URL: https://api.test/v1/agents/ — Authentication failed",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add backend-neutral `client.agents` helpers for list/search, retrieve, and basic updates
- add `client.conversations` helpers for list/search, retrieve, create, update, and paginated message history
- route Cloud clients through REST and local/remote clients through the existing Letta Code app-server protocol
- export the same surface from the browser/React Native `/client` entry and document the intended Expo usage

Agent creation intentionally stays on the existing high-level `client.createAgent()` path so personality, MemFS, preset, and SDK-origin tag behavior remains centralized in Letta Code. `session.listMessages()` also remains as the contextual convenience API; this does not expose a nested raw REST client.

This is additive/backward-compatible: existing client and session code does not need to change.

Addresses the management portion of #154 and the SDK prerequisite for [LET-10209](https://linear.app/letta/issue/LET-10209/make-an-example-mobile-app-repo).

## Verification

- `bun run check`
- `bun test` (309 passed, 9 live tests skipped)
- `bun run build` (including browser-targeted `/client` build)
- Cloud REST, remote app-server, local app-server, error, auth, and parameter-mapping coverage in `management.test.ts`