### PR TITLE
feat: agents.delete and session-less models.list

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ const conversations = await client.conversations.list({
 });
 
 // No open session required — safe for model pickers and settings screens.
-const models = await client.models.list();
+const { entries: models, availableHandles } = await client.models.list();
 
 await client.agents.delete(agents[0].id);
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For authenticated Remote App Servers in React Native, pass the platform WebSocke
 
 ## Management APIs
 
-The client exposes agent, conversation, and Cloud repository management alongside active sessions:
+The client exposes agent, conversation, model, and Cloud repository management alongside active sessions:
 
 ```ts
 const agents = await client.agents.list({ tags: ["support"] });
@@ -124,6 +124,11 @@ const conversations = await client.conversations.list({
   orderBy: "lastMessageAt",
   order: "desc",
 });
+
+// No open session required — safe for model pickers and settings screens.
+const models = await client.models.list();
+
+await client.agents.delete(agents[0].id);
 
 const repository = await client.repositories.create({ name: "inputs" });
 await client.repositories.files.create(repository.id, {

--- a/src/app-server-management.ts
+++ b/src/app-server-management.ts
@@ -12,9 +12,12 @@ import type {
   ConversationMessagesResult,
   LettaAgent,
   LettaConversation,
-  LettaModelEntry,
 } from "./management-types.js";
-import type { LettaCodeRemoteClientOptions } from "./types.js";
+import type {
+  LettaCodeModelEntry,
+  LettaCodeRemoteClientOptions,
+  ListModelsResult,
+} from "./types.js";
 
 type OwnedConnection = { url: string; close(): void };
 
@@ -44,18 +47,10 @@ type ConversationMessagesResponse = ManagementResponse & {
   messages: Record<string, unknown>[];
 };
 
-type ListModelsEntry = Record<string, unknown> & {
-  id: string;
-  handle: string;
-  label: string;
-  description: string;
-  isDefault?: boolean;
-  isFeatured?: boolean;
-  free?: boolean;
-};
-
 type ListModelsResponse = ManagementResponse & {
-  entries: ListModelsEntry[];
+  entries?: unknown;
+  available_handles?: unknown;
+  byok_provider_aliases?: unknown;
 };
 
 export type AppServerManagementOptions =
@@ -73,6 +68,39 @@ function ensureResponse<T>(
     throw new Error(response.error ?? fallback);
   }
   return value;
+}
+
+function modelEntries(value: unknown): LettaCodeModelEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const record = entry as Record<string, unknown>;
+    if (
+      typeof record.id !== "string" ||
+      typeof record.handle !== "string" ||
+      typeof record.label !== "string" ||
+      typeof record.description !== "string"
+    ) {
+      return [];
+    }
+    return [{
+      ...record,
+      id: record.id,
+      handle: record.handle,
+      label: record.label,
+      description: record.description,
+    }];
+  });
+}
+
+function stringRecord(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 export class AppServerManagementTransport
@@ -132,7 +160,7 @@ export class AppServerManagementTransport
     }
   }
 
-  async listModels(): Promise<LettaModelEntry[]> {
+  async listModels(): Promise<ListModelsResult> {
     // A bare list_models command (no runtime scope) is answered on the
     // control channel, so no session or conversation is required.
     const response = await this.request<ListModelsResponse>(
@@ -143,10 +171,19 @@ export class AppServerManagementTransport
     if (!response.success) {
       throw new Error(response.error ?? "Failed to list models.");
     }
-    return response.entries.map((entry) => ({
-      ...entry,
-      displayName: entry.label,
-    }));
+    const result: ListModelsResult = {
+      entries: modelEntries(response.entries),
+    };
+    if (response.available_handles === null) {
+      result.availableHandles = null;
+    } else if (Array.isArray(response.available_handles)) {
+      result.availableHandles = response.available_handles.filter(
+        (handle): handle is string => typeof handle === "string",
+      );
+    }
+    const aliases = stringRecord(response.byok_provider_aliases);
+    if (aliases) result.byokProviderAliases = aliases;
+    return result;
   }
 
   async listConversations(

--- a/src/app-server-management.ts
+++ b/src/app-server-management.ts
@@ -12,6 +12,7 @@ import type {
   ConversationMessagesResult,
   LettaAgent,
   LettaConversation,
+  LettaModelEntry,
 } from "./management-types.js";
 import type { LettaCodeRemoteClientOptions } from "./types.js";
 
@@ -41,6 +42,20 @@ type ConversationResponse = ManagementResponse & {
 
 type ConversationMessagesResponse = ManagementResponse & {
   messages: Record<string, unknown>[];
+};
+
+type ListModelsEntry = Record<string, unknown> & {
+  id: string;
+  handle: string;
+  label: string;
+  description: string;
+  isDefault?: boolean;
+  isFeatured?: boolean;
+  free?: boolean;
+};
+
+type ListModelsResponse = ManagementResponse & {
+  entries: ListModelsEntry[];
 };
 
 export type AppServerManagementOptions =
@@ -104,6 +119,34 @@ export class AppServerManagementTransport
       response.agent,
       `Failed to update agent ${agentId}.`,
     );
+  }
+
+  async deleteAgent(agentId: string): Promise<void> {
+    const response = await this.request<ManagementResponse>(
+      "agent_delete",
+      { agent_id: agentId },
+      "agent_delete_response",
+    );
+    if (!response.success) {
+      throw new Error(response.error ?? `Failed to delete agent ${agentId}.`);
+    }
+  }
+
+  async listModels(): Promise<LettaModelEntry[]> {
+    // A bare list_models command (no runtime scope) is answered on the
+    // control channel, so no session or conversation is required.
+    const response = await this.request<ListModelsResponse>(
+      "list_models",
+      {},
+      "list_models_response",
+    );
+    if (!response.success) {
+      throw new Error(response.error ?? "Failed to list models.");
+    }
+    return response.entries.map((entry) => ({
+      ...entry,
+      displayName: entry.label,
+    }));
   }
 
   async listConversations(

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -14,11 +14,13 @@ import {
 import {
   createAgentsClient,
   createConversationsClient,
+  createModelsClient,
   type ManagementTransport,
 } from "./management.js";
 import type {
   AgentsClient,
   ConversationsClient,
+  ModelsClient,
 } from "./management-types.js";
 import type {
   CreateAgentOptions,
@@ -98,6 +100,7 @@ export class LettaAgentClientBase {
   readonly environment: LettaCodeEnvironment | undefined;
   readonly agents: AgentsClient;
   readonly conversations: ConversationsClient;
+  readonly models: ModelsClient;
   protected readonly options: LettaCodeClientOptions;
   private repositoriesClient: RepositoriesClient | null = null;
   private managementTransport: ManagementTransport | null = null;
@@ -117,6 +120,7 @@ export class LettaAgentClientBase {
     this.conversations = createConversationsClient(
       () => this.getManagementTransport(),
     );
+    this.models = createModelsClient(() => this.getManagementTransport());
 
     if (this.backend === "local" && this.environment !== undefined) {
       throw new Error(

--- a/src/cloud-management.ts
+++ b/src/cloud-management.ts
@@ -6,9 +6,12 @@ import type {
   ConversationMessagesResult,
   LettaAgent,
   LettaConversation,
-  LettaModelEntry,
 } from "./management-types.js";
-import type { LettaCodeCloudClientOptions } from "./types.js";
+import type {
+  LettaCodeCloudClientOptions,
+  LettaCodeModelEntry,
+  ListModelsResult,
+} from "./types.js";
 
 const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
 
@@ -122,14 +125,29 @@ function asArray<T>(body: unknown, action: string): T[] {
   return body as T[];
 }
 
-function cloudModelEntry(raw: Record<string, unknown>): LettaModelEntry {
+function cloudModelEntry(
+  raw: Record<string, unknown>,
+): LettaCodeModelEntry | null {
+  if (typeof raw.handle !== "string" || raw.handle.length === 0) {
+    return null;
+  }
+  const label =
+    typeof raw.display_name === "string"
+      ? raw.display_name
+      : typeof raw.name === "string"
+        ? raw.name
+        : raw.handle;
   return {
     ...raw,
-    handle: String(raw.handle ?? ""),
-    ...(typeof raw.display_name === "string"
-      ? { displayName: raw.display_name }
-      : {}),
-  } as LettaModelEntry;
+    id:
+      typeof raw.id === "string" && raw.id.length > 0
+        ? raw.id
+        : raw.handle,
+    handle: raw.handle,
+    label,
+    description:
+      typeof raw.description === "string" ? raw.description : "",
+  };
 }
 
 export class CloudManagementTransport implements ManagementTransport {
@@ -171,7 +189,7 @@ export class CloudManagementTransport implements ManagementTransport {
     );
   }
 
-  async listModels(): Promise<LettaModelEntry[]> {
+  async listModels(): Promise<ListModelsResult> {
     // No trailing slash for consistency with the non-GET routes above (the
     // production router only tolerates trailing slashes on GET).
     const entries = await this.getArray<Record<string, unknown>>(
@@ -179,7 +197,16 @@ export class CloudManagementTransport implements ManagementTransport {
       {},
       "Cloud list models",
     );
-    return entries.map(cloudModelEntry);
+    const normalized = entries.flatMap((entry) => {
+      const model = cloudModelEntry(entry);
+      return model ? [model] : [];
+    });
+    return {
+      entries: normalized,
+      // Cloud's authenticated endpoint already returns the models available to
+      // this user, so its catalog is also the authoritative availability set.
+      availableHandles: normalized.map((entry) => entry.handle),
+    };
   }
 
   listConversations(

--- a/src/cloud-management.ts
+++ b/src/cloud-management.ts
@@ -6,6 +6,7 @@ import type {
   ConversationMessagesResult,
   LettaAgent,
   LettaConversation,
+  LettaModelEntry,
 } from "./management-types.js";
 import type { LettaCodeCloudClientOptions } from "./types.js";
 
@@ -121,6 +122,16 @@ function asArray<T>(body: unknown, action: string): T[] {
   return body as T[];
 }
 
+function cloudModelEntry(raw: Record<string, unknown>): LettaModelEntry {
+  return {
+    ...raw,
+    handle: String(raw.handle ?? ""),
+    ...(typeof raw.display_name === "string"
+      ? { displayName: raw.display_name }
+      : {}),
+  } as LettaModelEntry;
+}
+
 export class CloudManagementTransport implements ManagementTransport {
   constructor(private readonly options: LettaCodeCloudClientOptions) {}
 
@@ -146,6 +157,29 @@ export class CloudManagementTransport implements ManagementTransport {
       body,
       "Cloud update agent",
     );
+  }
+
+  async deleteAgent(agentId: string): Promise<void> {
+    // No trailing slash: the production api.letta.com router 404s
+    // trailing-slash non-GET agent routes (see `POST /v1/agents` in
+    // cloud-session.ts — GET tolerates the slash; DELETE does not).
+    await this.requestUrl(
+      this.url(`/v1/agents/${encodeURIComponent(agentId)}`),
+      "DELETE",
+      undefined,
+      "Cloud delete agent",
+    );
+  }
+
+  async listModels(): Promise<LettaModelEntry[]> {
+    // No trailing slash for consistency with the non-GET routes above (the
+    // production router only tolerates trailing slashes on GET).
+    const entries = await this.getArray<Record<string, unknown>>(
+      "/v1/models",
+      {},
+      "Cloud list models",
+    );
+    return entries.map(cloudModelEntry);
   }
 
   listConversations(

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,6 @@ export type {
   LettaAgent,
   LettaConversation,
   LettaConversationMessage,
-  LettaModelEntry,
   ModelsClient,
   ListAgentsOptions,
   UpdateAgentOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,8 @@ export type {
   LettaAgent,
   LettaConversation,
   LettaConversationMessage,
+  LettaModelEntry,
+  ModelsClient,
   ListAgentsOptions,
   UpdateAgentOptions,
   ListConversationsOptions,

--- a/src/management-types.ts
+++ b/src/management-types.ts
@@ -1,4 +1,4 @@
-import type { ListMessagesResult } from "./types.js";
+import type { ListMessagesResult, ListModelsResult } from "./types.js";
 
 /** Agent state returned by either the Cloud API or Letta Code app-server. */
 export type LettaAgent = Record<string, unknown> & {
@@ -28,34 +28,6 @@ export type LettaConversation = Record<string, unknown> & {
 
 /** Raw Letta API message returned from conversation history. */
 export type LettaConversationMessage = Record<string, unknown>;
-
-/**
- * Model entry unified across backends.
- *
- * The Cloud API (`GET /v1/models`) provides `handle`, `name`, and
- * `display_name` (surfaced here as `displayName`). The app-server
- * `list_models` command provides `id`, `handle`, `label` (surfaced here as
- * `displayName`), `description`, and the optional flags. Only `handle` is
- * guaranteed by every backend; raw backend fields are preserved on the entry.
- */
-export type LettaModelEntry = Record<string, unknown> & {
-  /** Internal model id (app-server backends only). */
-  id?: string;
-  /** Provider-qualified handle, e.g. "anthropic/claude-haiku-4-5". */
-  handle: string;
-  /** Raw model name (Cloud backend only). */
-  name?: string;
-  /** Human-readable name (Cloud `display_name` / app-server `label`). */
-  displayName?: string;
-  /** Model description (app-server backends only). */
-  description?: string;
-  /** Whether this is the default model (app-server backends only). */
-  isDefault?: boolean;
-  /** Whether this model is featured (app-server backends only). */
-  isFeatured?: boolean;
-  /** Whether this model is free to use (app-server backends only). */
-  free?: boolean;
-};
 
 export interface ListAgentsOptions {
   before?: string;
@@ -135,8 +107,13 @@ export interface AgentsClient {
 }
 
 export interface ModelsClient {
-  /** List available models. Does not require an open session. */
-  list(): Promise<LettaModelEntry[]>;
+  /**
+   * List the model catalog without opening a session.
+   *
+   * Uses the same normalized result shape as `session.listModels()`, including
+   * availability and BYOK-alias metadata when the backend provides it.
+   */
+  list(): Promise<ListModelsResult>;
 }
 
 export interface ConversationsClient {

--- a/src/management-types.ts
+++ b/src/management-types.ts
@@ -29,6 +29,34 @@ export type LettaConversation = Record<string, unknown> & {
 /** Raw Letta API message returned from conversation history. */
 export type LettaConversationMessage = Record<string, unknown>;
 
+/**
+ * Model entry unified across backends.
+ *
+ * The Cloud API (`GET /v1/models`) provides `handle`, `name`, and
+ * `display_name` (surfaced here as `displayName`). The app-server
+ * `list_models` command provides `id`, `handle`, `label` (surfaced here as
+ * `displayName`), `description`, and the optional flags. Only `handle` is
+ * guaranteed by every backend; raw backend fields are preserved on the entry.
+ */
+export type LettaModelEntry = Record<string, unknown> & {
+  /** Internal model id (app-server backends only). */
+  id?: string;
+  /** Provider-qualified handle, e.g. "anthropic/claude-haiku-4-5". */
+  handle: string;
+  /** Raw model name (Cloud backend only). */
+  name?: string;
+  /** Human-readable name (Cloud `display_name` / app-server `label`). */
+  displayName?: string;
+  /** Model description (app-server backends only). */
+  description?: string;
+  /** Whether this is the default model (app-server backends only). */
+  isDefault?: boolean;
+  /** Whether this model is featured (app-server backends only). */
+  isFeatured?: boolean;
+  /** Whether this model is free to use (app-server backends only). */
+  free?: boolean;
+};
+
 export interface ListAgentsOptions {
   before?: string;
   after?: string;
@@ -103,6 +131,12 @@ export interface AgentsClient {
     agentId: string,
     options: UpdateAgentOptions,
   ): Promise<LettaAgent>;
+  delete(agentId: string): Promise<void>;
+}
+
+export interface ModelsClient {
+  /** List available models. Does not require an open session. */
+  list(): Promise<LettaModelEntry[]>;
 }
 
 export interface ConversationsClient {

--- a/src/management.ts
+++ b/src/management.ts
@@ -5,7 +5,6 @@ import type {
   CreateConversationOptions,
   LettaAgent,
   LettaConversation,
-  LettaModelEntry,
   ListAgentsOptions,
   ListConversationsOptions,
   ModelsClient,
@@ -13,6 +12,7 @@ import type {
   UpdateConversationOptions,
   ConversationMessagesOptions,
 } from "./management-types.js";
+import type { ListModelsResult } from "./types.js";
 
 export type ManagementQuery = Record<
   string,
@@ -27,7 +27,7 @@ export interface ManagementTransport {
     body: Record<string, unknown>,
   ): Promise<LettaAgent>;
   deleteAgent(agentId: string): Promise<void>;
-  listModels(): Promise<LettaModelEntry[]>;
+  listModels(): Promise<ListModelsResult>;
   listConversations(
     query: ManagementQuery,
   ): Promise<LettaConversation[]>;
@@ -55,6 +55,12 @@ function definedEntries(
   return Object.fromEntries(
     Object.entries(values).filter(([, value]) => value !== undefined),
   );
+}
+
+function assertNonEmptyId(value: string, name: string): void {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Invalid ${name}. Expected a non-empty string.`);
+  }
 }
 
 function agentListQuery(options: ListAgentsOptions): ManagementQuery {
@@ -154,7 +160,10 @@ export function createAgentsClient(
     retrieve: (agentId) => transport().retrieveAgent(agentId),
     update: (agentId, options) =>
       transport().updateAgent(agentId, agentUpdateBody(options)),
-    delete: (agentId) => transport().deleteAgent(agentId),
+    delete: async (agentId) => {
+      assertNonEmptyId(agentId, "agent id");
+      await transport().deleteAgent(agentId);
+    },
   };
 }
 

--- a/src/management.ts
+++ b/src/management.ts
@@ -5,8 +5,10 @@ import type {
   CreateConversationOptions,
   LettaAgent,
   LettaConversation,
+  LettaModelEntry,
   ListAgentsOptions,
   ListConversationsOptions,
+  ModelsClient,
   UpdateAgentOptions,
   UpdateConversationOptions,
   ConversationMessagesOptions,
@@ -24,6 +26,8 @@ export interface ManagementTransport {
     agentId: string,
     body: Record<string, unknown>,
   ): Promise<LettaAgent>;
+  deleteAgent(agentId: string): Promise<void>;
+  listModels(): Promise<LettaModelEntry[]>;
   listConversations(
     query: ManagementQuery,
   ): Promise<LettaConversation[]>;
@@ -150,6 +154,15 @@ export function createAgentsClient(
     retrieve: (agentId) => transport().retrieveAgent(agentId),
     update: (agentId, options) =>
       transport().updateAgent(agentId, agentUpdateBody(options)),
+    delete: (agentId) => transport().deleteAgent(agentId),
+  };
+}
+
+export function createModelsClient(
+  transport: TransportProvider,
+): ModelsClient {
+  return {
+    list: () => transport().listModels(),
   };
 }
 

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -45,6 +45,19 @@ function createManagementFetch(
     if (url.pathname === "/v1/agents/agent-1" && method === "PATCH") {
       return jsonResponse({ id: "agent-1", name: "Renamed", ...body as object });
     }
+    if (url.pathname === "/v1/agents/agent-1" && method === "DELETE") {
+      return new Response(null, { status: 204 });
+    }
+    if (url.pathname === "/v1/models" && method === "GET") {
+      return jsonResponse([
+        {
+          handle: "anthropic/claude-haiku-4-5",
+          name: "claude-haiku-4-5",
+          display_name: "Claude Haiku 4.5",
+          context_window: 200_000,
+        },
+      ]);
+    }
     if (url.pathname === "/v1/conversations/" && method === "GET") {
       return jsonResponse([
         { id: "conv-1", agent_id: "agent-1", summary: "First" },
@@ -139,6 +152,20 @@ class ManagementSocket {
           ...(command.body as object),
         },
       },
+      agent_delete: {
+        agent_id: command.agent_id,
+      },
+      list_models: {
+        entries: [
+          {
+            id: "claude-haiku-4-5",
+            handle: "anthropic/claude-haiku-4-5",
+            label: "Claude Haiku 4.5",
+            description: "Fast everyday model.",
+            isDefault: true,
+          },
+        ],
+      },
       conversation_list: {
         conversations: [
           { id: "conv-1", agent_id: "agent-1", summary: "First" },
@@ -209,6 +236,14 @@ async function exerciseManagementApi(
       contextWindowLimit: 32_000,
     }),
   ).resolves.toMatchObject({ id: "agent-1", name: "Renamed" });
+  await expect(client.agents.delete("agent-1")).resolves.toBeUndefined();
+
+  const models = await client.models.list();
+  expect(models).toHaveLength(1);
+  expect(models[0]).toMatchObject({
+    handle: "anthropic/claude-haiku-4-5",
+    displayName: "Claude Haiku 4.5",
+  });
 
   await expect(
     client.conversations.list({
@@ -295,6 +330,18 @@ describe("portable management namespaces", () => {
         body: { name: "Renamed", context_window_limit: 32_000 },
       },
       {
+        path: "/v1/agents/agent-1",
+        query: {},
+        method: "DELETE",
+        body: undefined,
+      },
+      {
+        path: "/v1/models",
+        query: {},
+        method: "GET",
+        body: undefined,
+      },
+      {
         path: "/v1/conversations/",
         query: {
           agent_id: "agent-1",
@@ -334,6 +381,12 @@ describe("portable management namespaces", () => {
       "mobile",
       "example",
     ]);
+    // Production api.letta.com 404s trailing-slash non-GET agent routes, so
+    // the delete URL must never gain a trailing slash.
+    const deleteRequest = requests.find(({ method }) => method === "DELETE");
+    expect(deleteRequest?.url.toString()).toBe(
+      "https://api.test/v1/agents/agent-1",
+    );
   });
 
   test("maps the same API to app-server protocol commands", async () => {
@@ -354,6 +407,8 @@ describe("portable management namespaces", () => {
       "agent_list",
       "agent_retrieve",
       "agent_update",
+      "agent_delete",
+      "list_models",
       "conversation_list",
       "conversation_retrieve",
       "conversation_create",
@@ -369,7 +424,17 @@ describe("portable management namespaces", () => {
         order_by: "last_run_completion",
       },
     });
-    expect(commands[5]).toMatchObject({
+    expect(commands[3]).toMatchObject({
+      type: "agent_delete",
+      agent_id: "agent-1",
+    });
+    // list_models must stay session-less: a bare command (no runtime scope)
+    // is answered on the control channel.
+    expect(Object.keys(commands[4] ?? {}).sort()).toEqual([
+      "request_id",
+      "type",
+    ]);
+    expect(commands[7]).toMatchObject({
       body: {
         agent_id: "agent-1",
         summary: "Mobile thread",

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -56,6 +56,7 @@ function createManagementFetch(
           display_name: "Claude Haiku 4.5",
           context_window: 200_000,
         },
+        { name: "malformed-without-handle" },
       ]);
     }
     if (url.pathname === "/v1/conversations/" && method === "GET") {
@@ -165,6 +166,8 @@ class ManagementSocket {
             isDefault: true,
           },
         ],
+        available_handles: ["anthropic/claude-haiku-4-5"],
+        byok_provider_aliases: { "lc-anthropic": "anthropic" },
       },
       conversation_list: {
         conversations: [
@@ -239,11 +242,14 @@ async function exerciseManagementApi(
   await expect(client.agents.delete("agent-1")).resolves.toBeUndefined();
 
   const models = await client.models.list();
-  expect(models).toHaveLength(1);
-  expect(models[0]).toMatchObject({
+  expect(models.entries).toHaveLength(1);
+  expect(models.entries[0]).toMatchObject({
     handle: "anthropic/claude-haiku-4-5",
-    displayName: "Claude Haiku 4.5",
+    label: "Claude Haiku 4.5",
   });
+  expect(models.availableHandles).toEqual([
+    "anthropic/claude-haiku-4-5",
+  ]);
 
   await expect(
     client.conversations.list({
@@ -296,6 +302,11 @@ describe("portable management namespaces", () => {
       apiKey: "sk-test",
       fetch: createManagementFetch(requests),
     });
+
+    await expect(client.agents.delete("  ")).rejects.toThrow(
+      "Invalid agent id. Expected a non-empty string.",
+    );
+    expect(requests).toHaveLength(0);
 
     await exerciseManagementApi(client);
 
@@ -447,6 +458,10 @@ describe("portable management namespaces", () => {
           socket.options?.headers?.Authorization === "Bearer remote-token",
       ),
     ).toBe(true);
+    await expect(client.models.list()).resolves.toMatchObject({
+      availableHandles: ["anthropic/claude-haiku-4-5"],
+      byokProviderAliases: { "lc-anthropic": "anthropic" },
+    });
   });
 
   test("uses the app-server protocol for the Node local backend too", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -578,7 +578,7 @@ export type ReasoningEffort =
   | "high"
   | "xhigh";
 
-export interface LettaCodeModelEntry {
+export type LettaCodeModelEntry = Record<string, unknown> & {
   id: string;
   handle: string;
   label: string;
@@ -587,7 +587,7 @@ export interface LettaCodeModelEntry {
   isFeatured?: boolean;
   free?: boolean;
   updateArgs?: Record<string, unknown>;
-}
+};
 
 export interface ListModelsResult {
   entries: LettaCodeModelEntry[];


### PR DESCRIPTION
## Motivation

Found while building the mobile reference app (LET-10209; letta-mobile `SDK-FEEDBACK.md` items 1–2). Two gaps in the portable management surface from #206:

1. **No way to delete an agent.** The `client.agents` namespace stopped at `update`, so cleanup flows (and test teardown) had to fall back to raw REST.
2. **Listing models required an open session.** A model picker or settings screen should not have to open a session just to enumerate models—on Cloud, opening a session provisions a sandbox, which is far too heavy for a read-only dropdown.

## API surface

```ts
await client.agents.delete(agentId); // Promise<void>

const {
  entries,
  availableHandles,
  byokProviderAliases,
} = await client.models.list(); // Promise<ListModelsResult>
```

`client.models.list()` deliberately returns the existing `ListModelsResult` used by `session.listModels()` rather than introducing a second model-catalog shape. Its entries use the existing `LettaCodeModelEntry` contract (`id`, `handle`, `label`, `description`, optional flags/update args), while preserving additional backend fields on the open record.

- **Cloud** normalizes `GET /v1/models` records into that contract and exposes the authenticated catalog as `availableHandles`.
- **App-server** preserves `available_handles` and `byok_provider_aliases` from `list_models`.
- Malformed entries without the required identity/display fields are ignored rather than producing unusable empty handles.
- `agents.delete()` rejects blank IDs before making a transport request.

## Backends

Both features work on all three backends (`cloud`, `remote`, `local` app-server transport) and from both the Node root entry and the portable `/client` entry:

- **Cloud:** `DELETE {base}/v1/agents/{id}`—no trailing slash; production api.letta.com 404s trailing-slash non-GET agent routes (same caution as #209, commented in code and pinned by a URL assertion in tests). `GET {base}/v1/models` provides the session-less catalog.
- **App-server (remote/local):** `agent_delete` protocol command; a bare `list_models` command (no runtime scope) is answered on the control channel, so no session is required. A test pins the command to only `type` + `request_id`.

## Verification

- `bun run check`: green.
- `bun test`: 238 pass / 11 skip / 0 fail, including Cloud and app-server coverage for deletion, blank-ID rejection, normalized model results, availability/BYOK metadata, malformed entries, and the no-trailing-slash Cloud URL.
- `bun run build`: green.

The original branch was also live-checked against Letta Cloud for the backend operations: 427 models were returned, a temporary agent was created and deleted, and a subsequent filtered list confirmed that it was gone. The follow-up result-shape and validation corrections are covered by the local automated suite; they were not separately re-run against production.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
