### PR TITLE
feat: pass approval context through canUseTool

### DIFF
--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -11,6 +11,7 @@ import {
   LETTA_CODE_ORIGIN_TAG,
 } from "@letta-ai/letta-code/agent-presets";
 import {
+  buildCanUseToolContext,
   isHeadlessAutoAllowTool,
   requiresRuntimeUserInput,
 } from "./interactiveToolPolicy.js";
@@ -29,6 +30,7 @@ import {
 } from "./remote-client-session-core.js";
 import type {
   AnyAgentTool,
+  CanUseToolContext,
   CanUseToolResponse,
   CreateAgentOptions,
   LettaCodeRemoteClientOptions,
@@ -352,6 +354,7 @@ export async function resolveAppServerToolApproval(
   options: AppServerApprovalOptions,
   toolName: string,
   toolInput: Record<string, unknown>,
+  context?: CanUseToolContext,
 ): Promise<CanUseToolResponse> {
   const hasCallback = typeof options.canUseTool === "function";
   const toolNeedsRuntimeUserInput = requiresRuntimeUserInput(toolName);
@@ -370,7 +373,7 @@ export async function resolveAppServerToolApproval(
 
   if (hasCallback) {
     try {
-      const result = await options.canUseTool!(toolName, toolInput);
+      const result = await options.canUseTool!(toolName, toolInput, context);
       if (result.behavior === "allow") {
         return {
           behavior: "allow",
@@ -560,7 +563,12 @@ async function respondToAppServerControlRequest(
     requestRecord.input && typeof requestRecord.input === "object" && !Array.isArray(requestRecord.input)
       ? (requestRecord.input as Record<string, unknown>)
       : {};
-  const decision = await resolveAppServerToolApproval(config.getOptions(), toolName, toolInput);
+  const decision = await resolveAppServerToolApproval(
+    config.getOptions(),
+    toolName,
+    toolInput,
+    buildCanUseToolContext(requestRecord, requestId),
+  );
   config.client.input({
     runtime,
     payload: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,8 @@ export type {
   PermissionMode,
   ReasoningEffort,
   CanUseToolCallback,
+  CanUseToolContext,
+  CanUseToolPermissionSuggestion,
   CanUseToolResponse,
   CanUseToolResponseAllow,
   CanUseToolResponseDeny,

--- a/src/interactiveToolPolicy.ts
+++ b/src/interactiveToolPolicy.ts
@@ -1,6 +1,8 @@
 // Interactive tool policy for SDK permission callbacks.
 // Centralizes behavior so transport/session logic doesn't hardcode names inline.
 
+import type { CanUseToolContext, CanUseToolPermissionSuggestion } from "./types.js";
+
 const INTERACTIVE_APPROVAL_TOOLS = new Set([
   "AskUserQuestion",
   "EnterPlanMode",
@@ -21,4 +23,40 @@ export function requiresRuntimeUserInput(toolName: string): boolean {
 
 export function isHeadlessAutoAllowTool(toolName: string): boolean {
   return HEADLESS_AUTO_ALLOW_TOOLS.has(toolName);
+}
+
+function normalizePermissionSuggestions(
+  value: unknown,
+): CanUseToolPermissionSuggestion[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const suggestions: CanUseToolPermissionSuggestion[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as Record<string, unknown>;
+    if (typeof record.id === "string" && typeof record.text === "string") {
+      suggestions.push({ id: record.id, text: record.text });
+    }
+  }
+  return suggestions;
+}
+
+/**
+ * Build the {@link CanUseToolContext} passed to canUseTool callbacks from a raw
+ * `can_use_tool` control request body. Fields absent from the wire request are
+ * left undefined so callbacks can distinguish "not provided" from empty values.
+ */
+export function buildCanUseToolContext(
+  request: Record<string, unknown>,
+  requestId?: string,
+): CanUseToolContext {
+  const context: CanUseToolContext = {};
+  if (typeof requestId === "string") context.requestId = requestId;
+  if (typeof request.tool_call_id === "string") context.toolCallId = request.tool_call_id;
+  const suggestions = normalizePermissionSuggestions(request.permission_suggestions);
+  if (suggestions !== undefined) context.permissionSuggestions = suggestions;
+  if (typeof request.blocked_path === "string" || request.blocked_path === null) {
+    context.blockedPath = request.blocked_path as string | null;
+  }
+  if (Array.isArray(request.diffs)) context.diffs = request.diffs as unknown[];
+  return context;
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -40,6 +40,7 @@ import type {
   UpdateModelResult,
 } from "./types.js";
 import {
+  buildCanUseToolContext,
   isHeadlessAutoAllowTool,
   requiresRuntimeUserInput,
 } from "./interactiveToolPolicy.js";
@@ -997,7 +998,11 @@ export class Session implements AsyncDisposable {
       } satisfies CanUseToolResponseAllow;
     } else if (hasCallback) {
       try {
-        const result = await this.options.canUseTool!(toolName, req.input);
+        const result = await this.options.canUseTool!(
+          toolName,
+          req.input,
+          buildCanUseToolContext(req as unknown as Record<string, unknown>, requestId),
+        );
         if (result.behavior === "allow") {
           response = {
             behavior: "allow",

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   CloudManagedSandboxExpiredError,
   LettaAgentClient,
+  type CanUseToolContext,
 } from "../index.js";
 import { asAdvanced } from "./advanced-session.js";
 
@@ -351,6 +352,12 @@ class FakeCloudSocket {
           subtype: "can_use_tool",
           tool_name: "Bash",
           input: { command: "pwd" },
+          tool_call_id: "toolu-approval-1",
+          permission_suggestions: [
+            { id: "suggestion-1", text: "Allow Bash(pwd) for this session" },
+          ],
+          blocked_path: null,
+          diffs: [{ mode: "fallback", fileName: "unused.txt", reason: "not a file edit" }],
         },
       });
       return;
@@ -1370,7 +1377,11 @@ describe("CloudEnvironmentSession", () => {
     resetFakeCloud();
     FakeCloudSocket.scenario = "approval";
     const requests: RecordedRequest[] = [];
-    const decisions: Array<{ toolName: string; input: Record<string, unknown> }> = [];
+    const decisions: Array<{
+      toolName: string;
+      input: Record<string, unknown>;
+      context: CanUseToolContext | undefined;
+    }> = [];
     const client = new LettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
@@ -1382,8 +1393,8 @@ describe("CloudEnvironmentSession", () => {
     });
 
     const session = client.resumeSession("agent-1", {
-      canUseTool: (toolName, input) => {
-        decisions.push({ toolName, input });
+      canUseTool: (toolName, input, context) => {
+        decisions.push({ toolName, input, context });
         return { behavior: "allow", updatedInput: { command: "echo approved" } };
       },
     });
@@ -1391,7 +1402,21 @@ describe("CloudEnvironmentSession", () => {
     const result = await asAdvanced(session).runTurn("run pwd");
 
     expect(result).toMatchObject({ success: true, result: "approved" });
-    expect(decisions).toEqual([{ toolName: "Bash", input: { command: "pwd" } }]);
+    expect(decisions).toEqual([
+      {
+        toolName: "Bash",
+        input: { command: "pwd" },
+        context: {
+          requestId: "approval-1",
+          toolCallId: "toolu-approval-1",
+          permissionSuggestions: [
+            { id: "suggestion-1", text: "Allow Bash(pwd) for this session" },
+          ],
+          blockedPath: null,
+          diffs: [{ mode: "fallback", fileName: "unused.txt", reason: "not a file edit" }],
+        },
+      },
+    ]);
     const approvalCommand = FakeCloudSocket.socket("control")!.sent.find((command) => {
       const payload = command.payload as Record<string, unknown> | undefined;
       return command.type === "input" && payload?.kind === "approval_response";
@@ -1407,6 +1432,36 @@ describe("CloudEnvironmentSession", () => {
         },
       },
     });
+
+    session.close();
+  });
+
+  test("legacy two-argument canUseTool callbacks still work for approval requests", async () => {
+    resetFakeCloud();
+    FakeCloudSocket.scenario = "approval";
+    const requests: RecordedRequest[] = [];
+    const decisions: Array<{ toolName: string; input: Record<string, unknown> }> = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      environment: { connectionId: "conn-explicit" },
+    });
+
+    const session = client.resumeSession("agent-1", {
+      canUseTool: (toolName, input) => {
+        decisions.push({ toolName, input });
+        return { behavior: "allow" };
+      },
+    });
+
+    const result = await asAdvanced(session).runTurn("run pwd");
+
+    expect(result).toMatchObject({ success: true, result: "approved" });
+    expect(decisions).toEqual([{ toolName: "Bash", input: { command: "pwd" } }]);
 
     session.close();
   });

--- a/src/tests/session.test.ts
+++ b/src/tests/session.test.ts
@@ -470,6 +470,46 @@ describe("Session", () => {
         },
       });
     });
+
+    test("passes approval context as third canUseTool argument", async () => {
+      const received: unknown[] = [];
+      const session = new Session({
+        permissionMode: "standard",
+        canUseTool: (toolName, toolInput, context) => {
+          received.push({ toolName, toolInput, context });
+          return { behavior: "allow" };
+        },
+      });
+
+      // @ts-expect-error - accessing private method for testing
+      const handleCanUseTool = session.handleCanUseTool.bind(session);
+      // @ts-expect-error - accessing private property for testing
+      session.transport.write = async () => {};
+
+      await handleCanUseTool("req-42", {
+        subtype: "can_use_tool",
+        tool_name: "Edit",
+        tool_call_id: "toolu-edit-1",
+        input: { file_path: "/tmp/a.txt" },
+        permission_suggestions: [{ id: "sugg-1", text: "Always allow edits in /tmp" }],
+        blocked_path: "/tmp/a.txt",
+        diffs: [{ mode: "fallback", fileName: "a.txt", reason: "test" }],
+      });
+
+      expect(received).toEqual([
+        {
+          toolName: "Edit",
+          toolInput: { file_path: "/tmp/a.txt" },
+          context: {
+            requestId: "req-42",
+            toolCallId: "toolu-edit-1",
+            permissionSuggestions: [{ id: "sugg-1", text: "Always allow edits in /tmp" }],
+            blockedPath: "/tmp/a.txt",
+            diffs: [{ mode: "fallback", fileName: "a.txt", reason: "test" }],
+          },
+        },
+      ]);
+    });
   });
 
   describe("transformMessage tool-call mapping", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -495,11 +495,49 @@ export interface GetRepositoryVersionParams {
 // ═══════════════════════════════════════════════════════════════
 
 /**
+ * A suggested permission grant attached to a `can_use_tool` approval request.
+ * Approval UIs can render these as selectable chips and echo the chosen ids
+ * back via `CanUseToolResponseAllow.updatedPermissions`.
+ */
+export interface CanUseToolPermissionSuggestion {
+  id: string;
+  text: string;
+}
+
+/**
+ * Additional context for a `can_use_tool` approval request, passed as the
+ * optional third argument to {@link CanUseToolCallback}.
+ *
+ * All fields are optional: transports pass through whatever subset the wire
+ * protocol provides, leaving absent fields undefined.
+ */
+export interface CanUseToolContext {
+  /** Id of the control request carrying this approval (for logging/correlation). */
+  requestId?: string;
+  /** Tool call id — links the approval to its tool_call card in the message stream. */
+  toolCallId?: string;
+  /** Suggested permission grants the user can select. */
+  permissionSuggestions?: CanUseToolPermissionSuggestion[];
+  /** Path that triggered the permission check, when the tool was blocked on a path rule. */
+  blockedPath?: string | null;
+  /**
+   * Diff previews for file-editing tools, passed through verbatim.
+   * Shape matches letta-code's `DiffPreview` (mode: "advanced" | "fallback" | "unpreviewable").
+   */
+  diffs?: unknown[];
+}
+
+/**
  * Callback for custom permission handling.
+ *
+ * The optional third argument carries approval context (tool call id,
+ * permission suggestions, diff previews). Two-argument callbacks remain
+ * fully supported.
  */
 export type CanUseToolCallback = (
   toolName: string,
   toolInput: Record<string, unknown>,
+  context?: CanUseToolContext,
 ) => Promise<CanUseToolResponse> | CanUseToolResponse;
 
 /**


### PR DESCRIPTION
## Motivation

The wire protocol's `can_use_tool` control request (`CanUseToolControlRequestBody` in letta-code's `protocol_v2`, mirrored in `src/protocol.ts`) carries `tool_call_id`, `permission_suggestions` (`{id, text}[]`), `blocked_path`, and optional `diffs` — but the SDK's `CanUseToolCallback` only received `(toolName, toolInput)`. Approval UIs need that context: suggestion chips, diff previews, and linking the approval to its tool card by `tool_call_id`. Found building the mobile reference app (LET-10209; letta-mobile SDK-FEEDBACK.md "API-surface gaps" item 5).

## What changed

New exported type (from both `src/index.ts` and `src/client-entry.ts`, alongside `CanUseToolPermissionSuggestion`):

```ts
export interface CanUseToolContext {
  requestId?: string;
  toolCallId?: string;
  permissionSuggestions?: CanUseToolPermissionSuggestion[]; // {id, text}
  blockedPath?: string | null;
  diffs?: unknown[]; // letta-code DiffPreview shape, passed through verbatim
}

export type CanUseToolCallback = (
  toolName: string,
  toolInput: Record<string, unknown>,
  context?: CanUseToolContext,
) => Promise<CanUseToolResponse> | CanUseToolResponse;
```

A shared `buildCanUseToolContext()` normalizer lives in `src/interactiveToolPolicy.ts`; fields absent from the wire request stay `undefined`.

## Backwards compatibility

Adding an optional parameter to a function *type* is non-breaking in TypeScript: a two-argument callback is still assignable to the three-argument type. Verified both by compilation of the existing two-arg callbacks in the test suite and by a new test that runs a legacy two-arg callback through the approval flow end to end.

## Dispatch sites threaded

- **App-server / cloud control requests** — `respondToAppServerControlRequest()` → `resolveAppServerToolApproval()` in `src/app-server-session.ts`. This one handler is registered by both the remote app-server session (`app-server-session.ts`) and the cloud session (`cloud-session.ts`), so both backends get context.
- **Legacy stdio path** — `Session.handleCanUseTool()` in `src/session.ts`, passing whatever subset the stdio protocol provides.

These are the only two places `options.canUseTool` is invoked (verified by grep for `canUseTool` / `can_use_tool` across `src/`).

## Tests

- `cloud-session.test.ts`: the fake cloud socket's approval request now includes `tool_call_id`, `permission_suggestions`, `blocked_path`, and `diffs`; the existing approval test asserts the third argument arrives with camelCase mapping, and a new test covers a legacy two-argument callback end to end.
- `session.test.ts`: new stdio-path test asserting the full context (including `requestId`) reaches the callback.

## Verification

- `bun run check` — clean
- `bun test` — 240 pass, 11 skip, 0 fail
- `bun run build` — clean; confirmed `CanUseToolContext` is exported from both built entrypoints and that a two-arg callback remains assignable, via a standalone `tsc --strict` probe against `dist/`
- No live end-to-end run: exercising a real approval requires a tool-invoking turn against a live backend, which wasn't done here. Coverage is unit/contract-level via the fake cloud socket and direct `handleCanUseTool` invocation.

README doesn't document the `canUseTool` signature, so no doc changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)