### PR TITLE
fix: make session initialization single-flight with collision-resistant request ids

### DIFF
--- a/src/app-server-management.ts
+++ b/src/app-server-management.ts
@@ -9,6 +9,7 @@ import type {
   ManagementQuery,
   ManagementTransport,
 } from "./management.js";
+import { applyUniqueRequestIds } from "./request-ids.js";
 import type {
   ConversationMessagesResult,
   LettaAgent,
@@ -510,7 +511,7 @@ export class AppServerManagementTransport
 
     let client: AppServerClient | null = null;
     try {
-      client = createAppServerClient({
+      client = applyUniqueRequestIds(createAppServerClient({
         url,
         ...(this.options.authToken !== undefined
           ? { authToken: this.options.authToken }
@@ -524,7 +525,7 @@ export class AppServerManagementTransport
         ...(this.options.requestTimeoutMs !== undefined
           ? { requestTimeoutMs: this.options.requestTimeoutMs }
           : {}),
-      });
+      }));
       await client.connect();
     } catch (error) {
       try {

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -16,6 +16,7 @@ import {
   isHeadlessAutoAllowTool,
   requiresRuntimeUserInput,
 } from "./interactiveToolPolicy.js";
+import { applyUniqueRequestIds } from "./request-ids.js";
 import {
   RemoteClientSessionCore,
   ensureSuccess,
@@ -773,7 +774,7 @@ export class AppServerSession extends RemoteClientSessionCore {
     await this.remoteOptions.beforeConnect?.();
     const url = await this.resolveAppServerUrl();
     await releaseAppServerManagementConnections(url);
-    const client = createAppServerClient({
+    const client = applyUniqueRequestIds(createAppServerClient({
       url,
       ...(this.remoteOptions.authToken !== undefined
         ? { authToken: this.remoteOptions.authToken }
@@ -784,7 +785,7 @@ export class AppServerSession extends RemoteClientSessionCore {
       ...(this.remoteOptions.requestTimeoutMs !== undefined
         ? { requestTimeoutMs: this.remoteOptions.requestTimeoutMs }
         : {}),
-    });
+    }));
 
     this.removeControlRequestHandler = registerAppServerControlRequestHandler({
       client,

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -17,6 +17,7 @@ import {
   RemoteEnvironmentClient,
   type RemoteEnvironmentTarget,
 } from "./remote.js";
+import { applyUniqueRequestIds } from "./request-ids.js";
 import {
   RemoteClientSessionCore,
   mapPermissionMode,
@@ -732,14 +733,14 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       apiKey,
       authMode: this.cloudOptions.webSocketAuth ?? "header",
     });
-    const client = createAppServerClient({
+    const client = applyUniqueRequestIds(createAppServerClient({
       url,
       WebSocket: createCloudStatusWebSocketConstructor({
         cloudOptions: this.cloudOptions,
         runtime: resolved.runtime,
       }),
       requestTimeoutMs: this.cloudOptions.requestTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
-    });
+    }));
     this.removeControlRequestHandler = registerAppServerControlRequestHandler({
       client,
       getRuntime: () => this.runtime,

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -727,18 +727,26 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     if (this.initializePromise) {
       return this.initializePromise;
     }
-    let memo: Promise<SDKInitMessage> | null = null;
-    memo = this.performInitialize().catch((error: unknown) => {
-      // Clear the memo so a later initialize() can retry, and tear down only
-      // this attempt's partial state. Never close() here: single-flight means
-      // no concurrent initialize exists whose healthy connection a losing
-      // attempt could destroy, and the session itself stays usable.
-      if (this.initializePromise === memo) {
-        this.initializePromise = null;
+    if (this.initialized) {
+      throw new Error("Session already initialized");
+    }
+
+    const attempt = this.performInitialize();
+    const memo = attempt
+      .catch((error: unknown) => {
+        // Tear down only this attempt's partial state. Never close() the
+        // session here: a failed remote attempt is retryable.
         this.cleanupFailedInitialize();
-      }
-      throw error;
-    });
+        throw error;
+      })
+      .finally(() => {
+        // Keep only the in-flight promise. Once it settles, preserve the
+        // existing API: a later explicit initialize() either retries a
+        // failure or throws "already initialized" after success.
+        if (this.initializePromise === memo) {
+          this.initializePromise = null;
+        }
+      });
     this.initializePromise = memo;
     return memo;
   }
@@ -759,10 +767,16 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
           : "";
     this.toolNames = init.tools;
     this.removeMessageHandler = this.controller.onMessage(this.handleProtocolMessage);
-    this.initialized = true;
 
     await this.afterRuntimeInitialized();
     await this.applyPostInitializeOptions();
+    if (this.closed) {
+      throw new Error("Session is closed");
+    }
+
+    // This is the lifecycle commit point. Lazy entry points must continue to
+    // await initializePromise until every post-initialize option is applied.
+    this.initialized = true;
 
     const initMessage: SDKInitMessage = {
       type: "init",
@@ -791,6 +805,12 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     // are attempt-scoped too; their cleanup hooks are idempotent.
     this.onCoreClose();
     this.runtime = null;
+    this._agentId = null;
+    this._conversationId = null;
+    this._sessionId = null;
+    this._modelSettings = null;
+    this._model = "";
+    this.toolNames = undefined;
     this.initialized = false;
   }
 
@@ -914,7 +934,15 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     if (!this.controller || !this.runtime) {
       throw new Error("Session is not initialized");
     }
+    return this.applyModelUpdate(update);
+  }
 
+  private async applyModelUpdate(
+    update: string | UpdateModelOptions,
+  ): Promise<UpdateModelResult> {
+    if (!this.controller || !this.runtime) {
+      throw new Error("Session is not initialized");
+    }
     const normalized = normalizeUpdateModelInput(update);
     const payload = await this.resolveUpdateModelPayload(normalized);
     const result = await this.controller.updateModel(this.runtime, payload);
@@ -1435,7 +1463,7 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
       this.mode.options.model !== undefined ||
       this.mode.options.reasoningEffort !== undefined
     ) {
-      await this.updateModel({
+      await this.applyModelUpdate({
         ...(this.mode.options.model !== undefined ? { model: this.mode.options.model } : {}),
         ...(this.mode.options.reasoningEffort !== undefined
           ? { reasoningEffort: this.mode.options.reasoningEffort }

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -689,6 +689,7 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
 
   private readonly label: string;
   private readonly requestTimeoutMs: number | undefined;
+  private initializePromise: Promise<SDKInitMessage> | null = null;
   private streamQueue: SDKMessage[] = [];
   private streamResolvers: Array<(msg: SDKMessage | null) => void> = [];
   private removeMessageHandler: (() => void) | null = null;
@@ -709,51 +710,88 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     this.requestTimeoutMs = config.requestTimeoutMs;
   }
 
+  /**
+   * Initialize the session.
+   *
+   * Single-flight: the first caller starts initialization and every
+   * concurrent caller (including the lazily-initializing entry points such
+   * as send()/stream()/listMessages()) awaits the same promise, so a fresh
+   * session never opens more than one runtime connection. A failed attempt
+   * clears the memo so a later call can retry; it only releases the
+   * resources that failed attempt created.
+   */
   async initialize(): Promise<SDKInitMessage> {
-    if (this.initialized) {
-      throw new Error("Session already initialized");
-    }
     if (this.closed) {
       throw new Error("Session is closed");
     }
-
-    try {
-      const init = await this.initializeRuntimeController();
-      this.controller = init.controller;
-      this.runtime = init.runtime;
-      this._agentId = init.runtime.agent_id;
-      this._conversationId = init.runtime.conversation_id;
-      this._sessionId = `${init.runtime.agent_id}:${init.runtime.conversation_id}`;
-      this._modelSettings = init.modelSettings ?? null;
-      this._model =
-        typeof init.model === "string"
-          ? init.model
-          : typeof this._modelSettings?.model === "string"
-            ? this._modelSettings.model
-            : "";
-      this.toolNames = init.tools;
-      this.removeMessageHandler = this.controller.onMessage(this.handleProtocolMessage);
-      this.initialized = true;
-
-      await this.afterRuntimeInitialized();
-      await this.applyPostInitializeOptions();
-
-      const initMessage: SDKInitMessage = {
-        type: "init",
-        agentId: init.runtime.agent_id,
-        sessionId: this._sessionId,
-        conversationId: init.runtime.conversation_id,
-        model: this._model,
-      };
-      if (this.toolNames !== undefined) initMessage.tools = this.toolNames;
-      if (init.skillSources !== undefined) {
-        initMessage.skillSources = init.skillSources;
-      }
-      return initMessage;
-    } catch (error) {
-      this.close();
-      throw error;
+    if (this.initializePromise) {
+      return this.initializePromise;
     }
+    let memo: Promise<SDKInitMessage> | null = null;
+    memo = this.performInitialize().catch((error: unknown) => {
+      // Clear the memo so a later initialize() can retry, and tear down only
+      // this attempt's partial state. Never close() here: single-flight means
+      // no concurrent initialize exists whose healthy connection a losing
+      // attempt could destroy, and the session itself stays usable.
+      if (this.initializePromise === memo) {
+        this.initializePromise = null;
+        this.cleanupFailedInitialize();
+      }
+      throw error;
+    });
+    this.initializePromise = memo;
+    return memo;
+  }
+
+  private async performInitialize(): Promise<SDKInitMessage> {
+    const init = await this.initializeRuntimeController();
+    this.controller = init.controller;
+    this.runtime = init.runtime;
+    this._agentId = init.runtime.agent_id;
+    this._conversationId = init.runtime.conversation_id;
+    this._sessionId = `${init.runtime.agent_id}:${init.runtime.conversation_id}`;
+    this._modelSettings = init.modelSettings ?? null;
+    this._model =
+      typeof init.model === "string"
+        ? init.model
+        : typeof this._modelSettings?.model === "string"
+          ? this._modelSettings.model
+          : "";
+    this.toolNames = init.tools;
+    this.removeMessageHandler = this.controller.onMessage(this.handleProtocolMessage);
+    this.initialized = true;
+
+    await this.afterRuntimeInitialized();
+    await this.applyPostInitializeOptions();
+
+    const initMessage: SDKInitMessage = {
+      type: "init",
+      agentId: init.runtime.agent_id,
+      sessionId: this._sessionId,
+      conversationId: init.runtime.conversation_id,
+      model: this._model,
+    };
+    if (this.toolNames !== undefined) initMessage.tools = this.toolNames;
+    if (init.skillSources !== undefined) {
+      initMessage.skillSources = init.skillSources;
+    }
+    return initMessage;
+  }
+
+  /**
+   * Release the partial state a failed initialize attempt created without
+   * closing the session, so a later initialize() can retry.
+   */
+  private cleanupFailedInitialize(): void {
+    this.removeMessageHandler?.();
+    this.removeMessageHandler = null;
+    this.controller?.close();
+    this.controller = null;
+    // Subclass-owned resources (spawned connections, sandboxes, handlers)
+    // are attempt-scoped too; their cleanup hooks are idempotent.
+    this.onCoreClose();
+    this.runtime = null;
+    this.initialized = false;
   }
 
   async send(message: SendMessage): Promise<void> {

--- a/src/request-ids.ts
+++ b/src/request-ids.ts
@@ -1,0 +1,33 @@
+/**
+ * Collision-free request-id generation for request/response correlation.
+ *
+ * AppServerClient's built-in nextRequestId() is a bare per-instance counter
+ * that restarts at 1, so two client instances (for example two session
+ * objects, or a session plus a management request) each emit ids like
+ * `conversation_retrieve-1`. When more than one connection is involved the
+ * app-server can deliver request-correlated responses where both ids look
+ * identical, and the wrong caller's pending request resolves (or times out).
+ *
+ * Ids generated here embed a per-client random nonce plus a process-wide
+ * monotonic counter, so no two clients in the same process can ever emit the
+ * same id, and cross-process collisions are vanishingly unlikely.
+ */
+
+let processRequestCounter = 0;
+
+/** Create a request-id generator scoped to one client/connection instance. */
+export function createRequestIdGenerator(): (prefix?: string) => string {
+  const nonce = Math.random().toString(36).slice(2, 10);
+  return (prefix = "req") => `${prefix}-${nonce}-${++processRequestCounter}`;
+}
+
+/**
+ * Replace a client's request-id generator with a collision-free one.
+ * Returns the same client for call-site convenience.
+ */
+export function applyUniqueRequestIds<
+  TClient extends { nextRequestId(prefix?: string): string },
+>(client: TClient): TClient {
+  client.nextRequestId = createRequestIdGenerator();
+  return client;
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -127,6 +127,7 @@ export class Session implements AsyncDisposable {
   private _sessionId: string | null = null;
   private _conversationId: string | null = null;
   private initialized = false;
+  private initializePromise: Promise<SDKInitMessage> | null = null;
   private externalTools: Map<string, AnyAgentTool> = new Map();
   private streamQueue: BufferedStreamMessage[] = [];
   private streamResolvers: Array<(msg: BufferedStreamMessage | null) => void> = [];
@@ -169,13 +170,29 @@ export class Session implements AsyncDisposable {
   }
 
   /**
-   * Initialize the session (called automatically on first send)
+   * Initialize the session (called automatically on first send).
+   *
+   * Single-flight: concurrent callers (including lazily-initializing entry
+   * points such as send()) share one in-flight initialization instead of
+   * each connecting the transport. A failed attempt clears the memo so a
+   * later call can retry.
    */
   async initialize(): Promise<SDKInitMessage> {
-    if (this.initialized) {
-      throw new Error("Session already initialized");
+    if (this.initializePromise) {
+      return this.initializePromise;
     }
+    let memo: Promise<SDKInitMessage> | null = null;
+    memo = this.performInitialize().catch((error: unknown) => {
+      if (this.initializePromise === memo) {
+        this.initializePromise = null;
+      }
+      throw error;
+    });
+    this.initializePromise = memo;
+    return memo;
+  }
 
+  private async performInitialize(): Promise<SDKInitMessage> {
     sessionLog("init", "connecting transport...");
     await this.transport.connect();
     sessionLog("init", "transport connected, sending initialize request");

--- a/src/session.ts
+++ b/src/session.ts
@@ -127,6 +127,7 @@ export class Session implements AsyncDisposable {
   private _sessionId: string | null = null;
   private _conversationId: string | null = null;
   private initialized = false;
+  private closed = false;
   private initializePromise: Promise<SDKInitMessage> | null = null;
   private externalTools: Map<string, AnyAgentTool> = new Map();
   private streamQueue: BufferedStreamMessage[] = [];
@@ -174,20 +175,34 @@ export class Session implements AsyncDisposable {
    *
    * Single-flight: concurrent callers (including lazily-initializing entry
    * points such as send()) share one in-flight initialization instead of
-   * each connecting the transport. A failed attempt clears the memo so a
-   * later call can retry.
+   * each connecting the transport. A failed stdio attempt closes the session
+   * because its subprocess transport is no longer safe to reuse.
    */
   async initialize(): Promise<SDKInitMessage> {
+    if (this.closed) {
+      throw new Error("Session is closed");
+    }
     if (this.initializePromise) {
       return this.initializePromise;
     }
-    let memo: Promise<SDKInitMessage> | null = null;
-    memo = this.performInitialize().catch((error: unknown) => {
-      if (this.initializePromise === memo) {
-        this.initializePromise = null;
-      }
-      throw error;
-    });
+    if (this.initialized) {
+      throw new Error("Session already initialized");
+    }
+
+    const attempt = this.performInitialize();
+    const memo = attempt
+      .catch((error: unknown) => {
+        // A failed stdio initialization can leave its one subprocess
+        // transport unusable. Closing this session cannot affect another
+        // initialize attempt because all callers share this promise.
+        this.cleanupFailedInitialize();
+        throw error;
+      })
+      .finally(() => {
+        if (this.initializePromise === memo) {
+          this.initializePromise = null;
+        }
+      });
     this.initializePromise = memo;
     return memo;
   }
@@ -235,13 +250,17 @@ export class Session implements AsyncDisposable {
         this._agentId = initMsg.agent_id;
         this._sessionId = initMsg.session_id;
         this._conversationId = initMsg.conversation_id;
-        this.initialized = true;
-        this.startBackgroundPump();
 
         // Register external tools with CLI
         if (this.externalTools.size > 0) {
           await this.registerExternalTools();
         }
+        if (this.closed) {
+          throw new Error("Session is closed");
+        }
+
+        this.initialized = true;
+        this.startBackgroundPump();
 
         // Include external tool names in the tools list
         const allTools = [
@@ -279,6 +298,17 @@ export class Session implements AsyncDisposable {
     const detail = stderr ? `\nCLI stderr:\n${stderr}` : '';
     sessionLog("init", `ERROR: transport closed before init message received${detail}`);
     throw new Error(`Failed to initialize session - no init message received${detail}`);
+  }
+
+  private cleanupFailedInitialize(): void {
+    this.transport.close();
+    this.closed = true;
+    this.initialized = false;
+    this._agentId = null;
+    this._sessionId = null;
+    this._conversationId = null;
+    this.pumpClosed = true;
+    this.resolveAllStreamWaiters(null);
   }
 
   /**
@@ -1306,6 +1336,8 @@ export class Session implements AsyncDisposable {
    * Close the session
    */
   close(): void {
+    if (this.closed) return;
+    this.closed = true;
     sessionLog("close", `closing session (agent=${this._agentId}, conversation=${this._conversationId})`);
     this.transport.close();
     this.pumpClosed = true;

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -37,6 +37,9 @@ class FakeAppServerSocket {
     | "queuedSecond"
     | "hang" = "normal";
   static failNextRuntimeStart = false;
+  static deferReflectionSettingsResponse = false;
+  static failNextReflectionSettings = false;
+  static pendingReflectionSettingsResponse: (() => void) | null = null;
   readyState = 0;
   sent: unknown[] = [];
   private listeners = new Map<string, Set<Listener>>();
@@ -180,13 +183,26 @@ function fakeAppServerHandle(
   }
 
   if (command.type === "set_reflection_settings") {
-    control.serverMessage({
-      type: "set_reflection_settings_response",
-      request_id: command.request_id,
-      success: true,
-      scope: command.scope,
-      reflection_settings: command.settings,
-    });
+    const respond = () => {
+      const success = !FakeAppServerSocket.failNextReflectionSettings;
+      FakeAppServerSocket.failNextReflectionSettings = false;
+      control.serverMessage({
+        type: "set_reflection_settings_response",
+        request_id: command.request_id,
+        success,
+        ...(success
+          ? {
+              scope: command.scope,
+              reflection_settings: command.settings,
+            }
+          : { error: "reflection settings failed (fake)" }),
+      });
+    };
+    if (FakeAppServerSocket.deferReflectionSettingsResponse) {
+      FakeAppServerSocket.pendingReflectionSettingsResponse = respond;
+    } else {
+      respond();
+    }
     return;
   }
 
@@ -1436,7 +1452,114 @@ describe("LettaAgentClient", () => {
       expect(first).toEqual(second);
       expect(first.conversationId).toBe("conv-abc");
       expect(FakeAppServerSocket.instances).toHaveLength(2);
+      await expect(asAdvanced(session).initialize()).rejects.toThrow(
+        "Session already initialized",
+      );
     } finally {
+      session.close();
+    }
+  });
+
+  test("lazy callers wait until post-initialize options finish", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.deferReflectionSettingsResponse = true;
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.resumeSession("agent-123", {
+      dreaming: { trigger: "step-count", stepCount: 3 },
+    });
+    try {
+      const initialize = asAdvanced(session).initialize();
+      for (let i = 0; i < 100; i++) {
+        if (FakeAppServerSocket.pendingReflectionSettingsResponse) break;
+        await Promise.resolve();
+      }
+      expect(FakeAppServerSocket.pendingReflectionSettingsResponse).not.toBeNull();
+
+      const listMessages = session.listMessages({ limit: 1 });
+      await Promise.resolve();
+      expect(
+        fakeControlSocket().sent.filter(
+          (command) =>
+            (command as { type?: string }).type ===
+            "conversation_messages_list",
+        ),
+      ).toHaveLength(0);
+
+      FakeAppServerSocket.pendingReflectionSettingsResponse?.();
+      const [, page] = await Promise.all([initialize, listMessages]);
+      expect(page.messages).toHaveLength(2);
+    } finally {
+      FakeAppServerSocket.deferReflectionSettingsResponse = false;
+      FakeAppServerSocket.pendingReflectionSettingsResponse = null;
+      session.close();
+    }
+  });
+
+  test("failed post-initialize work clears partial session metadata", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.failNextReflectionSettings = true;
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.resumeSession("agent-123", {
+      dreaming: { trigger: "step-count", stepCount: 3 },
+    });
+    try {
+      await expect(asAdvanced(session).initialize()).rejects.toThrow(
+        "reflection settings failed (fake)",
+      );
+      expect(session.agentId).toBeNull();
+      expect(session.sessionId).toBeNull();
+      expect(session.conversationId).toBeNull();
+
+      const init = await asAdvanced(session).initialize();
+      expect(init.agentId).toBe("agent-123");
+    } finally {
+      FakeAppServerSocket.failNextReflectionSettings = false;
+      session.close();
+    }
+  });
+
+  test("closing during initialization cannot resurrect the session", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.deferReflectionSettingsResponse = true;
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.resumeSession("agent-123", {
+      dreaming: { trigger: "step-count", stepCount: 3 },
+    });
+    try {
+      const initialize = asAdvanced(session).initialize();
+      for (let i = 0; i < 100; i++) {
+        if (FakeAppServerSocket.pendingReflectionSettingsResponse) break;
+        await Promise.resolve();
+      }
+      expect(FakeAppServerSocket.pendingReflectionSettingsResponse).not.toBeNull();
+
+      session.close();
+      FakeAppServerSocket.pendingReflectionSettingsResponse?.();
+      await expect(initialize).rejects.toThrow();
+      await expect(asAdvanced(session).initialize()).rejects.toThrow(
+        "Session is closed",
+      );
+      expect(session.agentId).toBeNull();
+      expect(session.sessionId).toBeNull();
+      expect(session.conversationId).toBeNull();
+    } finally {
+      FakeAppServerSocket.deferReflectionSettingsResponse = false;
+      FakeAppServerSocket.pendingReflectionSettingsResponse = null;
       session.close();
     }
   });

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -36,6 +36,7 @@ class FakeAppServerSocket {
     | "manualApprovalWait"
     | "queuedSecond"
     | "hang" = "normal";
+  static failNextRuntimeStart = false;
   readyState = 0;
   sent: unknown[] = [];
   private listeners = new Map<string, Set<Listener>>();
@@ -54,7 +55,7 @@ class FakeAppServerSocket {
   send(data: string): void {
     const command = JSON.parse(data) as Record<string, unknown>;
     this.sent.push(command);
-    fakeAppServerHandle(command);
+    fakeAppServerHandle(command, this);
   }
 
   close(): void {
@@ -110,6 +111,20 @@ function fakeStreamSocket(): FakeAppServerSocket {
   return socket;
 }
 
+/**
+ * The stream socket belonging to the same AppServerClient as `control`.
+ * AppServerClient constructs its control socket immediately before its
+ * stream socket, so the pair is adjacent in the instances list.
+ */
+function fakeStreamPairOf(control: FakeAppServerSocket): FakeAppServerSocket {
+  const index = FakeAppServerSocket.instances.indexOf(control);
+  const stream = FakeAppServerSocket.instances[index + 1];
+  if (!stream || !stream.url.includes("channel=stream")) {
+    throw new Error("missing paired fake stream socket");
+  }
+  return stream;
+}
+
 const FAKE_MODEL_ENTRIES = [
   {
     id: "sonnet-low",
@@ -134,10 +149,18 @@ const FAKE_MODEL_ENTRIES = [
   },
 ];
 
-function fakeAppServerHandle(command: Record<string, unknown>): void {
+function fakeAppServerHandle(
+  command: Record<string, unknown>,
+  sender: FakeAppServerSocket,
+): void {
+  // Commands always arrive on a control socket; reply to the sending
+  // client's own pair so tests can run several client instances at once.
+  const control = sender;
+  const stream = fakeStreamPairOf(sender);
+
   if (command.type === "conversation_retrieve") {
     const conversationId = command.conversation_id as string;
-    fakeControlSocket().serverMessage({
+    control.serverMessage({
       type: "conversation_retrieve_response",
       request_id: command.request_id,
       success: true,
@@ -147,7 +170,7 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
   }
 
   if (command.type === "enable_memfs") {
-    fakeControlSocket().serverMessage({
+    control.serverMessage({
       type: "enable_memfs_response",
       request_id: command.request_id,
       success: true,
@@ -157,7 +180,7 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
   }
 
   if (command.type === "set_reflection_settings") {
-    fakeControlSocket().serverMessage({
+    control.serverMessage({
       type: "set_reflection_settings_response",
       request_id: command.request_id,
       success: true,
@@ -168,7 +191,7 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
   }
 
   if (command.type === "list_models") {
-    fakeControlSocket().serverMessage({
+    control.serverMessage({
       type: "list_models_response",
       request_id: command.request_id,
       success: true,
@@ -186,7 +209,7 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
     const modelHandle =
       (typeof payload?.model_handle === "string" ? payload.model_handle : undefined) ??
       byId?.handle;
-    fakeControlSocket().serverMessage({
+    control.serverMessage({
       type: "update_model_response",
       request_id: command.request_id,
       success: true,
@@ -209,7 +232,7 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
   }
 
   if (command.type === "update_toolset") {
-    fakeControlSocket().serverMessage({
+    control.serverMessage({
       type: "update_toolset_response",
       request_id: command.request_id,
       success: true,
@@ -221,7 +244,7 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
 
   if (command.type === "sync") {
     if (FakeAppServerSocket.deviceStatusOnSync && command.force_device_status === true) {
-      fakeControlSocket().serverMessage({
+      control.serverMessage({
         type: "update_device_status",
         runtime: command.runtime,
         device_status: {
@@ -255,7 +278,7 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
       });
     }
     if (typeof command.request_id === "string") {
-      fakeControlSocket().serverMessage({
+      control.serverMessage({
         type: "sync_response",
         request_id: command.request_id,
         runtime: command.runtime,
@@ -266,7 +289,7 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
   }
 
   if (command.type === "remove_queue_item" && typeof command.request_id === "string") {
-    fakeControlSocket().serverMessage({
+    control.serverMessage({
       type: "remove_queue_item_response",
       request_id: command.request_id,
       runtime: command.runtime,
@@ -277,7 +300,7 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
   }
 
   if (command.type === "abort_message" && typeof command.request_id === "string") {
-    fakeControlSocket().serverMessage({
+    control.serverMessage({
       type: "abort_message_response",
       request_id: command.request_id,
       runtime: command.runtime,
@@ -288,7 +311,7 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
   }
 
   if (command.type === "conversation_messages_list") {
-    fakeControlSocket().serverMessage({
+    control.serverMessage({
       type: "conversation_messages_list_response",
       request_id: command.request_id,
       success: true,
@@ -301,13 +324,26 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
   }
 
   if (command.type === "runtime_start") {
+    if (FakeAppServerSocket.failNextRuntimeStart) {
+      FakeAppServerSocket.failNextRuntimeStart = false;
+      control.serverMessage({
+        type: "runtime_start_response",
+        request_id: command.request_id,
+        success: false,
+        runtime: null,
+        agent: null,
+        conversation: null,
+        error: "runtime start failed (fake)",
+      });
+      return;
+    }
     const createdAgent = command.create_agent as Record<string, unknown> | undefined;
     const agentId = (command.agent_id as string | undefined) ?? "agent-created";
     const conversationId =
       command.conversation_id === "default"
         ? "default"
         : ((command.conversation_id as string | undefined) ?? "conv-created");
-    fakeControlSocket().serverMessage({
+    control.serverMessage({
       type: "runtime_start_response",
       request_id: command.request_id,
       success: true,
@@ -332,13 +368,13 @@ function fakeAppServerHandle(command: Record<string, unknown>): void {
     const runtime = command.runtime;
     const emitStream = (message: unknown) => {
       if (FakeAppServerSocket.mirrorStreamToControl) {
-        fakeControlSocket().serverMessage(message);
+        control.serverMessage(message);
       }
-      fakeStreamSocket().serverMessage(message);
+      stream.serverMessage(message);
     };
 
     if (FakeAppServerSocket.inputScenario === "queuedSecond") {
-      const inputCount = fakeControlSocket().sent.filter(
+      const inputCount = control.sent.filter(
         (sent) => (sent as { type?: string }).type === "input",
       ).length;
       const payload = command.payload as { messages?: Array<Record<string, unknown>> };
@@ -1352,6 +1388,113 @@ describe("LettaAgentClient", () => {
         conversation_id: "conv-abc",
       });
     } finally {
+      session.close();
+    }
+  });
+
+  test("concurrent listMessages and send on a fresh session share one initialize", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.resumeSession("conv-abc");
+    try {
+      const [page] = await Promise.all([
+        session.listMessages({ limit: 2 }),
+        session.send("hello"),
+      ]);
+      expect(page.messages).toHaveLength(2);
+
+      // Exactly one control+stream pair: the second caller must join the
+      // in-flight initialize instead of opening its own connection.
+      expect(FakeAppServerSocket.instances).toHaveLength(2);
+      const sent = fakeControlSocket().sent as Array<{ type?: string }>;
+      expect(sent.filter((cmd) => cmd.type === "conversation_retrieve")).toHaveLength(1);
+      expect(sent.filter((cmd) => cmd.type === "runtime_start")).toHaveLength(1);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("concurrent initialize callers resolve from the same attempt", async () => {
+    FakeAppServerSocket.instances = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.resumeSession("conv-abc");
+    try {
+      const [first, second] = await Promise.all([
+        asAdvanced(session).initialize(),
+        asAdvanced(session).initialize(),
+      ]);
+      expect(first).toEqual(second);
+      expect(first.conversationId).toBe("conv-abc");
+      expect(FakeAppServerSocket.instances).toHaveLength(2);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("request ids never collide across two concurrent client instances", async () => {
+    FakeAppServerSocket.instances = [];
+    const makeClient = () =>
+      new LettaAgentClient({
+        backend: "remote",
+        url: "ws://127.0.0.1:4500/ws",
+        WebSocket: FakeAppServerSocket,
+      });
+
+    const sessionA = makeClient().resumeSession("conv-abc");
+    const sessionB = makeClient().resumeSession("conv-abc");
+    try {
+      await Promise.all([
+        asAdvanced(sessionA).initialize(),
+        asAdvanced(sessionB).initialize(),
+      ]);
+
+      const requestIds = FakeAppServerSocket.instances
+        .flatMap((socket) => socket.sent as Array<{ request_id?: unknown }>)
+        .map((cmd) => cmd.request_id)
+        .filter((id): id is string => typeof id === "string");
+      // Both sessions send conversation_retrieve + runtime_start; per-client
+      // counters restarting at 1 would collide here (conversation_retrieve-1).
+      expect(requestIds.length).toBeGreaterThanOrEqual(4);
+      expect(new Set(requestIds).size).toBe(requestIds.length);
+    } finally {
+      sessionA.close();
+      sessionB.close();
+    }
+  });
+
+  test("a failed initialize clears the single-flight memo so a retry succeeds", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.failNextRuntimeStart = true;
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.resumeSession("agent-123");
+    try {
+      await expect(asAdvanced(session).initialize()).rejects.toThrow(
+        "runtime start failed (fake)",
+      );
+
+      // The failure must not close the session; a retry opens a fresh
+      // connection and completes.
+      const init = await asAdvanced(session).initialize();
+      expect(init.agentId).toBe("agent-123");
+      const page = await session.listMessages();
+      expect(page.messages).toHaveLength(2);
+    } finally {
+      FakeAppServerSocket.failNextRuntimeStart = false;
       session.close();
     }
   });

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1398,6 +1398,38 @@ describe("CloudEnvironmentSession", () => {
     }
   });
 
+  test("concurrent Cloud listMessages and send share one initialize and connection", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      environment: { connectionId: "conn-explicit" },
+    });
+
+    const session = client.resumeSession("conv-1");
+    try {
+      const [page] = await Promise.all([
+        session.listMessages({ limit: 1 }),
+        session.send("hello"),
+      ]);
+      expect(page.messages).toEqual([{ id: "msg-from-runtime" }]);
+
+      // A single control+stream pair and a single runtime_start: the second
+      // caller joins the in-flight initialize instead of reconnecting.
+      expect(FakeCloudSocket.instances).toHaveLength(2);
+      expect(
+        FakeCloudSocket.allSent().filter((cmd) => cmd.type === "runtime_start"),
+      ).toHaveLength(1);
+    } finally {
+      session.close();
+    }
+  });
+
   test("lists explicit Cloud conversation ids through runtime protocol instead of Cloud REST", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];

--- a/src/tests/session.test.ts
+++ b/src/tests/session.test.ts
@@ -6,11 +6,13 @@ const BUFFER_LIMIT = 100;
 
 class MockTransport {
   writes: unknown[] = [];
+  connectCount = 0;
   private queue: WireMessage[] = [];
   private resolvers: Array<(msg: WireMessage | null) => void> = [];
   private closed = false;
 
   async connect(): Promise<void> {
+    this.connectCount++;
     return;
   }
 
@@ -283,6 +285,34 @@ async function waitFor(
 }
 
 describe("Session", () => {
+  test("concurrent initialize callers share one stdio attempt", async () => {
+    const session = new Session();
+    const transport = new MockTransport();
+    attachMockTransport(session, transport);
+
+    try {
+      const first = session.initialize();
+      const second = session.initialize();
+      transport.push(createInitMessage());
+
+      const [firstInit, secondInit] = await Promise.all([first, second]);
+      expect(firstInit).toEqual(secondInit);
+      expect(transport.connectCount).toBe(1);
+      expect(
+        transport.writes.filter(
+          (message) =>
+            (message as { request?: { subtype?: string } }).request?.subtype ===
+            "initialize",
+        ),
+      ).toHaveLength(1);
+      await expect(session.initialize()).rejects.toThrow(
+        "Session already initialized",
+      );
+    } finally {
+      session.close();
+    }
+  });
+
   test("initialize returns optional init settings when provided by CLI", async () => {
     const session = new Session();
     const transport = new MockTransport();


### PR DESCRIPTION
## The bug

Reproduced live against a local `letta server --listen` app-server while building the mobile reference app (LET-10209); tracked there as **SDK-FEEDBACK.md #000**.

Calling `session.listMessages()` and `session.send()` or `stream()` concurrently on a fresh remote session made each entry point trigger its own `initialize()`:

1. Two control+stream socket pairs opened.
2. The single-client app-server rejected the second pair with `1008 control channel already connected`.
3. Both clients could emit the same per-instance request IDs, such as `conversation_retrieve-1`.
4. Failure cleanup from one attempt could tear down state established by the other.

## What changed

### Single-flight initialization

`RemoteClientSessionCore` and the legacy stdio `Session` now memoize only the in-flight initialization attempt. Concurrent lazy entry points share that attempt and cannot create duplicate transports.

The lifecycle commit now happens only after all startup work finishes:

- post-initialize settings such as dreaming, memfs, model, and reasoning effort complete before lazy callers can use the session
- internal model setup bypasses the public lazy-initialize wrapper, avoiding self-deadlock
- failed remote initialization clears partial controller/runtime state and public IDs before a retry
- closing during initialization cannot resurrect the session
- failed stdio initialization closes its single subprocess session because that transport is not safely reusable
- a later explicit `initialize()` on a successfully initialized session still throws `Session already initialized`, preserving the existing API

### Collision-resistant request IDs

`applyUniqueRequestIds()` adds a per-client nonce and process-wide monotonic counter to request IDs. Separate SDK clients in the same process no longer reuse IDs such as `conversation_retrieve-1`.

It is applied to every `AppServerClient` created by app-server sessions, Cloud sessions, and the pooled management transport.

## Rebase onto #213

#213 is merged and this branch is rebased onto it. The combined connection path intentionally:

1. waits for #213's in-flight management request and releases its pooled control connection
2. creates the session's control/stream client
3. applies #214's collision-resistant request-ID generator

The pooled management client also retains the same request-ID generator.

## Tests

New regression coverage verifies:

- concurrent `listMessages()` and `send()` open one socket pair and send one initialize sequence
- concurrent explicit `initialize()` calls share one remote attempt
- concurrent legacy stdio initialization shares one subprocess attempt
- lazy callers remain blocked until post-initialize options finish
- failed post-initialize work clears partial IDs and can retry remotely
- closing during initialization cannot resurrect a session
- sequential explicit initialization preserves the prior error contract
- request IDs do not collide across concurrent client instances
- Cloud lazy callers share one initialization and connection
- the #213 management-to-session handoff suite remains green

Verification after rebasing:

- `bun run check`
- `bun test` — 260 pass, 11 skipped, 0 fail
- `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
