### PR TITLE
fix: cloud createAgent 404s on production (trailing-slash route)

### DIFF
--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -643,8 +643,10 @@ export async function createCloudAgent(
 ): Promise<string> {
   const body = await createAgentBody(agentOptions);
 
+  // No trailing slash: production api.letta.com 404s `POST /v1/agents/` at
+  // the router (GET tolerates the slash; POST does not).
   const response = await getFetch(clientOptions.fetch)(
-    `${normalizeCloudApiBaseUrl(clientOptions.apiBaseUrl)}/v1/agents/`,
+    `${normalizeCloudApiBaseUrl(clientOptions.apiBaseUrl)}/v1/agents`,
     {
       method: "POST",
       headers: cloudHeaders(clientOptions),

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -69,7 +69,8 @@ function createCloudFetchMock(
       body: bodyOf(init),
     });
 
-    if (parsed.pathname === "/v1/agents/" && method === "POST") {
+    // Mirrors production routing: `POST /v1/agents/` (trailing slash) 404s.
+    if (parsed.pathname === "/v1/agents" && method === "POST") {
       return Promise.resolve(jsonResponse({ id: "agent-created" }));
     }
 
@@ -1315,7 +1316,8 @@ describe("CloudEnvironmentSession", () => {
 
     expect(requests).toHaveLength(1);
     expect(requests[0]).toMatchObject({
-      url: "https://api.test/v1/agents/",
+      // No trailing slash — production 404s `POST /v1/agents/`.
+      url: "https://api.test/v1/agents",
       method: "POST",
       headers: {
         authorization: "Bearer sk-test",

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { createAgent, createSession, resumeSession } from "../index.js";
+import { LettaAgentClient, createAgent, createSession, resumeSession } from "../index.js";
 import { asAdvanced } from "./advanced-session.js";
 import type {
   SDKMessage,
@@ -341,6 +341,35 @@ describeLive("live integration: letta-agent-sdk", () => {
         selectedAgentName,
         init,
       });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "cloud createAgent uses a route production accepts",
+    async () => {
+      // Guards the REST create path against server routing drift: production
+      // 404s `POST /v1/agents/` (trailing slash) while accepting
+      // `POST /v1/agents` — a mocked fetch cannot catch this class of bug.
+      const client = new LettaAgentClient({
+        backend: "cloud",
+        apiKey: API_KEY!,
+        apiBaseUrl: BASE_URL,
+      });
+      const createdAgentId = await client.createAgent({
+        name: `sdk-cloud-route-test-${Date.now()}`,
+        model: "anthropic/claude-haiku-4-5",
+        tags: ["sdk-live-test"],
+        memfs: false,
+      });
+      try {
+        expect(createdAgentId.startsWith("agent-")).toBe(true);
+      } finally {
+        await fetch(`${BASE_URL}/v1/agents/${createdAgentId}`, {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${API_KEY}` },
+        });
+      }
     },
     TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
## Summary

- `createCloudAgent` POSTs `${apiBaseUrl}/v1/agents/` — production api.letta.com 404s the trailing-slash form at the router (generic `{"error":"Not Found"}"), while `POST /v1/agents` reaches the handler. GET tolerates the slash; POST does not. Every cloud `createAgent()` on main is broken against production since #202 (not yet in an npm release — 0.2.7 predates the merge).
- Drops the slash, updates the unit test **and the fetch mock** (which itself encoded the buggy route — the reason CI couldn't catch this), and adds a live-integration route guard that creates + deletes a real agent, gated by `LETTA_LIVE_INTEGRATION=1`.

Found while building the Expo mobile reference app (LET-10209); repro details in that repo's SDK-FEEDBACK.md.

## Verification

- `bun test` — 249 pass
- `bun run check` / `bun run build`
- New live test green against production: create → id assert → cleanup delete
- Direct curl evidence: `POST /v1/agents/` → 404; `POST /v1/agents` → handler (422/200 by payload)

## Note for the server side

The production router's slash handling is inconsistent (`GET /v1/agents/` 200, `POST /v1/conversations/` 200, `PATCH /v1/agents/{id}/` 200 — only `POST /v1/agents/` 404s). This client fix is correct regardless, but a letta-cloud routing normalization is being looked at separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)