### PR TITLE
feat(cloud): clone GitHub repositories into sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ access through the organization's GitHub integration.
 await using session = client.createSession(agentId, {
   sandbox: {
     githubRepositories: [
-      { owner: "letta-ai", repo: "letta-docs" },
+      { owner: "letta-ai", repo: "letta-docs-md" },
       { owner: "letta-ai", repo: "letta-code" },
     ],
   },

--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ await using session = client.createSession(agentId, {
 });
 ```
 
+### Managed Cloud sandbox repositories
+
+Cloud sessions can clone up to 10 GitHub repositories into the managed
+sandbox. Public repositories clone directly; private repositories require
+access through the organization's GitHub integration.
+
+```ts
+await using session = client.createSession(agentId, {
+  sandbox: {
+    githubRepositories: [
+      { owner: "letta-ai", repo: "letta-docs" },
+      { owner: "letta-ai", repo: "letta-code" },
+    ],
+  },
+});
+```
+
 ### Remote App Server
 
 ```ts

--- a/src/cloud-sandbox.ts
+++ b/src/cloud-sandbox.ts
@@ -1,0 +1,117 @@
+/** A GitHub repository cloned into an SDK-managed Cloud sandbox. */
+export interface GitHubRepositoryRef {
+  owner: string;
+  repo: string;
+}
+
+export interface LettaCodeCloudSandboxOptions {
+  /**
+   * TTL to request when refreshing an SDK-managed sandbox. Defaults to 5
+   * minutes, matching the Cloud API default. Valid range: 1-60.
+   */
+  ttlMinutes?: number;
+  /** Timeout waiting for a newly created sandbox environment to come online. */
+  readyTimeoutMs?: number;
+  /** Poll interval while waiting for a newly created sandbox environment. */
+  readyPollIntervalMs?: number;
+  /** Interval for proactive TTL refreshes while the session is open. */
+  refreshIntervalMs?: number;
+  /**
+   * GitHub repositories to clone into `/root/workspace` when creating the
+   * managed sandbox. Up to 10 repositories may be provided. Private
+   * repositories require access through the organization's GitHub integration.
+   */
+  githubRepositories?: GitHubRepositoryRef[];
+  /**
+   * Best-effort terminate the SDK-managed sandbox on session close. Defaults to
+   * false so other sessions for the same conversation and reconnecting clients
+   * can continue using it. Set true to restore eager cleanup when this session
+   * exclusively owns the sandbox.
+   */
+  terminateOnClose?: boolean;
+}
+
+const MIN_TTL_MINUTES = 1;
+const MAX_TTL_MINUTES = 60;
+const MAX_GITHUB_REPOSITORIES = 10;
+const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9-]+$/;
+const GITHUB_REPOSITORY_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+function validatePositiveInteger(value: number | undefined, name: string): void {
+  if (value !== undefined && (!Number.isInteger(value) || value <= 0)) {
+    throw new Error(`Invalid ${name}. Expected a positive integer.`);
+  }
+}
+
+export function validateCloudSandboxOptions(
+  options: LettaCodeCloudSandboxOptions | undefined,
+  name: string,
+): void {
+  if (options === undefined) return;
+  if (options === null || typeof options !== "object" || Array.isArray(options)) {
+    throw new Error(`Invalid ${name}. Expected an object.`);
+  }
+  if (
+    options.ttlMinutes !== undefined &&
+    (!Number.isInteger(options.ttlMinutes) ||
+      options.ttlMinutes < MIN_TTL_MINUTES ||
+      options.ttlMinutes > MAX_TTL_MINUTES)
+  ) {
+    throw new Error(
+      `Invalid ${name}.ttlMinutes. Expected an integer between ${MIN_TTL_MINUTES} and ${MAX_TTL_MINUTES}.`,
+    );
+  }
+  validatePositiveInteger(options.readyTimeoutMs, `${name}.readyTimeoutMs`);
+  validatePositiveInteger(
+    options.readyPollIntervalMs,
+    `${name}.readyPollIntervalMs`,
+  );
+  validatePositiveInteger(options.refreshIntervalMs, `${name}.refreshIntervalMs`);
+
+  if (options.githubRepositories !== undefined) {
+    if (!Array.isArray(options.githubRepositories)) {
+      throw new Error(
+        `Invalid ${name}.githubRepositories. Expected an array.`,
+      );
+    }
+    if (options.githubRepositories.length > MAX_GITHUB_REPOSITORIES) {
+      throw new Error(
+        `Invalid ${name}.githubRepositories. Expected at most ${MAX_GITHUB_REPOSITORIES} repositories.`,
+      );
+    }
+    for (const [index, repository] of options.githubRepositories.entries()) {
+      if (
+        repository === null ||
+        typeof repository !== "object" ||
+        Array.isArray(repository)
+      ) {
+        throw new Error(
+          `Invalid ${name}.githubRepositories[${index}]. Expected an object.`,
+        );
+      }
+      if (
+        typeof repository.owner !== "string" ||
+        !GITHUB_OWNER_PATTERN.test(repository.owner)
+      ) {
+        throw new Error(
+          `Invalid ${name}.githubRepositories[${index}].owner.`,
+        );
+      }
+      if (
+        typeof repository.repo !== "string" ||
+        !GITHUB_REPOSITORY_PATTERN.test(repository.repo)
+      ) {
+        throw new Error(
+          `Invalid ${name}.githubRepositories[${index}].repo.`,
+        );
+      }
+    }
+  }
+
+  if (
+    options.terminateOnClose !== undefined &&
+    typeof options.terminateOnClose !== "boolean"
+  ) {
+    throw new Error(`Invalid ${name}.terminateOnClose. Expected a boolean.`);
+  }
+}

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -31,19 +31,20 @@ import type {
   CreateAgentOptions,
   LettaCodeClientSessionOptions,
   LettaCodeCloudClientOptions,
-  LettaCodeCloudSandboxOptions,
   LettaCodeEnvironment,
   LettaCodeSocketConstructor,
   LettaCodeSocketLike,
   RepositoryResource,
 } from "./types.js";
+import {
+  type LettaCodeCloudSandboxOptions,
+  validateCloudSandboxOptions,
+} from "./cloud-sandbox.js";
 
 const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
 const DEFAULT_TURN_TIMEOUT_MS = 120_000;
 const DEFAULT_PING_INTERVAL_MS = 30_000;
 const DEFAULT_SANDBOX_TTL_MINUTES = 5;
-const MIN_SANDBOX_TTL_MINUTES = 1;
-const MAX_SANDBOX_TTL_MINUTES = 60;
 const DEFAULT_SANDBOX_READY_TIMEOUT_MS = 120_000;
 const DEFAULT_SANDBOX_READY_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_REPOSITORY_ATTACH_TIMEOUT_MS = 10_000;
@@ -262,43 +263,6 @@ function assertOkResponse(response: Response, body: unknown, action: string, url
 function validatePositiveInteger(value: number | undefined, name: string): void {
   if (value !== undefined && (!Number.isInteger(value) || value <= 0)) {
     throw new Error(`Invalid ${name}. Expected a positive integer.`);
-  }
-}
-
-function validateIntegerRange(
-  value: number | undefined,
-  name: string,
-  min: number,
-  max: number,
-): void {
-  if (value === undefined) return;
-  if (!Number.isInteger(value) || value < min || value > max) {
-    throw new Error(`Invalid ${name}. Expected an integer between ${min} and ${max}.`);
-  }
-}
-
-function validateCloudSandboxOptions(
-  options: LettaCodeCloudSandboxOptions | undefined,
-  name: string,
-): void {
-  if (options === undefined) return;
-  if (options === null || typeof options !== "object" || Array.isArray(options)) {
-    throw new Error(`Invalid ${name}. Expected an object.`);
-  }
-  validateIntegerRange(
-    options.ttlMinutes,
-    `${name}.ttlMinutes`,
-    MIN_SANDBOX_TTL_MINUTES,
-    MAX_SANDBOX_TTL_MINUTES,
-  );
-  validatePositiveInteger(options.readyTimeoutMs, `${name}.readyTimeoutMs`);
-  validatePositiveInteger(options.readyPollIntervalMs, `${name}.readyPollIntervalMs`);
-  validatePositiveInteger(options.refreshIntervalMs, `${name}.refreshIntervalMs`);
-  if (
-    options.terminateOnClose !== undefined &&
-    typeof options.terminateOnClose !== "boolean"
-  ) {
-    throw new Error(`Invalid ${name}.terminateOnClose. Expected a boolean.`);
   }
 }
 
@@ -1083,12 +1047,19 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   ): Promise<ManagedCloudSandbox> {
     const fetchImpl = getFetch(this.cloudOptions.fetch);
     const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+    const sandboxOptions = this.resolvedSandboxOptions();
+    const githubRepositories = sandboxOptions.githubRepositories;
     const response = await fetchImpl(
       `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/sandboxes`,
       {
         method: "POST",
         headers: cloudHeaders(this.cloudOptions),
-        body: JSON.stringify(conversationId ? { conversationId } : {}),
+        body: JSON.stringify({
+          ...(conversationId ? { conversationId } : {}),
+          ...(githubRepositories && githubRepositories.length > 0
+            ? { githubRepositories }
+            : {}),
+        }),
       },
     );
     const body = await parseJsonResponse(response);
@@ -1108,7 +1079,6 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       );
     }
 
-    const sandboxOptions = this.resolvedSandboxOptions();
     const ttlMinutes = sandboxOptions.ttlMinutes ?? DEFAULT_SANDBOX_TTL_MINUTES;
     const readyTimeoutMs = sandboxOptions.readyTimeoutMs
       ?? DEFAULT_SANDBOX_READY_TIMEOUT_MS;

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ export type {
   LettaCodeLocalAppServerOptions,
   LettaCodeRemoteClientOptions,
   LettaCodeCloudClientOptions,
+  LettaCodeCloudSandboxOptions,
+  GitHubRepositoryRef,
   LettaCodeClientOptions,
   LettaCodeClientSessionOptions,
   LettaCodeSession,

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -697,6 +697,45 @@ describe("CloudEnvironmentSession", () => {
     }
   });
 
+  test("clones configured GitHub repositories into a managed sandbox", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+    });
+
+    const session = client.resumeSession("conv-1", {
+      sandbox: {
+        githubRepositories: [
+          { owner: "letta-ai", repo: "letta-docs" },
+          { owner: "letta-ai", repo: "letta-code" },
+        ],
+      },
+    });
+    try {
+      await asAdvanced(session).initialize();
+
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "POST",
+        url: "https://api.test/v1/agents/agent-from-conv/sandboxes",
+        body: {
+          conversationId: "conv-1",
+          githubRepositories: [
+            { owner: "letta-ai", repo: "letta-docs" },
+            { owner: "letta-ai", repo: "letta-code" },
+          ],
+        },
+      }));
+    } finally {
+      session.close();
+    }
+  });
+
   test("falls back to the agent-scoped sandbox lifecycle against legacy servers", async () => {
     resetFakeCloud();
     const requests: RecordedRequest[] = [];
@@ -1840,6 +1879,42 @@ describe("CloudEnvironmentSession", () => {
       WebSocket: FakeCloudSocket,
       sandbox: { ttlMinutes: 61 },
     })).toThrow("Invalid sandbox.ttlMinutes");
+
+    expect(() => new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock([]),
+      WebSocket: FakeCloudSocket,
+      sandbox: {
+        githubRepositories: Array.from({ length: 11 }, (_, index) => ({
+          owner: "letta-ai",
+          repo: `repo-${index}`,
+        })),
+      },
+    })).toThrow("Expected at most 10 repositories");
+
+    expect(() => new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock([]),
+      WebSocket: FakeCloudSocket,
+      sandbox: {
+        githubRepositories: [{ owner: "letta ai", repo: "letta-code" }],
+      },
+    })).toThrow("githubRepositories[0].owner");
+
+    expect(() => new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock([]),
+      WebSocket: FakeCloudSocket,
+      sandbox: {
+        githubRepositories: [{ owner: "letta-ai", repo: "letta/code" }],
+      },
+    })).toThrow("githubRepositories[0].repo");
 
     const clientWithEnvironment = new LettaAgentClient({
       backend: "cloud",

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,11 @@ export type {
 // Import types for use in this file
 import type { CreateBlock, CanUseToolResponse } from "./protocol.js";
 import type { PersonalityId } from "@letta-ai/letta-code/agent-presets";
+import type { LettaCodeCloudSandboxOptions } from "./cloud-sandbox.js";
+export type {
+  GitHubRepositoryRef,
+  LettaCodeCloudSandboxOptions,
+} from "./cloud-sandbox.js";
 
 /** Letta Code personality preset used to seed a new agent. */
 export type LettaCodePersonalityId = PersonalityId;
@@ -346,27 +351,6 @@ export interface LettaCodeRemoteClientOptions {
   idleLingerMs?: number;
   /** Whether agents created through this app-server are added to Letta Code's global pinned-agent list. */
   pinGlobalAgent?: boolean;
-}
-
-export interface LettaCodeCloudSandboxOptions {
-  /**
-   * TTL to request when refreshing an SDK-managed sandbox. Defaults to 5
-   * minutes, matching the Cloud API default. Valid range: 1-60.
-   */
-  ttlMinutes?: number;
-  /** Timeout waiting for a newly created sandbox environment to come online. */
-  readyTimeoutMs?: number;
-  /** Poll interval while waiting for a newly created sandbox environment. */
-  readyPollIntervalMs?: number;
-  /** Interval for proactive TTL refreshes while the session is open. */
-  refreshIntervalMs?: number;
-  /**
-   * Best-effort terminate the SDK-managed sandbox on session close. Defaults to
-   * false so other sessions for the same conversation and reconnecting clients
-   * can continue using it. Set true to restore eager cleanup when this session
-   * exclusively owns the sandbox.
-   */
-  terminateOnClose?: boolean;
 }
 
 export interface LettaCodeCloudClientOptions {


### PR DESCRIPTION
## Summary

- expose `githubRepositories` on managed Cloud sandbox options for both client defaults and individual sessions
- forward up to 10 validated owner/repository pairs when creating a managed sandbox
- export the new public option types from the root and portable client surfaces
- document repository cloning and preserve existing managed-sandbox lifecycle behavior
- extract sandbox option validation into a focused module so source-size budgets continue to pass

This provides the Agent SDK seam needed by LET-10278 so application agents can inspect checked-out documentation and source repositories without custom sandbox provisioning.

## Validation

- `bun run check`
- `bun test` — 261 passing, 11 skipped
- `bun run build`

👾 Generated with [Letta Code](https://letta.com)