### PR TITLE
fix(stream): expose text stream lineage and replay cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ for await (const message of session.stream()) {
 }
 ```
 
+Assistant and reasoning messages are incremental text fragments. Reconcile
+fragments by `type` and `otid` when `otid` is available; `uuid` is a legacy
+transport identifier and is not a portable lineage key. After reconnecting,
+use `(runId, seqId)` to suppress replayed fragments. Sequence IDs are scoped to
+their run and must not be compared across runs.
+
 An agent is the persistent entity with memory. A conversation is a thread on that agent. A session is the active connection used to send messages, stream events, execute tools, and handle approvals.
 
 - `createSession(agentId)` starts a new conversation.

--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -450,6 +450,20 @@ export function streamDeltaRunId(delta: Record<string, unknown>): string | undef
   return typeof delta.run_id === "string" ? delta.run_id : undefined;
 }
 
+export function streamDeltaOtid(
+  delta: Record<string, unknown>,
+): string | null | undefined {
+  return typeof delta.otid === "string" || delta.otid === null
+    ? delta.otid
+    : undefined;
+}
+
+export function streamDeltaSeqId(
+  delta: Record<string, unknown>,
+): number | undefined {
+  return typeof delta.seq_id === "number" ? delta.seq_id : undefined;
+}
+
 export function streamDeltaStopReason(delta: Record<string, unknown>): string | null | undefined {
   return typeof delta.stop_reason === "string" ? delta.stop_reason : undefined;
 }

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -18,8 +18,10 @@ import {
   queueItems,
   sameRuntime,
   streamDeltaMessageType,
+  streamDeltaOtid,
   streamDeltaRecord,
   streamDeltaRunId,
+  streamDeltaSeqId,
   streamDeltaStopReason,
   toSdkErrorCode,
   toSessionDeviceStatus,
@@ -303,6 +305,8 @@ export class RemoteTurnCoordinator {
     const messageType =
       typeof delta.message_type === "string" ? delta.message_type : undefined;
     const runId = typeof delta.run_id === "string" ? delta.run_id : undefined;
+    const otid = streamDeltaOtid(delta);
+    const seqId = streamDeltaSeqId(delta);
     const uuid =
       typeof delta.id === "string"
         ? delta.id
@@ -312,7 +316,14 @@ export class RemoteTurnCoordinator {
       const content = extractTextFromContent(delta.content);
       if (!content) return null;
       if (this.activeTurn) this.activeTurn.assistantText += content;
-      return { type: "assistant", content, uuid, runId };
+      return {
+        type: "assistant",
+        content,
+        uuid,
+        ...(otid !== undefined ? { otid } : {}),
+        ...(seqId !== undefined ? { seqId } : {}),
+        runId,
+      };
     }
 
     if (messageType === "reasoning_message") {
@@ -321,7 +332,14 @@ export class RemoteTurnCoordinator {
           ? delta.reasoning
           : extractTextFromContent(delta.content);
       if (!content) return null;
-      return { type: "reasoning", content, uuid, runId };
+      return {
+        type: "reasoning",
+        content,
+        uuid,
+        ...(otid !== undefined ? { otid } : {}),
+        ...(seqId !== undefined ? { seqId } : {}),
+        runId,
+      };
     }
 
     if (

--- a/src/session.ts
+++ b/src/session.ts
@@ -1419,6 +1419,8 @@ export class Session implements AsyncDisposable {
       const msg = wireMsg as WireMessage & {
         message_type: string;
         uuid: string;
+        otid?: string | null;
+        seq_id?: number;
         run_id?: string;
         // assistant_message fields
         content?: string;
@@ -1441,6 +1443,8 @@ export class Session implements AsyncDisposable {
           type: "assistant",
           content: msg.content,
           uuid: msg.uuid,
+          ...(msg.otid !== undefined ? { otid: msg.otid } : {}),
+          ...(msg.seq_id !== undefined ? { seqId: msg.seq_id } : {}),
           runId,
         };
       }
@@ -1517,6 +1521,8 @@ export class Session implements AsyncDisposable {
           type: "reasoning",
           content: msg.reasoning,
           uuid: msg.uuid,
+          ...(msg.otid !== undefined ? { otid: msg.otid } : {}),
+          ...(msg.seq_id !== undefined ? { seqId: msg.seq_id } : {}),
           runId,
         };
       }

--- a/src/tests/stream-message-identity.test.ts
+++ b/src/tests/stream-message-identity.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import type { WireMessage } from "../protocol.js";
+import type { ProtocolMessage, RuntimeScope } from "../remote-session-protocol.js";
+import { RemoteTurnCoordinator } from "../remote-turn-coordinator.js";
+import { Session } from "../session.js";
+import type { SDKMessage } from "../types.js";
+
+describe("cooked stream message identity", () => {
+  test("preserves distinct OTIDs and replay cursors on remote text slices sharing an id", async () => {
+    const runtime: RuntimeScope = {
+      agent_id: "agent-1",
+      conversation_id: "conv-1",
+    };
+    const coordinator = new RemoteTurnCoordinator({
+      label: "test",
+      onDeviceStatus: () => {},
+    });
+    coordinator.trackSentTurn(runtime);
+
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        id: "message-shared",
+        otid: "message-shared-0",
+        seq_id: 41,
+        run_id: "run-1",
+        message_type: "assistant_message",
+        content: "answer",
+      }),
+      runtime,
+    );
+    coordinator.handleProtocolMessage(
+      streamDelta(runtime, {
+        id: "message-shared",
+        otid: "message-shared-1",
+        seq_id: 42,
+        run_id: "run-1",
+        message_type: "reasoning_message",
+        reasoning: "thought",
+      }),
+      runtime,
+    );
+
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "assistant",
+      uuid: "message-shared",
+      otid: "message-shared-0",
+      seqId: 41,
+      runId: "run-1",
+    });
+    expect(await coordinator.nextMessage()).toMatchObject({
+      type: "reasoning",
+      uuid: "message-shared",
+      otid: "message-shared-1",
+      seqId: 42,
+      runId: "run-1",
+    });
+    coordinator.close();
+  });
+
+  test("preserves OTIDs and replay cursors on legacy stdio text messages", async () => {
+    const wireMessages = [
+      textWireMessage("assistant_message", "assistant-uuid", {
+        content: "answer",
+        otid: "assistant-otid",
+        seq_id: 71,
+      }),
+      textWireMessage("reasoning_message", "reasoning-uuid", {
+        reasoning: "thought",
+        otid: "reasoning-otid",
+        seq_id: 72,
+      }),
+    ];
+    const session = new Session({ agentId: "agent-1" });
+    const transport = {
+      async *messages() {
+        yield* wireMessages;
+      },
+      async write() {},
+    };
+    (session as unknown as { transport: typeof transport }).transport = transport;
+
+    await (
+      session as unknown as { runBackgroundPump(): Promise<void> }
+    ).runBackgroundPump();
+
+    const queued = (
+      session as unknown as { streamQueue: Array<{ message: SDKMessage }> }
+    ).streamQueue.map((entry) => entry.message);
+    expect(queued[0]).toMatchObject({
+      type: "assistant",
+      uuid: "assistant-uuid",
+      otid: "assistant-otid",
+      seqId: 71,
+      runId: "run-stdio",
+    });
+    expect(queued[1]).toMatchObject({
+      type: "reasoning",
+      uuid: "reasoning-uuid",
+      otid: "reasoning-otid",
+      seqId: 72,
+      runId: "run-stdio",
+    });
+  });
+});
+
+function streamDelta(
+  runtime: RuntimeScope,
+  delta: Record<string, unknown>,
+): ProtocolMessage {
+  return { type: "stream_delta", runtime, delta };
+}
+
+function textWireMessage(
+  messageType: "assistant_message" | "reasoning_message",
+  uuid: string,
+  fields: Record<string, unknown>,
+): WireMessage {
+  return {
+    type: "message",
+    message_type: messageType,
+    uuid,
+    run_id: "run-stdio",
+    ...fields,
+  } as WireMessage;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1044,7 +1044,12 @@ export interface SDKInitMessage {
 export interface SDKAssistantMessage {
   type: "assistant";
   content: string;
+  /** Legacy transport identifier. Prefer `otid` for message lineage. */
   uuid: string;
+  /** Stable lineage key for this typed message slice, when provided. */
+  otid?: string | null;
+  /** Per-run replay cursor. Compare only within the same `runId`. */
+  seqId?: number;
   /** Run ID from the Letta API for this event (used for stale-run detection). */
   runId?: string;
 }
@@ -1074,7 +1079,12 @@ export interface SDKToolResultMessage {
 export interface SDKReasoningMessage {
   type: "reasoning";
   content: string;
+  /** Legacy transport identifier. Prefer `otid` for message lineage. */
   uuid: string;
+  /** Stable lineage key for this typed message slice, when provided. */
+  otid?: string | null;
+  /** Per-run replay cursor. Compare only within the same `runId`. */
+  seqId?: number;
   /** Run ID from the Letta API for this event (used for stale-run detection). */
   runId?: string;
 }
@@ -1126,6 +1136,8 @@ export interface SDKStreamEventMessagePayload {
   message_type: string;
   id?: string;
   otid?: string | null;
+  seq_id?: number;
+  run_id?: string;
   content?: unknown;
   reasoning?: string;
   name?: string;


### PR DESCRIPTION
## Summary

- expose optional `otid` and `seqId` on cooked `SDKAssistantMessage` and `SDKReasoningMessage` values instead of dropping identity already present on the wire
- preserve both fields through portable app-server/Cloud sessions and the legacy stdio transport without changing existing `uuid` behavior
- explicitly type `seq_id` and `run_id` on raw message-shaped stream-event payloads
- document the contract: assistant/reasoning content is incremental, `message type + otid` identifies a typed slice, and `(runId, seqId)` is the per-run replay key
- cover one top-level message ID carrying distinct assistant/reasoning OTIDs, plus stdio transport parity

Tool messages remain deliberately unchanged: their payload lifecycle uses `toolCallId`, and assistant/reasoning identity rules should not be applied generically across message families.

Closes #220.

## Validation

- `bun run check`
- `bun test` — 263 passing, 11 skipped
- `bun run build`

👾 Generated with [Letta Code](https://letta.com)