### PR TITLE
fix: release the app-server management connection when idle

### DIFF
--- a/src/app-server-management.ts
+++ b/src/app-server-management.ts
@@ -57,7 +57,28 @@ export type AppServerManagementOptions =
   Partial<LettaCodeRemoteClientOptions> & {
     url?: string;
     connect?: () => Promise<OwnedConnection>;
+    /**
+     * How long (in milliseconds) an idle control connection lingers before it
+     * is released. Defaults to {@link DEFAULT_IDLE_LINGER_MS}.
+     */
+    idleLingerMs?: number;
   };
+
+/**
+ * How long an idle control connection lingers before it is released.
+ *
+ * Long enough to batch a burst of management calls (for example a screen
+ * fetching a list plus a retrieve together) over one connection, short enough
+ * that the app-server's single control-client slot frees up quickly for
+ * sessions.
+ */
+const DEFAULT_IDLE_LINGER_MS = 250;
+
+type ActiveConnection = {
+  client: AppServerClient;
+  ownedConnection: OwnedConnection | null;
+  detachDisconnect: () => void;
+};
 
 function ensureResponse<T>(
   response: { success: boolean; error?: string },
@@ -103,10 +124,40 @@ function stringRecord(value: unknown): Record<string, string> | undefined {
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
+/**
+ * Management transport that speaks the app-server control protocol.
+ *
+ * Connection lifecycle: the Letta Code app-server currently accepts a single
+ * control client at a time — while one control socket is attached, additional
+ * control sockets are rejected with close code 1008
+ * `"control channel already connected"` (see letta-ai/letta-code
+ * `src/websocket/app-server.ts`). Sessions (`AppServerSession`) need that same
+ * control slot, so a management transport that holds an idle connection
+ * starves any later `resumeSession()`/`createSession()` from the same process
+ * (live-reproduced in the letta-mobile reference app, SDK-FEEDBACK.md #00).
+ *
+ * To stay out of the way, this transport pools a single lazily-connected
+ * client while requests are in flight (bursts share one connection and one
+ * request-id counter, so responses correlate correctly), then releases the
+ * connection shortly after it goes idle ({@link DEFAULT_IDLE_LINGER_MS}) and
+ * reconnects lazily on the next request. `LettaAgentClientBase` additionally
+ * calls {@link releaseIdleConnection} before creating or resuming a session so
+ * sessions never have to wait out the linger. The inverse contention — a
+ * management request issued while a session holds the control slot — cannot be
+ * solved client-side and still fails until the app-server allows multiple
+ * control clients.
+ */
 export class AppServerManagementTransport
   implements ManagementTransport
 {
-  constructor(private readonly options: AppServerManagementOptions) {}
+  private connectionPromise: Promise<ActiveConnection> | null = null;
+  private inFlightRequests = 0;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly idleLingerMs: number;
+
+  constructor(private readonly options: AppServerManagementOptions) {
+    this.idleLingerMs = options.idleLingerMs ?? DEFAULT_IDLE_LINGER_MS;
+  }
 
   async listAgents(query: ManagementQuery): Promise<LettaAgent[]> {
     const response = await this.request<AgentListResponse>(
@@ -265,14 +316,83 @@ export class AppServerManagementTransport
     return { messages: response.messages };
   }
 
+  /**
+   * Immediately release the pooled control connection if no request is in
+   * flight, instead of waiting out the idle linger.
+   *
+   * The app-server accepts a single control client (see the class docs), so
+   * this is called before opening a session to hand the control slot over
+   * without a linger-sized race window.
+   */
+  releaseIdleConnection(): void {
+    if (this.inFlightRequests > 0) return;
+    this.clearIdleTimer();
+    const promise = this.connectionPromise;
+    if (!promise) return;
+    this.connectionPromise = null;
+    void promise.then(
+      (connection) => closeConnection(connection),
+      () => {},
+    );
+  }
+
   private async request<TResponse extends { type: string }>(
     type: string,
     body: Record<string, unknown>,
     responseType: string,
   ): Promise<TResponse> {
+    this.clearIdleTimer();
+    this.inFlightRequests += 1;
+    try {
+      // Concurrent requests share the pooled connection (queueing behind the
+      // same connect promise) and its request-id counter, so correlation is
+      // stable across a burst and across reconnects: a fresh connection gets a
+      // fresh client whose pending map starts empty.
+      const { client } = await this.acquireConnection();
+      const command = {
+        type,
+        request_id: client.nextRequestId(type),
+        ...body,
+      } as AppServerRequestCommandWithId;
+      const response = await client.request(command, {
+        predicate: (message): message is typeof message =>
+          message.type === responseType,
+      });
+      return response as unknown as TResponse;
+    } finally {
+      this.inFlightRequests -= 1;
+      if (this.inFlightRequests === 0) {
+        this.scheduleIdleRelease();
+      }
+    }
+  }
+
+  private acquireConnection(): Promise<ActiveConnection> {
+    if (this.connectionPromise) return this.connectionPromise;
+    const promise: Promise<ActiveConnection> = this.openConnection().then(
+      (connection) => {
+        // Unexpected disconnects (explicit closes do not notify) drop the
+        // pooled connection so the next request reconnects lazily.
+        connection.detachDisconnect = connection.client.onDisconnect(() => {
+          this.discardConnection(promise, connection);
+        });
+        return connection;
+      },
+      (error) => {
+        if (this.connectionPromise === promise) {
+          this.connectionPromise = null;
+        }
+        throw error;
+      },
+    );
+    this.connectionPromise = promise;
+    return promise;
+  }
+
+  private async openConnection(): Promise<ActiveConnection> {
     const ownedConnection = this.options.url
       ? null
-      : await this.options.connect?.();
+      : ((await this.options.connect?.()) ?? null);
     const url = this.options.url ?? ownedConnection?.url;
     if (!url) {
       throw new Error("App-server management requires a url or connect hook.");
@@ -296,19 +416,46 @@ export class AppServerManagementTransport
           : {}),
       });
       await client.connect();
-      const command = {
-        type,
-        request_id: client.nextRequestId(type),
-        ...body,
-      } as AppServerRequestCommandWithId;
-      const response = await client.request(command, {
-        predicate: (message): message is typeof message =>
-          message.type === responseType,
-      });
-      return response as unknown as TResponse;
-    } finally {
+    } catch (error) {
       client?.close();
       ownedConnection?.close();
+      throw error;
     }
+    return { client, ownedConnection, detachDisconnect: () => {} };
   }
+
+  private discardConnection(
+    promise: Promise<ActiveConnection>,
+    connection: ActiveConnection,
+  ): void {
+    if (this.connectionPromise === promise) {
+      this.connectionPromise = null;
+      this.clearIdleTimer();
+    }
+    closeConnection(connection);
+  }
+
+  private scheduleIdleRelease(): void {
+    if (!this.connectionPromise) return;
+    this.clearIdleTimer();
+    const timer = setTimeout(() => {
+      this.idleTimer = null;
+      this.releaseIdleConnection();
+    }, this.idleLingerMs);
+    this.idleTimer = timer;
+    // Do not keep a Node event loop alive just for the linger.
+    (timer as unknown as { unref?: () => void }).unref?.();
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer === null) return;
+    clearTimeout(this.idleTimer);
+    this.idleTimer = null;
+  }
+}
+
+function closeConnection(connection: ActiveConnection): void {
+  connection.detachDisconnect();
+  connection.client.close();
+  connection.ownedConnection?.close();
 }

--- a/src/app-server-management.ts
+++ b/src/app-server-management.ts
@@ -3,6 +3,7 @@ import {
   type AppServerClient,
   type AppServerRequestCommandWithId,
   type AppServerSocketConstructor,
+  type AppServerSocketLike,
 } from "@letta-ai/letta-code/app-server-client";
 import type {
   ManagementQuery,
@@ -78,7 +79,70 @@ type ActiveConnection = {
   client: AppServerClient;
   ownedConnection: OwnedConnection | null;
   detachDisconnect: () => void;
+  unregister: () => void;
 };
+
+type RegisteredManagementTransport = {
+  releaseIdleConnection(): Promise<void>;
+};
+
+type ManagementTransportRegistration = {
+  transport: RegisteredManagementTransport;
+};
+
+const registeredTransportsByUrl =
+  new Map<string, Set<ManagementTransportRegistration>>();
+
+function appServerUrlKey(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol === "http:") url.protocol = "ws:";
+    if (url.protocol === "https:") url.protocol = "wss:";
+    url.hash = "";
+    url.searchParams.delete("channel");
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+function registerManagementTransport(
+  url: string,
+  transport: RegisteredManagementTransport,
+): () => void {
+  const key = appServerUrlKey(url);
+  const registration = { transport };
+  const transports =
+    registeredTransportsByUrl.get(key) ??
+    new Set<ManagementTransportRegistration>();
+  transports.add(registration);
+  registeredTransportsByUrl.set(key, transports);
+  return () => {
+    transports.delete(registration);
+    if (transports.size === 0) {
+      registeredTransportsByUrl.delete(key);
+    }
+  };
+}
+
+/**
+ * Wait for every management transport targeting this app-server to release
+ * its control connection. The registry is process-wide so a session created
+ * by a different `LettaAgentClient` instance can still take the server's
+ * single control slot safely.
+ */
+export async function releaseAppServerManagementConnections(
+  url: string,
+): Promise<void> {
+  const key = appServerUrlKey(url);
+  while (true) {
+    const transports = [...(registeredTransportsByUrl.get(key) ?? [])];
+    if (transports.length === 0) return;
+    await Promise.all(
+      transports.map(({ transport }) => transport.releaseIdleConnection()),
+    );
+  }
+}
 
 function ensureResponse<T>(
   response: { success: boolean; error?: string },
@@ -140,18 +204,21 @@ function stringRecord(value: unknown): Record<string, string> | undefined {
  * client while requests are in flight (bursts share one connection and one
  * request-id counter, so responses correlate correctly), then releases the
  * connection shortly after it goes idle ({@link DEFAULT_IDLE_LINGER_MS}) and
- * reconnects lazily on the next request. `LettaAgentClientBase` additionally
- * calls {@link releaseIdleConnection} before creating or resuming a session so
- * sessions never have to wait out the linger. The inverse contention — a
- * management request issued while a session holds the control slot — cannot be
- * solved client-side and still fails until the app-server allows multiple
- * control clients.
+ * reconnects lazily on the next request. Before a session connects, all
+ * management transports registered for the same app-server URL relinquish
+ * their connections; the handoff waits for in-flight work and for the control
+ * socket's close event. The inverse contention — a management request issued
+ * while a session holds the control slot — cannot be solved client-side and
+ * still fails until the app-server allows multiple control clients.
  */
 export class AppServerManagementTransport
   implements ManagementTransport
 {
   private connectionPromise: Promise<ActiveConnection> | null = null;
+  private releasePromise: Promise<void> | null = null;
+  private closingConnections = new Set<Promise<void>>();
   private inFlightRequests = 0;
+  private idleWaiters = new Set<() => void>();
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly idleLingerMs: number;
 
@@ -317,23 +384,32 @@ export class AppServerManagementTransport
   }
 
   /**
-   * Immediately release the pooled control connection if no request is in
-   * flight, instead of waiting out the idle linger.
+   * Release the pooled control connection instead of waiting out the idle
+   * linger. If requests are in flight, wait for them to settle first.
    *
    * The app-server accepts a single control client (see the class docs), so
-   * this is called before opening a session to hand the control slot over
-   * without a linger-sized race window.
+   * This is called before opening a session to hand the control slot over
+   * without a linger-sized or socket-close race window.
    */
-  releaseIdleConnection(): void {
-    if (this.inFlightRequests > 0) return;
+  releaseIdleConnection(): Promise<void> {
     this.clearIdleTimer();
-    const promise = this.connectionPromise;
-    if (!promise) return;
-    this.connectionPromise = null;
-    void promise.then(
-      (connection) => closeConnection(connection),
-      () => {},
+    if (this.releasePromise) return this.releasePromise;
+
+    const release = this.releaseConnectionWhenIdle();
+    this.releasePromise = release;
+    void release.then(
+      () => {
+        if (this.releasePromise === release) {
+          this.releasePromise = null;
+        }
+      },
+      () => {
+        if (this.releasePromise === release) {
+          this.releasePromise = null;
+        }
+      },
     );
+    return release;
   }
 
   private async request<TResponse extends { type: string }>(
@@ -341,6 +417,12 @@ export class AppServerManagementTransport
     body: Record<string, unknown>,
     responseType: string,
   ): Promise<TResponse> {
+    if (this.releasePromise) {
+      await this.releasePromise;
+    }
+    if (this.closingConnections.size > 0) {
+      await Promise.all([...this.closingConnections]);
+    }
     this.clearIdleTimer();
     this.inFlightRequests += 1;
     try {
@@ -362,8 +444,35 @@ export class AppServerManagementTransport
     } finally {
       this.inFlightRequests -= 1;
       if (this.inFlightRequests === 0) {
-        this.scheduleIdleRelease();
+        const waiters = [...this.idleWaiters];
+        this.idleWaiters.clear();
+        for (const resolve of waiters) resolve();
+        if (!this.releasePromise) {
+          this.scheduleIdleRelease();
+        }
       }
+    }
+  }
+
+  private async releaseConnectionWhenIdle(): Promise<void> {
+    if (this.inFlightRequests > 0) {
+      await new Promise<void>((resolve) => {
+        this.idleWaiters.add(resolve);
+      });
+    }
+
+    this.clearIdleTimer();
+    const promise = this.connectionPromise;
+    try {
+      if (promise) {
+        this.connectionPromise = null;
+        await this.trackClosingConnection(await promise);
+      }
+      if (this.closingConnections.size > 0) {
+        await Promise.all([...this.closingConnections]);
+      }
+    } catch {
+      // A failed connect already closes its partially-created resources.
     }
   }
 
@@ -397,6 +506,7 @@ export class AppServerManagementTransport
     if (!url) {
       throw new Error("App-server management requires a url or connect hook.");
     }
+    const unregister = registerManagementTransport(url, this);
 
     let client: AppServerClient | null = null;
     try {
@@ -417,11 +527,28 @@ export class AppServerManagementTransport
       });
       await client.connect();
     } catch (error) {
-      client?.close();
-      ownedConnection?.close();
+      try {
+        if (client) {
+          const controlClosed = waitForSocketClose(client.control);
+          client.close();
+          ownedConnection?.close();
+          await controlClosed;
+        } else {
+          ownedConnection?.close();
+        }
+      } catch {
+        // Preserve the original connect error after best-effort cleanup.
+      } finally {
+        unregister();
+      }
       throw error;
     }
-    return { client, ownedConnection, detachDisconnect: () => {} };
+    return {
+      client,
+      ownedConnection,
+      detachDisconnect: () => {},
+      unregister,
+    };
   }
 
   private discardConnection(
@@ -432,7 +559,19 @@ export class AppServerManagementTransport
       this.connectionPromise = null;
       this.clearIdleTimer();
     }
-    closeConnection(connection);
+    void this.trackClosingConnection(connection);
+  }
+
+  private trackClosingConnection(
+    connection: ActiveConnection,
+  ): Promise<void> {
+    const closing = closeConnection(connection);
+    this.closingConnections.add(closing);
+    void closing.then(
+      () => this.closingConnections.delete(closing),
+      () => this.closingConnections.delete(closing),
+    );
+    return closing;
   }
 
   private scheduleIdleRelease(): void {
@@ -454,8 +593,48 @@ export class AppServerManagementTransport
   }
 }
 
-function closeConnection(connection: ActiveConnection): void {
+async function closeConnection(connection: ActiveConnection): Promise<void> {
   connection.detachDisconnect();
-  connection.client.close();
-  connection.ownedConnection?.close();
+  const controlClosed = waitForSocketClose(connection.client.control);
+  try {
+    connection.client.close();
+    connection.ownedConnection?.close();
+    await controlClosed;
+  } finally {
+    connection.unregister();
+  }
+}
+
+function waitForSocketClose(socket: AppServerSocketLike): Promise<void> {
+  if (socket.readyState === 3) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let detach = () => {};
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      detach();
+      resolve();
+    };
+
+    if (socket.addEventListener) {
+      socket.addEventListener("close", finish);
+      detach = () => socket.removeEventListener?.("close", finish);
+    } else if (socket.once) {
+      socket.once("close", finish);
+      detach = () => socket.off?.("close", finish);
+    } else if (socket.on) {
+      socket.on("close", finish);
+      detach = () => socket.off?.("close", finish);
+    } else {
+      resolve();
+      return;
+    }
+
+    const timeout = setTimeout(finish, 1_000);
+    (timeout as unknown as { unref?: () => void }).unref?.();
+    if (socket.readyState === 3) finish();
+  });
 }

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -10,6 +10,7 @@ import {
   GIT_MEMORY_ENABLED_TAG,
   LETTA_CODE_ORIGIN_TAG,
 } from "@letta-ai/letta-code/agent-presets";
+import { releaseAppServerManagementConnections } from "./app-server-management.js";
 import {
   buildCanUseToolContext,
   isHeadlessAutoAllowTool,
@@ -125,6 +126,11 @@ export type AppServerSessionOptions = Partial<LettaCodeRemoteClientOptions> & {
   connect?: (
     sessionEnv?: Record<string, string>,
   ) => Promise<{ url: string; close(): void }>;
+  /**
+   * Internal handoff hook used to release a management connection owned by
+   * the same SDK client before this session opens its control socket.
+   */
+  beforeConnect?: () => Promise<void>;
   /** Whether SDK create-agent payloads should add the origin tag automatically. */
   includeSdkOriginTag?: boolean;
 };
@@ -764,7 +770,9 @@ export class AppServerSession extends RemoteClientSessionCore {
   }
 
   protected override async initializeRuntimeController(): Promise<RuntimeSessionInit> {
+    await this.remoteOptions.beforeConnect?.();
     const url = await this.resolveAppServerUrl();
+    await releaseAppServerManagementConnections(url);
     const client = createAppServerClient({
       url,
       ...(this.remoteOptions.authToken !== undefined

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -196,6 +196,7 @@ export class LettaAgentClientBase {
     }
 
     validateCreateAgentOptions(options);
+    this.releaseIdleManagementConnection();
 
     if (this.backend === "remote") {
       const session = new AppServerSession(this.remoteOptions(), {
@@ -230,6 +231,7 @@ export class LettaAgentClientBase {
     this.assertSessionBackend("createSession", resolvedOptions);
     const sessionOptions = stripCloudExecutionOptions(resolvedOptions);
     validateCreateSessionOptions(sessionOptions);
+    this.releaseIdleManagementConnection();
 
     if (this.backend === "remote") {
       if (!agentId) {
@@ -273,6 +275,7 @@ export class LettaAgentClientBase {
     this.assertSessionBackend("resumeSession", options);
     const sessionOptions = stripCloudExecutionOptions(options);
     validateCreateSessionOptions(sessionOptions);
+    this.releaseIdleManagementConnection();
 
     if (this.backend === "remote") {
       if (looksLikeConversationId(id)) {
@@ -425,6 +428,16 @@ export class LettaAgentClientBase {
     }
     this.repositoriesClient ??= new RepositoriesClient(this.cloudOptions());
     return this.repositoriesClient;
+  }
+
+  /**
+   * The app-server accepts a single control client at a time, so an idle
+   * pooled management connection would starve the session we are about to
+   * open. Release it up front; it reconnects lazily on the next
+   * agents/conversations/models call.
+   */
+  private releaseIdleManagementConnection(): void {
+    this.managementTransport?.releaseIdleConnection?.();
   }
 
   private getManagementTransport(): ManagementTransport {

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -3,6 +3,7 @@ import { AppServerManagementTransport } from "./app-server-management.js";
 import {
   AppServerSession,
   assertRemoteSessionOptionsSupported,
+  type AppServerSessionOptions,
 } from "./app-server-session.js";
 import { CloudManagementTransport } from "./cloud-management.js";
 import {
@@ -152,6 +153,13 @@ export class LettaAgentClientBase {
       ) {
         throw new Error("Invalid appServer.requestTimeoutMs. Expected a positive integer.");
       }
+      const idleLingerMs = localOptions.appServer?.idleLingerMs;
+      if (
+        idleLingerMs !== undefined &&
+        (!Number.isInteger(idleLingerMs) || idleLingerMs < 0)
+      ) {
+        throw new Error("Invalid appServer.idleLingerMs. Expected a non-negative integer.");
+      }
       const startupTimeoutMs = localOptions.appServer?.startupTimeoutMs;
       if (
         startupTimeoutMs !== undefined &&
@@ -170,6 +178,12 @@ export class LettaAgentClientBase {
         (!Number.isInteger(options.requestTimeoutMs) || options.requestTimeoutMs <= 0)
       ) {
         throw new Error("Invalid requestTimeoutMs. Expected a positive integer.");
+      }
+      if (
+        options.idleLingerMs !== undefined &&
+        (!Number.isInteger(options.idleLingerMs) || options.idleLingerMs < 0)
+      ) {
+        throw new Error("Invalid idleLingerMs. Expected a non-negative integer.");
       }
     }
 
@@ -196,10 +210,9 @@ export class LettaAgentClientBase {
     }
 
     validateCreateAgentOptions(options);
-    this.releaseIdleManagementConnection();
 
     if (this.backend === "remote") {
-      const session = new AppServerSession(this.remoteOptions(), {
+      const session = new AppServerSession(this.appServerSessionOptions(), {
         kind: "create-agent",
         options,
       });
@@ -231,7 +244,6 @@ export class LettaAgentClientBase {
     this.assertSessionBackend("createSession", resolvedOptions);
     const sessionOptions = stripCloudExecutionOptions(resolvedOptions);
     validateCreateSessionOptions(sessionOptions);
-    this.releaseIdleManagementConnection();
 
     if (this.backend === "remote") {
       if (!agentId) {
@@ -239,7 +251,7 @@ export class LettaAgentClientBase {
           "App-server createSession() requires an agent id. Call createAgent() first or pass an agent id.",
         );
       }
-      return new AppServerSession(this.remoteOptions(), {
+      return new AppServerSession(this.appServerSessionOptions(), {
         kind: "session",
         agentId,
         newConversation: true,
@@ -275,17 +287,16 @@ export class LettaAgentClientBase {
     this.assertSessionBackend("resumeSession", options);
     const sessionOptions = stripCloudExecutionOptions(options);
     validateCreateSessionOptions(sessionOptions);
-    this.releaseIdleManagementConnection();
 
     if (this.backend === "remote") {
       if (looksLikeConversationId(id)) {
-        return new AppServerSession(this.remoteOptions(), {
+        return new AppServerSession(this.appServerSessionOptions(), {
           kind: "session",
           conversationId: id,
           options,
         });
       }
-      return new AppServerSession(this.remoteOptions(), {
+      return new AppServerSession(this.appServerSessionOptions(), {
         kind: "session",
         agentId: id,
         defaultConversation: true,
@@ -422,6 +433,13 @@ export class LettaAgentClientBase {
     return this.options as LettaCodeRemoteClientOptions;
   }
 
+  private appServerSessionOptions(): AppServerSessionOptions {
+    return {
+      ...this.remoteOptions(),
+      beforeConnect: () => this.releaseIdleManagementConnection(),
+    };
+  }
+
   private getRepositoriesClient(): RepositoriesClient {
     if (this.backend !== "cloud") {
       throw new Error('client.repositories is only available with backend: "cloud".');
@@ -431,13 +449,12 @@ export class LettaAgentClientBase {
   }
 
   /**
-   * The app-server accepts a single control client at a time, so an idle
-   * pooled management connection would starve the session we are about to
-   * open. Release it up front; it reconnects lazily on the next
-   * agents/conversations/models call.
+   * The app-server accepts a single control client at a time. Before a session
+   * connects, wait for this client's management work to settle and relinquish
+   * its pooled connection; management reconnects lazily on its next call.
    */
-  private releaseIdleManagementConnection(): void {
-    this.managementTransport?.releaseIdleConnection?.();
+  protected async releaseIdleManagementConnection(): Promise<void> {
+    await this.managementTransport?.releaseIdleConnection?.();
   }
 
   private getManagementTransport(): ManagementTransport {

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,6 +39,9 @@ export class LettaAgentClient extends LettaAgentClientBase {
       ...(localOptions?.requestTimeoutMs !== undefined
         ? { requestTimeoutMs: localOptions.requestTimeoutMs }
         : {}),
+      ...(localOptions?.idleLingerMs !== undefined
+        ? { idleLingerMs: localOptions.idleLingerMs }
+        : {}),
     });
   }
 
@@ -47,10 +50,14 @@ export class LettaAgentClient extends LettaAgentClientBase {
   ): Promise<string> {
     if (!this.useLegacyLocalStdio()) {
       const localOptions = this.options as LettaCodeLocalClientOptions;
-      const session = createLocalAppServerSession(localOptions.appServer, {
-        kind: "create-agent",
-        options,
-      });
+      const session = createLocalAppServerSession(
+        localOptions.appServer,
+        {
+          kind: "create-agent",
+          options,
+        },
+        () => this.releaseIdleManagementConnection(),
+      );
       const initMsg = await session.initialize();
       session.close();
       return initMsg.agentId;
@@ -69,12 +76,16 @@ export class LettaAgentClient extends LettaAgentClientBase {
   ): LettaCodeSession {
     if (!this.useLegacyLocalStdio() && agentId) {
       const localOptions = this.options as LettaCodeLocalClientOptions;
-      return createLocalAppServerSession(localOptions.appServer, {
-        kind: "session",
-        agentId,
-        newConversation: true,
-        options,
-      });
+      return createLocalAppServerSession(
+        localOptions.appServer,
+        {
+          kind: "session",
+          agentId,
+          newConversation: true,
+          options,
+        },
+        () => this.releaseIdleManagementConnection(),
+      );
     }
     if (agentId) {
       return new Session({ ...sessionOptions, agentId, newConversation: true });
@@ -90,18 +101,26 @@ export class LettaAgentClient extends LettaAgentClientBase {
     if (!this.useLegacyLocalStdio()) {
       const localOptions = this.options as LettaCodeLocalClientOptions;
       if (looksLikeConversationId(id)) {
-        return createLocalAppServerSession(localOptions.appServer, {
-          kind: "session",
-          conversationId: id,
-          options,
-        });
+        return createLocalAppServerSession(
+          localOptions.appServer,
+          {
+            kind: "session",
+            conversationId: id,
+            options,
+          },
+          () => this.releaseIdleManagementConnection(),
+        );
       }
-      return createLocalAppServerSession(localOptions.appServer, {
-        kind: "session",
-        agentId: id,
-        defaultConversation: true,
-        options,
-      });
+      return createLocalAppServerSession(
+        localOptions.appServer,
+        {
+          kind: "session",
+          agentId: id,
+          defaultConversation: true,
+          options,
+        },
+        () => this.releaseIdleManagementConnection(),
+      );
     }
     if (looksLikeConversationId(id)) {
       return new Session({ ...sessionOptions, conversationId: id });

--- a/src/local-app-server-session.ts
+++ b/src/local-app-server-session.ts
@@ -9,6 +9,7 @@ import type { LettaCodeLocalAppServerOptions } from "./types.js";
 export function createLocalAppServerSession(
   options: LettaCodeLocalAppServerOptions | undefined,
   mode: AppServerSessionMode,
+  beforeConnect?: () => Promise<void>,
 ): AppServerSession {
   const appServer = options ?? {};
   const sessionOptions: AppServerSessionOptions = {
@@ -32,6 +33,7 @@ export function createLocalAppServerSession(
     ...(appServer.pinGlobalAgent !== undefined
       ? { pinGlobalAgent: appServer.pinGlobalAgent }
       : {}),
+    ...(beforeConnect ? { beforeConnect } : {}),
   };
   return new AppServerSession(sessionOptions, mode);
 }

--- a/src/management.ts
+++ b/src/management.ts
@@ -45,6 +45,13 @@ export interface ManagementTransport {
     conversationId: string,
     query: ManagementQuery,
   ): Promise<ConversationMessagesResult>;
+  /**
+   * Release any idle pooled connection so other clients of the same backend
+   * (for example sessions, which compete for the app-server's single
+   * control-client slot) can connect immediately. Optional; transports whose
+   * backend has no such contention (Cloud REST) do not implement it.
+   */
+  releaseIdleConnection?(): void;
 }
 
 type TransportProvider = () => ManagementTransport;

--- a/src/management.ts
+++ b/src/management.ts
@@ -46,12 +46,12 @@ export interface ManagementTransport {
     query: ManagementQuery,
   ): Promise<ConversationMessagesResult>;
   /**
-   * Release any idle pooled connection so other clients of the same backend
-   * (for example sessions, which compete for the app-server's single
-   * control-client slot) can connect immediately. Optional; transports whose
-   * backend has no such contention (Cloud REST) do not implement it.
+   * Release the pooled connection, waiting for in-flight work when necessary,
+   * so other clients of the same backend (for example sessions, which compete
+   * for the app-server's single control-client slot) can connect. Optional;
+   * transports whose backend has no such contention (Cloud REST) omit it.
    */
-  releaseIdleConnection?(): void;
+  releaseIdleConnection?(): Promise<void> | void;
 }
 
 type TransportProvider = () => ManagementTransport;

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -514,6 +514,24 @@ describe("LettaAgentClient", () => {
     expect(client.environment).toBeUndefined();
   });
 
+  test("validates management connection linger options", () => {
+    expect(
+      () =>
+        new LettaAgentClient({
+          backend: "remote",
+          url: "ws://127.0.0.1:4500/ws",
+          idleLingerMs: -1,
+        }),
+    ).toThrow("Invalid idleLingerMs");
+    expect(
+      () =>
+        new LettaAgentClient({
+          backend: "local",
+          appServer: { idleLingerMs: 1.5 },
+        }),
+    ).toThrow("Invalid appServer.idleLingerMs");
+  });
+
   test("creates local app-server sessions without starting transport until use", () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -544,10 +544,17 @@ describe("portable management namespaces", () => {
 class SingleControlAppServerSocket extends ManagementSocket {
   static activeControl: SingleControlAppServerSocket | null = null;
   static rejectedControlSockets = 0;
+  static controlCloseDelayMs = 0;
+  static agentListResponseDelayMs = 0;
+  static agentListRequests = 0;
+  private closeScheduled = false;
 
   static reset(): void {
     SingleControlAppServerSocket.activeControl = null;
     SingleControlAppServerSocket.rejectedControlSockets = 0;
+    SingleControlAppServerSocket.controlCloseDelayMs = 0;
+    SingleControlAppServerSocket.agentListResponseDelayMs = 0;
+    SingleControlAppServerSocket.agentListRequests = 0;
     ManagementSocket.instances = [];
   }
 
@@ -570,14 +577,40 @@ class SingleControlAppServerSocket extends ManagementSocket {
   }
 
   override close(): void {
-    if (SingleControlAppServerSocket.activeControl === this) {
-      SingleControlAppServerSocket.activeControl = null;
+    if (this.closeScheduled || this.readyState === 3) return;
+    this.closeScheduled = true;
+    this.readyState = 2;
+    const finishClose = () => {
+      if (SingleControlAppServerSocket.activeControl === this) {
+        SingleControlAppServerSocket.activeControl = null;
+      }
+      super.close();
+    };
+    if (
+      this.url.includes("channel=control") &&
+      SingleControlAppServerSocket.controlCloseDelayMs > 0
+    ) {
+      setTimeout(
+        finishClose,
+        SingleControlAppServerSocket.controlCloseDelayMs,
+      );
+      return;
     }
-    super.close();
+    finishClose();
   }
 
   protected override respond(command: Record<string, unknown>): void {
     const type = String(command.type);
+    if (type === "agent_list") {
+      SingleControlAppServerSocket.agentListRequests += 1;
+      if (SingleControlAppServerSocket.agentListResponseDelayMs > 0) {
+        setTimeout(
+          () => super.respond(command),
+          SingleControlAppServerSocket.agentListResponseDelayMs,
+        );
+        return;
+      }
+    }
     if (type === "runtime_start") {
       this.serverMessage({
         type: "runtime_start_response",
@@ -685,6 +718,7 @@ describe("app-server management connection lifecycle", () => {
 
   test("a session created right after management calls gets the control channel", async () => {
     SingleControlAppServerSocket.reset();
+    SingleControlAppServerSocket.controlCloseDelayMs = 10;
     const client = new PortableLettaAgentClient({
       backend: "remote",
       url,
@@ -713,6 +747,64 @@ describe("app-server management connection lifecycle", () => {
       expect(SingleControlAppServerSocket.activeControl).not.toBe(
         managementControl,
       );
+    } finally {
+      session.close();
+    }
+  });
+
+  test("a session waits for an in-flight management request before taking the control channel", async () => {
+    SingleControlAppServerSocket.reset();
+    SingleControlAppServerSocket.agentListResponseDelayMs = 20;
+    SingleControlAppServerSocket.controlCloseDelayMs = 10;
+    const client = new PortableLettaAgentClient({
+      backend: "remote",
+      url,
+      WebSocket: SingleControlAppServerSocket,
+    });
+
+    const agentsPromise = client.agents.list();
+    while (SingleControlAppServerSocket.agentListRequests === 0) {
+      await Bun.sleep(1);
+    }
+
+    const session = client.resumeSession("conv-1");
+    try {
+      const [agents, init] = await Promise.all([
+        agentsPromise,
+        asAdvanced(session).initialize(),
+      ]);
+      expect(agents).toHaveLength(1);
+      expect(init.conversationId).toBe("conv-1");
+      expect(SingleControlAppServerSocket.rejectedControlSockets).toBe(0);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("a session releases a lingering management connection owned by another client", async () => {
+    SingleControlAppServerSocket.reset();
+    SingleControlAppServerSocket.controlCloseDelayMs = 10;
+    const listClient = new PortableLettaAgentClient({
+      backend: "remote",
+      url,
+      WebSocket: SingleControlAppServerSocket,
+    });
+    const chatClient = new PortableLettaAgentClient({
+      backend: "remote",
+      url,
+      WebSocket: SingleControlAppServerSocket,
+    });
+
+    await listClient.agents.list();
+    const managementControl = SingleControlAppServerSocket.activeControl;
+    expect(managementControl).not.toBeNull();
+
+    const session = chatClient.resumeSession("conv-1");
+    try {
+      const init = await asAdvanced(session).initialize();
+      expect(init.conversationId).toBe("conv-1");
+      expect(managementControl?.readyState).toBe(3);
+      expect(SingleControlAppServerSocket.rejectedControlSockets).toBe(0);
     } finally {
       session.close();
     }

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { AppServerManagementTransport } from "../app-server-management.js";
 import { LettaAgentClient as PortableLettaAgentClient } from "../client-entry.js";
 import { LettaAgentClient as NodeLettaAgentClient } from "../index.js";
 import type { LettaCodeSocketOptions } from "../types.js";
+import { asAdvanced } from "./advanced-session.js";
 
 type FetchInput = Parameters<typeof fetch>[0];
 type Listener = (event: unknown) => void;
@@ -112,10 +114,12 @@ class ManagementSocket {
     readonly options?: LettaCodeSocketOptions,
   ) {
     ManagementSocket.instances.push(this);
-    queueMicrotask(() => {
-      this.readyState = 1;
-      this.emit("open", {});
-    });
+    queueMicrotask(() => this.handleConnect());
+  }
+
+  protected handleConnect(): void {
+    this.readyState = 1;
+    this.emit("open", {});
   }
 
   send(data: string): void {
@@ -139,7 +143,7 @@ class ManagementSocket {
     this.listeners.get(type)?.delete(listener);
   }
 
-  private respond(command: Record<string, unknown>): void {
+  protected respond(command: Record<string, unknown>): void {
     const responses: Record<string, Record<string, unknown>> = {
       agent_list: {
         agents: [{ id: "agent-1", name: "Memo" }],
@@ -527,5 +531,190 @@ describe("portable management namespaces", () => {
     await expect(client.agents.list()).rejects.toThrow(
       "Cloud list agents failed — Unauthorized — URL: https://api.test/v1/agents/ — Authentication failed",
     );
+  });
+});
+
+/**
+ * Fake mirroring the app-server's single-control-client rule: while one
+ * control socket is attached, later control sockets are accepted at the
+ * websocket layer and then rejected with 1008 "control channel already
+ * connected" (letta-code src/websocket/app-server.ts), which strands any
+ * request sent over them.
+ */
+class SingleControlAppServerSocket extends ManagementSocket {
+  static activeControl: SingleControlAppServerSocket | null = null;
+  static rejectedControlSockets = 0;
+
+  static reset(): void {
+    SingleControlAppServerSocket.activeControl = null;
+    SingleControlAppServerSocket.rejectedControlSockets = 0;
+    ManagementSocket.instances = [];
+  }
+
+  protected override handleConnect(): void {
+    if (this.url.includes("channel=control")) {
+      if (SingleControlAppServerSocket.activeControl) {
+        SingleControlAppServerSocket.rejectedControlSockets += 1;
+        // The real server completes the upgrade, then closes the socket.
+        super.handleConnect();
+        this.readyState = 3;
+        this.emit("close", {
+          code: 1008,
+          reason: "control channel already connected",
+        });
+        return;
+      }
+      SingleControlAppServerSocket.activeControl = this;
+    }
+    super.handleConnect();
+  }
+
+  override close(): void {
+    if (SingleControlAppServerSocket.activeControl === this) {
+      SingleControlAppServerSocket.activeControl = null;
+    }
+    super.close();
+  }
+
+  protected override respond(command: Record<string, unknown>): void {
+    const type = String(command.type);
+    if (type === "runtime_start") {
+      this.serverMessage({
+        type: "runtime_start_response",
+        request_id: command.request_id,
+        success: true,
+        runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+        agent: { id: "agent-1", model: "anthropic/claude-haiku-4-5" },
+        conversation: { id: "conv-1", agent_id: "agent-1" },
+        created: { agent: false, conversation: false },
+      });
+      return;
+    }
+    if (type === "sync") {
+      if (typeof command.request_id === "string") {
+        this.serverMessage({
+          type: "sync_response",
+          request_id: command.request_id,
+          runtime: command.runtime,
+          success: true,
+        });
+      }
+      return;
+    }
+    super.respond(command);
+  }
+
+  private serverMessage(message: Record<string, unknown>): void {
+    queueMicrotask(() => {
+      this.emit("message", { data: JSON.stringify(message) });
+    });
+  }
+}
+
+describe("app-server management connection lifecycle", () => {
+  const url = "ws://remote.test/ws";
+
+  function openSockets(): ManagementSocket[] {
+    return ManagementSocket.instances.filter(
+      (socket) => socket.readyState !== 3,
+    );
+  }
+
+  test("releases the connection after a request settles and the linger elapses", async () => {
+    ManagementSocket.instances = [];
+    const transport = new AppServerManagementTransport({
+      url,
+      WebSocket: ManagementSocket,
+      idleLingerMs: 20,
+    });
+
+    await expect(transport.listAgents({})).resolves.toEqual([
+      { id: "agent-1", name: "Memo" },
+    ]);
+    // One control + one stream socket, still open during the linger.
+    expect(ManagementSocket.instances).toHaveLength(2);
+    expect(openSockets()).toHaveLength(2);
+
+    await Bun.sleep(60);
+    expect(openSockets()).toHaveLength(0);
+  });
+
+  test("reconnects lazily after an idle release", async () => {
+    ManagementSocket.instances = [];
+    const transport = new AppServerManagementTransport({
+      url,
+      WebSocket: ManagementSocket,
+      idleLingerMs: 20,
+    });
+
+    await transport.listAgents({});
+    await Bun.sleep(60);
+    expect(openSockets()).toHaveLength(0);
+
+    await expect(transport.listConversations({})).resolves.toHaveLength(1);
+    // A fresh connection was opened for the follow-up request.
+    expect(ManagementSocket.instances).toHaveLength(4);
+    expect(openSockets()).toHaveLength(2);
+    await Bun.sleep(60);
+    expect(openSockets()).toHaveLength(0);
+  });
+
+  test("a burst of requests shares one connection", async () => {
+    ManagementSocket.instances = [];
+    const transport = new AppServerManagementTransport({
+      url,
+      WebSocket: ManagementSocket,
+      idleLingerMs: 20,
+    });
+
+    const [agents, conversations] = await Promise.all([
+      transport.listAgents({}),
+      transport.listConversations({}),
+    ]);
+    expect(agents).toHaveLength(1);
+    expect(conversations).toHaveLength(1);
+    // A sequential follow-up inside the linger reuses the connection too.
+    await expect(transport.retrieveAgent("agent-1")).resolves.toMatchObject({
+      id: "agent-1",
+    });
+    expect(ManagementSocket.instances).toHaveLength(2);
+
+    await Bun.sleep(60);
+    expect(openSockets()).toHaveLength(0);
+  });
+
+  test("a session created right after management calls gets the control channel", async () => {
+    SingleControlAppServerSocket.reset();
+    const client = new PortableLettaAgentClient({
+      backend: "remote",
+      url,
+      WebSocket: SingleControlAppServerSocket,
+    });
+
+    await client.agents.list();
+    await client.conversations.list();
+    // The pooled management connection is still lingering (default 250ms) and
+    // holds the single control slot; a second control client would be
+    // rejected 1008 by the fake, exactly like the real app-server.
+    expect(SingleControlAppServerSocket.activeControl).not.toBeNull();
+    const managementControl = SingleControlAppServerSocket.activeControl;
+
+    // resumeSession() must release the idle management connection before the
+    // session connects, without waiting out the linger.
+    const session = client.resumeSession("conv-1");
+    try {
+      const init = await asAdvanced(session).initialize();
+      expect(init.conversationId).toBe("conv-1");
+      expect(init.agentId).toBe("agent-1");
+      // The management control socket was closed before the session's control
+      // socket connected, so nothing got rejected.
+      expect(managementControl?.readyState).toBe(3);
+      expect(SingleControlAppServerSocket.rejectedControlSockets).toBe(0);
+      expect(SingleControlAppServerSocket.activeControl).not.toBe(
+        managementControl,
+      );
+    } finally {
+      session.close();
+    }
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -314,6 +314,8 @@ export interface LettaCodeLocalAppServerOptions {
   WebSocket?: LettaCodeSocketConstructor;
   /** Timeout for websocket protocol request/turn correlation. */
   requestTimeoutMs?: number;
+  /** Milliseconds an idle management connection may be reused before release. Defaults to 250. */
+  idleLingerMs?: number;
   /** Whether agents created through this app-server are added to Letta Code's global pinned-agent list. */
   pinGlobalAgent?: boolean;
   /** Local app-server listen URL when the SDK spawns it. Defaults to ws://127.0.0.1:0. */
@@ -340,6 +342,8 @@ export interface LettaCodeRemoteClientOptions {
   WebSocket?: LettaCodeSocketConstructor;
   /** Timeout for websocket protocol request/turn correlation. */
   requestTimeoutMs?: number;
+  /** Milliseconds an idle management connection may be reused before release. Defaults to 250. */
+  idleLingerMs?: number;
   /** Whether agents created through this app-server are added to Letta Code's global pinned-agent list. */
   pinGlobalAgent?: boolean;
 }


### PR DESCRIPTION
## The bug

Live-reproduced in the mobile reference app (LET-10209, SDK-FEEDBACK.md #00): after any `client.agents.list()` / `client.conversations.*` call on the `remote` backend, a subsequent `client.resumeSession()` from the same process deadlocked — its `conversation_retrieve` timed out.

Root cause: the letta app-server accepts **one control client at a time**. While a control socket is attached, additional control sockets are accepted at the websocket layer and then rejected with 1008 `"control channel already connected"` (letta-code `src/websocket/app-server.ts`), which strands every request sent over them. `AppServerManagementTransport` opened a fresh control+stream socket pair **per request**, so:

- concurrent management calls (a screen fetching list + retrieve together) starved *each other* — the second connection got 1008'd and timed out;
- management connections raced sessions for the control slot, so a chat screen opened right after a list screen couldn't connect.

## Design chosen

The safe minimum from the options considered (vs. sharing one `AppServerClient` between the management transport and `AppServerSession`, which would mean rewiring session lifecycle/stream handling and wasn't a clean fit):

- **Pool one lazily-connected client per transport.** Requests refcount in-flight work and queue behind a shared connect promise, so a burst uses one connection and one request-id counter — correlation is stable across the burst and across reconnects (a fresh connection gets a fresh client with an empty pending map). Unexpected disconnects drop the pooled connection so the next request reconnects lazily.
- **Release the connection when idle**, after a short linger (`DEFAULT_IDLE_LINGER_MS = 250`, configurable via `idleLingerMs`) that batches bursts without holding the control slot. The linger timer is unref'd so it never keeps a Node event loop alive.
- **Hand the slot to sessions eagerly:** `LettaAgentClientBase.createAgent()/createSession()/resumeSession()` call the transport's new `releaseIdleConnection()` first, so a session created *inside* the linger window still connects — no linger-sized race. (`ManagementTransport.releaseIdleConnection` is optional; Cloud REST has no such contention and doesn't implement it.)
- The single-control-client constraint and the inverse limitation (management calls issued *while a session holds the slot* still fail until the app-server allows multiple control clients) are documented in the transport's JSDoc.

For the local backend's `connect` hook this also stops spawning a fresh app-server process per management request — the owned server now lives for the pooled connection's lifetime.

## Tests

New `app-server management connection lifecycle` suite in `src/tests/management.test.ts`, using the existing fake-socket patterns:

- after a request settles and the linger elapses, the control+stream sockets are closed;
- a follow-up request reconnects lazily and succeeds;
- a burst (parallel pair + sequential follow-up inside the linger) uses exactly one connection;
- a session resumed immediately after management calls gets the control channel, against a `SingleControlAppServerSocket` fake that enforces the app-server's 1008 single-control-client semantics (asserts the management control socket closed before the session's connected and zero 1008 rejections).

`bun run check`, `bun test` (248 pass / 0 fail), and `bun run build` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up hardening

Review found that the initial idle-only handoff still reproduced the same 1008 failure in two realistic cases: when a management request was still in flight as the chat session initialized, and when the list and chat screens used different LettaAgentClient instances targeting the same app-server. The original fake also released the server slot synchronously from close(), masking the real WebSocket close-handshake window.

Commit e64db0e closes those gaps:

- session initialization now asynchronously waits for same-client management work to settle before connecting;
- active management transports are registered by normalized app-server URL, so a session can release lingering connections owned by other SDK client instances in the same process;
- handoff waits for the control socket close event (with bounded fallback) before opening the session socket;
- reconnects also wait for any previous socket teardown, avoiding overlap after unexpected disconnects;
- idleLingerMs is now part of the public remote/local app-server options and is validated as a non-negative integer.

Regression tests cover an in-flight management request, cross-client handoff, and delayed socket teardown. A real-WebSocket reproduction that previously returned 1008 plus a conversation_retrieve timeout now completes with zero rejected control sockets.