### PR TITLE
feat: expose portable session controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ An agent is the persistent entity with memory. A conversation is a thread on tha
 - `resumeSession(agentId)` resumes the agent's default conversation.
 - `prompt(message, agentId)` runs a one-shot prompt in a new conversation.
 
+Portable sessions also expose the stateful controls needed by interactive
+clients:
+
+```ts
+const state = await session.bootstrapState();
+await session.changeDeviceState({
+  cwd: "/workspace/project",
+  permissionMode: "acceptEdits",
+});
+
+const removed = await session.removeQueuedMessage(queueItemId);
+if (!removed.removed) {
+  // Reconcile the authoritative queue before offering the action again.
+}
+
+await session.recoverPendingApprovals();
+```
+
+`removeQueuedMessage()` waits for an app-server acknowledgement.
+`changeDeviceState()` currently confirms command transport only because the
+underlying protocol does not acknowledge that mutation.
+
 ## Deployment options
 
 | Backend | Agent state | Tool execution |

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "build": "bun run build.ts",
+    "prepare": "bun run build",
     "dev": "bun run build.ts --watch",
     "check": "tsc --noEmit",
     "test": "bun test",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   ],
   "scripts": {
     "build": "bun run build.ts",
-    "prepare": "bun run build",
     "dev": "bun run build.ts --watch",
     "check": "tsc --noEmit",
     "test": "bun test",

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,8 @@ export type {
   RunTurnOptions,
   RecoverPendingApprovalsOptions,
   RecoverPendingApprovalsResult,
+  ChangeDeviceStateOptions,
+  RemoveQueuedMessageResult,
   SkillSource,
   DreamingOptions,
   DreamingTrigger,

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -1,6 +1,7 @@
 import type {
   BootstrapStateOptions,
   BootstrapStateResult,
+  ChangeDeviceStateOptions,
   CreateAgentOptions,
   LettaCodeClientSessionOptions,
   LettaCodeSession,
@@ -11,6 +12,7 @@ import type {
   MessageContentItem,
   RecoverPendingApprovalsOptions,
   RecoverPendingApprovalsResult,
+  RemoveQueuedMessageResult,
   ReasoningEffort,
   RunTurnOptions,
   SDKErrorCode,
@@ -736,6 +738,40 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     return this.controller.recoverPendingApprovals(this.runtime, options);
   }
 
+  async removeQueuedMessage(itemId: string): Promise<RemoveQueuedMessageResult> {
+    if (typeof itemId !== "string" || itemId.trim().length === 0) {
+      throw new Error("Invalid queue item id. Expected a non-empty string.");
+    }
+    if (!this.initialized) {
+      await this.initialize();
+    }
+    if (!this.controller || !this.runtime) {
+      throw new Error("Session is not initialized");
+    }
+
+    const response = await this.controller.request(
+      "remove_queue_item",
+      {
+        runtime: this.runtime,
+        item_id: itemId,
+      },
+      {
+        predicate: (message) =>
+          message.type === "remove_queue_item_response" &&
+          message.item_id === itemId,
+      },
+    );
+    if (typeof response.success !== "boolean") {
+      throw new Error("Invalid remove_queue_item_response from runtime");
+    }
+
+    return {
+      itemId:
+        typeof response.item_id === "string" ? response.item_id : itemId,
+      removed: response.success,
+    };
+  }
+
   async listMessages(options: ListMessagesOptions = {}): Promise<ListMessagesResult> {
     if (!this.initialized) {
       await this.initialize();
@@ -813,12 +849,7 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
   }
 
   async changeDeviceState(
-    updates: {
-      cwd?: string;
-      permissionMode?: LettaCodeClientSessionOptions["permissionMode"];
-      agentId?: string;
-      conversationId?: string;
-    },
+    updates: ChangeDeviceStateOptions,
   ): Promise<void> {
     if (!this.initialized) {
       await this.initialize();
@@ -832,8 +863,11 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
       const mode = mapPermissionMode(updates.permissionMode);
       if (mode !== undefined) payload.mode = mode;
     }
-    if (updates.agentId !== undefined) payload.agent_id = updates.agentId;
-    if (updates.conversationId !== undefined) payload.conversation_id = updates.conversationId;
+    if (Object.keys(payload).length === 0) {
+      throw new Error(
+        "Invalid device state update. Expected cwd or permissionMode.",
+      );
+    }
 
     this.controller.send({
       type: "change_device_state",

--- a/src/session.ts
+++ b/src/session.ts
@@ -27,10 +27,12 @@ import type {
   ListModelsResult,
   BootstrapStateOptions,
   BootstrapStateResult,
+  ChangeDeviceStateOptions,
   SDKStreamEventPayload,
   RunTurnOptions,
   RecoverPendingApprovalsOptions,
   RecoverPendingApprovalsResult,
+  RemoveQueuedMessageResult,
   SDKProtocolCommand,
   SDKProtocolMessage,
   SendCommandOptions,
@@ -1178,6 +1180,18 @@ export class Session implements AsyncDisposable {
   async updateModel(_update: string | UpdateModelOptions): Promise<UpdateModelResult> {
     throw new Error(
       "updateModel() is not supported by this session. Use a Cloud, Remote, or local agent session.",
+    );
+  }
+
+  async changeDeviceState(_updates: ChangeDeviceStateOptions): Promise<void> {
+    throw new Error(
+      "changeDeviceState() is not supported by the legacy stdio transport. Use a Cloud, Remote, or local app-server session.",
+    );
+  }
+
+  async removeQueuedMessage(_itemId: string): Promise<RemoveQueuedMessageResult> {
+    throw new Error(
+      "removeQueuedMessage() is not supported by the legacy stdio transport. Use a Cloud, Remote, or local app-server session.",
     );
   }
 

--- a/src/tests/advanced-session.ts
+++ b/src/tests/advanced-session.ts
@@ -1,9 +1,5 @@
 import type {
-  BootstrapStateOptions,
-  BootstrapStateResult,
   LettaCodeSession,
-  RecoverPendingApprovalsOptions,
-  RecoverPendingApprovalsResult,
   SDKInitMessage,
   SDKResultMessage,
   SendMessage,
@@ -12,17 +8,7 @@ import type {
 export type AdvancedSession = LettaCodeSession & {
   initialize(): Promise<SDKInitMessage>;
   runTurn(message: SendMessage): Promise<SDKResultMessage>;
-  recoverPendingApprovals(
-    options?: RecoverPendingApprovalsOptions,
-  ): Promise<RecoverPendingApprovalsResult>;
-  changeDeviceState(updates: {
-    cwd?: string;
-    permissionMode?: "standard" | "acceptEdits" | "unrestricted";
-    agentId?: string;
-    conversationId?: string;
-  }): Promise<void>;
   updateToolset(toolsetPreference: string): Promise<void>;
-  bootstrapState(options?: BootstrapStateOptions): Promise<BootstrapStateResult>;
 };
 
 export function asAdvanced(session: LettaCodeSession): AdvancedSession {

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -227,6 +227,17 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
     return;
   }
 
+  if (command.type === "remove_queue_item" && typeof command.request_id === "string") {
+    fakeControlSocket().serverMessage({
+      type: "remove_queue_item_response",
+      request_id: command.request_id,
+      runtime: command.runtime,
+      success: command.item_id !== "missing-item",
+      item_id: command.item_id,
+    });
+    return;
+  }
+
   if (command.type === "abort_message" && typeof command.request_id === "string") {
     fakeControlSocket().serverMessage({
       type: "abort_message_response",
@@ -1504,7 +1515,7 @@ describe("LettaAgentClient", () => {
         toolset_preference: "developer",
       });
 
-      await asAdvanced(session).changeDeviceState({ cwd: "/workspace/method" });
+      await session.changeDeviceState({ cwd: "/workspace/method" });
       const cwdOnlyDeviceState = fakeControlSocket().sent.at(-1) as {
         payload?: Record<string, unknown>;
       };
@@ -1515,12 +1526,15 @@ describe("LettaAgentClient", () => {
       });
       expect(cwdOnlyDeviceState.payload).not.toHaveProperty("mode");
 
-      await asAdvanced(session).changeDeviceState({ permissionMode: "unrestricted" });
+      await session.changeDeviceState({ permissionMode: "unrestricted" });
       expect(fakeControlSocket().sent.at(-1)).toMatchObject({
         type: "change_device_state",
         runtime: { agent_id: "agent-123", conversation_id: "default" },
         payload: { mode: "unrestricted" },
       });
+      await expect(session.changeDeviceState({})).rejects.toThrow(
+        "Expected cwd or permissionMode",
+      );
 
       await session.sendCommand({
         type: "change_device_state",
@@ -1543,7 +1557,7 @@ describe("LettaAgentClient", () => {
       );
       expect(syncResponse.success).toBe(true);
 
-      await expect(asAdvanced(session).recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
+      await expect(session.recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
         recovered: true,
         unsupported: false,
       });
@@ -1553,6 +1567,24 @@ describe("LettaAgentClient", () => {
         recover_approvals: true,
         force_device_status: true,
       });
+
+      await expect(session.removeQueuedMessage("queue-1")).resolves.toEqual({
+        itemId: "queue-1",
+        removed: true,
+      });
+      expect(fakeControlSocket().sent.at(-1)).toMatchObject({
+        type: "remove_queue_item",
+        runtime: { agent_id: "agent-123", conversation_id: "default" },
+        item_id: "queue-1",
+      });
+
+      await expect(session.removeQueuedMessage("missing-item")).resolves.toEqual({
+        itemId: "missing-item",
+        removed: false,
+      });
+      await expect(session.removeQueuedMessage("  ")).rejects.toThrow(
+        "Invalid queue item id",
+      );
     } finally {
       session.close();
     }

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -952,7 +952,7 @@ describe("CloudEnvironmentSession", () => {
       toolset_preference: "developer",
     }));
 
-    await expect(asAdvanced(session).recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
+    await expect(session.recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
       recovered: true,
       unsupported: false,
     });
@@ -1064,7 +1064,7 @@ describe("CloudEnvironmentSession", () => {
     const session = client.resumeSession("agent-1");
     try {
       await asAdvanced(session).initialize();
-      await expect(asAdvanced(session).recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
+      await expect(session.recoverPendingApprovals({ timeoutMs: 1_000 })).resolves.toEqual({
         recovered: false,
         unsupported: false,
         detail: "sync failed",
@@ -1236,7 +1236,7 @@ describe("CloudEnvironmentSession", () => {
 
     const session = client.resumeSession("conv-1");
     try {
-      const state = await asAdvanced(session).bootstrapState({ limit: 3 });
+      const state = await session.bootstrapState({ limit: 3 });
       expect(state).toMatchObject({
         agentId: "agent-from-conv",
         conversationId: "conv-1",

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -666,7 +666,7 @@ describeLive("live integration: letta-agent-sdk", () => {
         log(`Session initialized for stuck agent, conversationId: ${init.conversationId}`);
 
         // Attempt recovery - the agent has a pending approval from a Bash tool call
-        const recovery = await asAdvanced(session).recoverPendingApprovals({ timeoutMs: 30000 });
+        const recovery = await session.recoverPendingApprovals({ timeoutMs: 30000 });
         log("Recovery result:", recovery);
 
         // The recovery should either succeed (recovered=true) or report that
@@ -695,7 +695,7 @@ describeLive("live integration: letta-agent-sdk", () => {
               stopReason: result.stopReason,
               errorCode: result.errorCode,
             });
-            const followupRecovery = await asAdvanced(session).recoverPendingApprovals({ timeoutMs: 30000 });
+            const followupRecovery = await session.recoverPendingApprovals({ timeoutMs: 30000 });
             log("Post-recovery approval cleanup result", followupRecovery);
           } else if (result.success) {
             log("Post-recovery turn succeeded");

--- a/src/tests/public-session-types.test.ts
+++ b/src/tests/public-session-types.test.ts
@@ -12,12 +12,14 @@ type _HasSendCommand = AssertTrue<HasKey<"sendCommand">>;
 type _HasListMessages = AssertTrue<HasKey<"listMessages">>;
 type _HasListModels = AssertTrue<HasKey<"listModels">>;
 type _HasUpdateModel = AssertTrue<HasKey<"updateModel">>;
+type _HasBootstrapState = AssertTrue<HasKey<"bootstrapState">>;
+type _HasRecoverPendingApprovals = AssertTrue<HasKey<"recoverPendingApprovals">>;
+type _HasChangeDeviceState = AssertTrue<HasKey<"changeDeviceState">>;
+type _HasRemoveQueuedMessage = AssertTrue<HasKey<"removeQueuedMessage">>;
 type _HasClose = AssertTrue<HasKey<"close">>;
 type _NoInitialize = AssertFalse<HasKey<"initialize">>;
 type _NoRunTurn = AssertFalse<HasKey<"runTurn">>;
-type _NoRecoverPendingApprovals = AssertFalse<HasKey<"recoverPendingApprovals">>;
 type _NoUpdateToolset = AssertFalse<HasKey<"updateToolset">>;
-type _NoBootstrapState = AssertFalse<HasKey<"bootstrapState">>;
 
 describe("public LettaCodeSession type", () => {
   test("keeps the canonical public session surface", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -742,10 +742,46 @@ export interface LettaCodeSession extends AsyncDisposable {
   listMessages(options?: ListMessagesOptions): Promise<ListMessagesResult>;
   listModels(): Promise<ListModelsResult>;
   updateModel(update: string | UpdateModelOptions): Promise<UpdateModelResult>;
+  /**
+   * Fetch the initial conversation projection used to hydrate or reconcile a
+   * resumed session.
+   */
+  bootstrapState(options?: BootstrapStateOptions): Promise<BootstrapStateResult>;
+  /**
+   * Ask the runtime to recover any approval that was pending across a
+   * disconnect.
+   */
+  recoverPendingApprovals(
+    options?: RecoverPendingApprovalsOptions,
+  ): Promise<RecoverPendingApprovalsResult>;
+  /**
+   * Update runtime controls for subsequent work in this conversation.
+   *
+   * The current app-server protocol does not acknowledge this command. The
+   * promise confirms that the command was accepted for transport, not that the
+   * runtime has applied it.
+   */
+  changeDeviceState(updates: ChangeDeviceStateOptions): Promise<void>;
+  /**
+   * Remove one queued user message and wait for the runtime acknowledgement.
+   */
+  removeQueuedMessage(itemId: string): Promise<RemoveQueuedMessageResult>;
   close(): void;
   readonly agentId: string | null;
   readonly sessionId: string | null;
   readonly conversationId: string | null;
+}
+
+export interface ChangeDeviceStateOptions {
+  cwd?: string;
+  permissionMode?: PermissionMode;
+}
+
+export interface RemoveQueuedMessageResult {
+  /** Queue item identifier echoed by the runtime. */
+  itemId: string;
+  /** False when the item was no longer present in the authoritative queue. */
+  removed: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- promote bootstrap reconciliation, approval recovery, and runtime cwd/permission controls onto the public `LettaCodeSession` interface
- add acknowledged `removeQueuedMessage(itemId)` queue mutation without requiring consumers to use raw protocol commands
- keep the legacy stdio transport explicit about unsupported interactive controls
- document acknowledgement semantics and exercise the public surface across Remote and Cloud tests

This closes the portable session-control gap identified while scoping the Expo mobile reference app (LET-10209). It complements the management namespaces added in #206.

## API notes

- `changeDeviceState()` intentionally exposes only `cwd` and `permissionMode`; agent/conversation routing remains session-owned. The current protocol does not acknowledge this command, so the promise confirms transport only.
- `removeQueuedMessage()` waits for `remove_queue_item_response` and returns `{ itemId, removed }`; `removed: false` means the authoritative queue no longer contained the item.

## Verification

- `bun run check`
- `bun test` (238 pass, 10 live-integration skips)
- `bun run build`

Authored by GPT-5.6 Sol.