### PR TITLE
feat: confine unattended memory sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/letta-ai/letta-agent-sdk"
   },
   "dependencies": {
-    "@letta-ai/letta-code": "0.29.4"
+    "@letta-ai/letta-code": "0.29.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -67,6 +67,7 @@ function stripCloudExecutionOptions(
   const sessionOptions = { ...options };
   delete sessionOptions.environment;
   delete sessionOptions.sandbox;
+  delete sessionOptions.filesystemConfinement;
   return sessionOptions;
 }
 
@@ -342,6 +343,14 @@ export class LettaAgentClientBase {
     action: string,
     options: LettaCodeClientSessionOptions,
   ): void {
+    if (
+      options.filesystemConfinement !== undefined &&
+      options.filesystemConfinement !== "memory"
+    ) {
+      throw new Error(
+        `Invalid filesystemConfinement '${String(options.filesystemConfinement)}'. Valid value: memory.`,
+      );
+    }
     const effectiveEnvironment = options.environment ?? this.environment;
     if (this.backend === "local") {
       if (effectiveEnvironment !== undefined) {
@@ -355,6 +364,19 @@ export class LettaAgentClientBase {
       if (hasRepositoryResources(options)) {
         throw new Error(`${action}() repository resources are only valid with backend: "cloud".`);
       }
+      if (options.filesystemConfinement !== undefined) {
+        const localOptions = this.options as LettaCodeLocalClientOptions;
+        if (this.useLegacyLocalStdio()) {
+          throw new Error(
+            `${action}() filesystemConfinement requires the local app-server transport.`,
+          );
+        }
+        if (localOptions.appServer?.url !== undefined) {
+          throw new Error(
+            `${action}() filesystemConfinement requires an SDK-owned local app-server process.`,
+          );
+        }
+      }
       if (!this.useLegacyLocalStdio()) {
         assertRemoteSessionOptionsSupported(action, options);
       }
@@ -362,6 +384,11 @@ export class LettaAgentClientBase {
     }
 
     if (this.backend === "remote") {
+      if (options.filesystemConfinement !== undefined) {
+        throw new Error(
+          `${action}() filesystemConfinement requires an SDK-owned local app-server process.`,
+        );
+      }
       if (options.environment !== undefined) {
         throw new Error(
           `${action}() environment overrides are only valid with backend: "cloud"; remote url selects the app-server runtime.`,
@@ -377,6 +404,11 @@ export class LettaAgentClientBase {
       return;
     }
     if (this.backend === "cloud") {
+      if (options.filesystemConfinement !== undefined) {
+        throw new Error(
+          `${action}() filesystemConfinement is only supported with backend: "local".`,
+        );
+      }
       const cloudOptions = this.cloudOptions();
       if (cloudOptions.environment !== undefined && options.sandbox !== undefined) {
         throw new Error(`Letta Cloud ${action}() cannot specify sandbox options when the client has a default environment.`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -74,6 +74,11 @@ export class LettaAgentClient extends LettaAgentClientBase {
     options: LettaCodeClientSessionOptions,
     sessionOptions: CreateSessionOptions,
   ): LettaCodeSession {
+    if (options.filesystemConfinement !== undefined && !agentId) {
+      throw new Error(
+        "createSession() filesystemConfinement requires an explicit agent id for the local app-server transport.",
+      );
+    }
     if (!this.useLegacyLocalStdio() && agentId) {
       const localOptions = this.options as LettaCodeLocalClientOptions;
       return createLocalAppServerSession(

--- a/src/local-app-server-session.ts
+++ b/src/local-app-server-session.ts
@@ -4,7 +4,10 @@ import {
   type AppServerSessionOptions,
 } from "./app-server-session.js";
 import { startLocalAppServer } from "./local-app-server.js";
-import type { LettaCodeLocalAppServerOptions } from "./types.js";
+import type {
+  LettaCodeClientSessionOptions,
+  LettaCodeLocalAppServerOptions,
+} from "./types.js";
 
 export function createLocalAppServerSession(
   options: LettaCodeLocalAppServerOptions | undefined,
@@ -22,6 +25,11 @@ export function createLocalAppServerSession(
               backend: appServer.harnessBackend ?? "local",
               startupTimeoutMs: appServer.startupTimeoutMs,
               env: sessionEnv,
+              filesystemConfinement:
+                mode.kind === "session"
+                  ? (mode.options as LettaCodeClientSessionOptions)
+                      .filesystemConfinement
+                  : undefined,
             }),
         }),
     ...(appServer.WebSocket !== undefined

--- a/src/local-app-server-session.ts
+++ b/src/local-app-server-session.ts
@@ -30,6 +30,10 @@ export function createLocalAppServerSession(
                   ? (mode.options as LettaCodeClientSessionOptions)
                       .filesystemConfinement
                   : undefined,
+              agentId:
+                mode.kind === "session" && "agentId" in mode
+                  ? mode.agentId
+                  : undefined,
             }),
         }),
     ...(appServer.WebSocket !== undefined

--- a/src/local-app-server.ts
+++ b/src/local-app-server.ts
@@ -1,4 +1,9 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import {
+  createMemoryConfinementLauncher,
+  type MemoryConfinementLauncherInput,
+  type MemoryConfinementLauncherResult,
+} from "@letta-ai/letta-code/memory-confinement";
 import { findLettaCli } from "./cli-resolver.js";
 
 export interface LocalAppServerHandle {
@@ -12,7 +17,18 @@ export interface StartLocalAppServerOptions {
   startupTimeoutMs?: number;
   cliPath?: string;
   env?: Record<string, string | undefined>;
+  filesystemConfinement?: "memory";
 }
+
+interface LocalAppServerProcess {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+}
+
+type MemoryConfinementLauncher = (
+  input: MemoryConfinementLauncherInput,
+) => MemoryConfinementLauncherResult;
 
 const DEFAULT_LISTEN_URL = "ws://127.0.0.1:0";
 const DEFAULT_STARTUP_TIMEOUT_MS = 30_000;
@@ -40,6 +56,32 @@ export function buildLocalAppServerArgs(
   ];
 }
 
+export function buildLocalAppServerProcess(
+  cliPath: string,
+  options: StartLocalAppServerOptions = {},
+  confineMemory: MemoryConfinementLauncher = createMemoryConfinementLauncher,
+): LocalAppServerProcess {
+  const env = { ...process.env, ...(options.env ?? {}) };
+  const launcher = [
+    process.execPath,
+    ...buildLocalAppServerArgs(cliPath, options),
+  ];
+  if (options.filesystemConfinement !== "memory") {
+    return {
+      command: launcher[0] as string,
+      args: launcher.slice(1),
+      env,
+    };
+  }
+
+  const confined = confineMemory({ launcher, env });
+  return {
+    command: confined.launcher[0] as string,
+    args: confined.launcher.slice(1),
+    env: confined.env,
+  };
+}
+
 function terminateProcess(child: ChildProcess): void {
   if (child.exitCode !== null || child.signalCode !== null) return;
   child.kill("SIGTERM");
@@ -57,13 +99,13 @@ export function startLocalAppServer(
   options: StartLocalAppServerOptions = {},
 ): Promise<LocalAppServerHandle> {
   const cliPath = options.cliPath ?? findLettaCli();
-  const args = buildLocalAppServerArgs(cliPath, options);
+  const processSpec = buildLocalAppServerProcess(cliPath, options);
   const startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
 
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, args, {
+    const child = spawn(processSpec.command, processSpec.args, {
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, ...(options.env ?? {}) },
+      env: processSpec.env,
     });
 
     let settled = false;

--- a/src/local-app-server.ts
+++ b/src/local-app-server.ts
@@ -1,4 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import {
   createMemoryConfinementLauncher,
   type MemoryConfinementLauncherInput,
@@ -18,6 +20,7 @@ export interface StartLocalAppServerOptions {
   cliPath?: string;
   env?: Record<string, string | undefined>;
   filesystemConfinement?: "memory";
+  agentId?: string;
 }
 
 interface LocalAppServerProcess {
@@ -33,6 +36,52 @@ type MemoryConfinementLauncher = (
 const DEFAULT_LISTEN_URL = "ws://127.0.0.1:0";
 const DEFAULT_STARTUP_TIMEOUT_MS = 30_000;
 const LISTENING_RE = /^Listening on\s+(ws:\/\/\S+)\s*$/m;
+
+function targetHomeDirectory(env: NodeJS.ProcessEnv): string {
+  if (process.platform === "win32") {
+    const profile = env.USERPROFILE?.trim();
+    if (profile) return profile;
+    const drive = env.HOMEDRIVE?.trim();
+    const path = env.HOMEPATH?.trim();
+    if (drive && path) return `${drive}${path}`;
+    return homedir();
+  }
+  return env.HOME?.trim() || homedir();
+}
+
+function withDefaultMemoryDirectory(
+  env: NodeJS.ProcessEnv,
+  options: StartLocalAppServerOptions,
+): NodeJS.ProcessEnv {
+  const explicitMemoryDir = options.env?.MEMORY_DIR?.trim();
+  const explicitLettaMemoryDir = options.env?.LETTA_MEMORY_DIR?.trim();
+  const scopedEnv = { ...env };
+  if (explicitMemoryDir || explicitLettaMemoryDir) {
+    if (!explicitMemoryDir) delete scopedEnv.MEMORY_DIR;
+    if (!explicitLettaMemoryDir) delete scopedEnv.LETTA_MEMORY_DIR;
+    return scopedEnv;
+  }
+
+  // Never inherit the SDK process's agent scope into a different session.
+  delete scopedEnv.MEMORY_DIR;
+  delete scopedEnv.LETTA_MEMORY_DIR;
+  if (!options.agentId) return scopedEnv;
+
+  const homeDir = targetHomeDirectory(env);
+  // Mirrors Letta Code's getScopedMemoryFilesystemRoot contract. The SDK pins
+  // an exact Letta Code version so the launch policy and layout move together.
+  const memoryDir =
+    options.backend === "api"
+      ? join(homeDir, ".letta", "agents", options.agentId, "memory")
+      : join(
+          env.LETTA_LOCAL_BACKEND_DIR?.trim() ||
+            join(homeDir, ".letta", "lc-local-backend"),
+          "memfs",
+          options.agentId,
+          "memory",
+        );
+  return { ...scopedEnv, MEMORY_DIR: memoryDir };
+}
 
 function appendLine(buffer: string, chunk: unknown): string {
   return buffer + String(chunk);
@@ -74,7 +123,10 @@ export function buildLocalAppServerProcess(
     };
   }
 
-  const confined = confineMemory({ launcher, env });
+  const confined = confineMemory({
+    launcher,
+    env: withDefaultMemoryDirectory(env, options),
+  });
   return {
     command: confined.launcher[0] as string,
     args: confined.launcher.slice(1),

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -620,6 +620,60 @@ describe("LettaAgentClient", () => {
     }
   });
 
+  test("restricts filesystem confinement to SDK-owned local app-server processes", () => {
+    const localClient = new LettaAgentClient({ backend: "local" });
+    expect(() =>
+      localClient.resumeSession("agent-123", {
+        filesystemConfinement: "invalid" as "memory",
+      }),
+    ).toThrow("Invalid filesystemConfinement 'invalid'");
+    expect(() =>
+      localClient.createSession({
+        filesystemConfinement: "memory",
+        env: { MEMORY_DIR: "/state/memory" },
+      }),
+    ).toThrow("requires an explicit agent id");
+
+    const stdioClient = new LettaAgentClient({
+      backend: "local",
+      transport: "stdio",
+    });
+    expect(() =>
+      stdioClient.resumeSession("agent-123", {
+        filesystemConfinement: "memory",
+        env: { MEMORY_DIR: "/state/memory" },
+      }),
+    ).toThrow("requires the local app-server transport");
+
+    const externalAppServerClient = new LettaAgentClient({
+      backend: "local",
+      appServer: { url: "ws://127.0.0.1:4500/ws" },
+    });
+    expect(() =>
+      externalAppServerClient.resumeSession("agent-123", {
+        filesystemConfinement: "memory",
+        env: { MEMORY_DIR: "/state/memory" },
+      }),
+    ).toThrow("requires an SDK-owned local app-server process");
+
+    const remoteClient = new LettaAgentClient({
+      backend: "remote",
+      url: "ws://127.0.0.1:4500/ws",
+    });
+    expect(() =>
+      remoteClient.resumeSession("agent-123", {
+        filesystemConfinement: "memory",
+      }),
+    ).toThrow("requires an SDK-owned local app-server process");
+
+    const cloudClient = new LettaAgentClient({ backend: "cloud" });
+    expect(() =>
+      cloudClient.resumeSession("agent-123", {
+        filesystemConfinement: "memory",
+      }),
+    ).toThrow('only supported with backend: "local"');
+  });
+
   test("rejects environment overrides on local sessions", () => {
     const client = new LettaAgentClient({ backend: "local" });
 

--- a/src/tests/local-app-server.test.ts
+++ b/src/tests/local-app-server.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import {
   buildLocalAppServerArgs,
   buildLocalAppServerProcess,
@@ -79,4 +80,87 @@ describe("buildLocalAppServerProcess", () => {
     expect(processSpec.args).toContain("/path/to/letta.js");
     expect(processSpec.env.LETTA_SANDBOX_ACTIVE).toBe("seatbelt");
   });
+
+  test("derives the standard local-backend memory directory from the agent id", () => {
+    let received: unknown;
+    buildLocalAppServerProcess(
+      "/path/to/letta.js",
+      {
+        filesystemConfinement: "memory",
+        agentId: "agent-local-123",
+        env: {
+          HOME: "/home/sdk",
+          USERPROFILE: "/home/sdk",
+          LETTA_LOCAL_BACKEND_DIR: "/state/local-backend",
+        },
+      },
+      (input) => {
+        received = input;
+        return { launcher: input.launcher, env: input.env, backend: "seatbelt" };
+      },
+    );
+
+    expect((received as MemoryConfinementInput).env.MEMORY_DIR).toBe(
+      join("/state/local-backend", "memfs", "agent-local-123", "memory"),
+    );
+  });
+
+  test("derives API-backed memory without overriding an explicit root", () => {
+    const received: MemoryConfinementInput[] = [];
+    const confine = (input: MemoryConfinementInput) => {
+      received.push(input);
+      return { launcher: input.launcher, env: input.env, backend: "seatbelt" as const };
+    };
+
+    buildLocalAppServerProcess(
+      "/path/to/letta.js",
+      {
+        backend: "api",
+        filesystemConfinement: "memory",
+        agentId: "agent-123",
+        env: { HOME: "/home/sdk", USERPROFILE: "/home/sdk" },
+      },
+      confine,
+    );
+    buildLocalAppServerProcess(
+      "/path/to/letta.js",
+      {
+        filesystemConfinement: "memory",
+        agentId: "agent-local-123",
+        env: { MEMORY_DIR: "/memory-copy" },
+      },
+      confine,
+    );
+
+    expect(received[0]?.env.MEMORY_DIR).toBe(
+      join("/home/sdk", ".letta", "agents", "agent-123", "memory"),
+    );
+    expect(received[1]?.env.MEMORY_DIR).toBe("/memory-copy");
+    expect(received[1]?.env.LETTA_MEMORY_DIR).toBeUndefined();
+  });
+
+  test("does not inherit another agent's memory root", () => {
+    let received: unknown;
+    buildLocalAppServerProcess(
+      "/path/to/letta.js",
+      {
+        filesystemConfinement: "memory",
+        env: {},
+      },
+      (input) => {
+        received = input;
+        return { launcher: input.launcher, env: input.env, backend: "seatbelt" };
+      },
+    );
+
+    expect((received as MemoryConfinementInput).env.MEMORY_DIR).toBeUndefined();
+    expect(
+      (received as MemoryConfinementInput).env.LETTA_MEMORY_DIR,
+    ).toBeUndefined();
+  });
 });
+
+type MemoryConfinementInput = {
+  launcher: string[];
+  env: NodeJS.ProcessEnv;
+};

--- a/src/tests/local-app-server.test.ts
+++ b/src/tests/local-app-server.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { buildLocalAppServerArgs } from "../local-app-server.js";
+import {
+  buildLocalAppServerArgs,
+  buildLocalAppServerProcess,
+} from "../local-app-server.js";
 
 describe("buildLocalAppServerArgs", () => {
   test("starts the app-server on an ephemeral loopback port by default", () => {
@@ -23,5 +26,57 @@ describe("buildLocalAppServerArgs", () => {
       "--listen",
       "ws://127.0.0.1:1234",
     ]);
+  });
+});
+
+describe("buildLocalAppServerProcess", () => {
+  test("keeps the normal app-server launcher unwrapped", () => {
+    const processSpec = buildLocalAppServerProcess("/path/to/letta.js", {
+      env: { SDK_TEST_VALUE: "present" },
+    });
+
+    expect(processSpec.command).toBe(process.execPath);
+    expect(processSpec.args).toEqual([
+      "/path/to/letta.js",
+      "app-server",
+      "--listen",
+      "ws://127.0.0.1:0",
+    ]);
+    expect(processSpec.env.SDK_TEST_VALUE).toBe("present");
+  });
+
+  test("wraps memory-confined app-server processes", () => {
+    let received: unknown;
+    const processSpec = buildLocalAppServerProcess(
+      "/path/to/letta.js",
+      {
+        filesystemConfinement: "memory",
+        env: { MEMORY_DIR: "/state/agent/memory" },
+      },
+      (input) => {
+        received = input;
+        return {
+          launcher: ["sandbox-exec", "--", ...input.launcher],
+          env: { ...input.env, LETTA_SANDBOX_ACTIVE: "seatbelt" },
+          backend: "seatbelt",
+        };
+      },
+    );
+
+    const confinementInput = received as {
+      launcher: string[];
+      env: NodeJS.ProcessEnv;
+    };
+    expect(confinementInput.launcher).toEqual([
+      process.execPath,
+      "/path/to/letta.js",
+      "app-server",
+      "--listen",
+      "ws://127.0.0.1:0",
+    ]);
+    expect(confinementInput.env.MEMORY_DIR).toBe("/state/agent/memory");
+    expect(processSpec.command).toBe("sandbox-exec");
+    expect(processSpec.args).toContain("/path/to/letta.js");
+    expect(processSpec.env.LETTA_SANDBOX_ACTIVE).toBe("seatbelt");
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -759,18 +759,11 @@ export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
    */
   env?: Record<string, string>;
   /**
-   * Constrain an SDK-owned local harness to memory-worker filesystem access.
-   * The harness may write its own memory and harness state, but not the project,
-   * temporary directories, the rest of the home directory, or other agents'
-   * memory. Agent-ID sessions derive the backend's standard memory directory;
-   * set `MEMORY_DIR` or `LETTA_MEMORY_DIR` in `env` to override it (including
-   * when resuming by conversation ID). Fails closed when no memory root can be
-   * resolved or the host has no supported kernel sandbox.
-   *
-   * Only supported by the default local app-server transport when the SDK owns
-   * the process. It applies to `createSession()` / `resumeSession()` harnesses,
-   * not agent creation or management calls. Remote URLs, Cloud execution, and
-   * the legacy stdio transport cannot enforce this option.
+   * Constrain an SDK-owned local session harness to memory-worker filesystem
+   * access. Agent-ID sessions derive the standard root; set `MEMORY_DIR` or
+   * `LETTA_MEMORY_DIR` for overrides and conversation-ID resumes. Fails closed
+   * without a root or supported kernel sandbox. Excludes agent creation,
+   * management calls, remote/Cloud runtimes, and legacy stdio.
    */
   filesystemConfinement?: "memory";
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -758,6 +758,19 @@ export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
    * memory copy. Ignored on remote and cloud transports.
    */
   env?: Record<string, string>;
+  /**
+   * Constrain an SDK-owned local harness to memory-worker filesystem access.
+   * The harness may write its own memory and harness state, but not the project,
+   * temporary directories, the rest of the home directory, or other agents'
+   * memory. Requires
+   * `MEMORY_DIR` or `LETTA_MEMORY_DIR` in `env` and fails closed when the host
+   * has no supported kernel sandbox.
+   *
+   * Only supported by the default local app-server transport when the SDK owns
+   * the process. Remote URLs, Cloud execution, and the legacy stdio transport
+   * cannot enforce this option.
+   */
+  filesystemConfinement?: "memory";
 }
 
 export interface LettaCodeSession extends AsyncDisposable {

--- a/src/types.ts
+++ b/src/types.ts
@@ -762,13 +762,15 @@ export interface LettaCodeClientSessionOptions extends CreateSessionOptions {
    * Constrain an SDK-owned local harness to memory-worker filesystem access.
    * The harness may write its own memory and harness state, but not the project,
    * temporary directories, the rest of the home directory, or other agents'
-   * memory. Requires
-   * `MEMORY_DIR` or `LETTA_MEMORY_DIR` in `env` and fails closed when the host
-   * has no supported kernel sandbox.
+   * memory. Agent-ID sessions derive the backend's standard memory directory;
+   * set `MEMORY_DIR` or `LETTA_MEMORY_DIR` in `env` to override it (including
+   * when resuming by conversation ID). Fails closed when no memory root can be
+   * resolved or the host has no supported kernel sandbox.
    *
    * Only supported by the default local app-server transport when the SDK owns
-   * the process. Remote URLs, Cloud execution, and the legacy stdio transport
-   * cannot enforce this option.
+   * the process. It applies to `createSession()` / `resumeSession()` harnesses,
+   * not agent creation or management calls. Remote URLs, Cloud execution, and
+   * the legacy stdio transport cannot enforce this option.
    */
   filesystemConfinement?: "memory";
 }


### PR DESCRIPTION
## Summary

- add an opt-in `filesystemConfinement: "memory"` session option for SDK-owned local app-server processes
- wrap the entire local harness process in Letta Code’s memory-worker filesystem policy before it starts, so child tools inherit kernel-enforced confinement without changing the WebSocket protocol
- derive standard local/API-backed memory roots from agent identity while preserving explicit `MEMORY_DIR` overrides for copied or conversation-scoped memory
- fail closed for unresolved roots, inherited cross-agent memory scope, unsupported sandbox hosts, cloud/remote/external transports, and legacy stdio
- keep agent creation, management calls, and sessions without the option unchanged

This allows unattended memory workers to run with unrestricted tool approval while limiting writes to their own memory and harness state. It closes #219.

Uses the confinement export published in `@letta-ai/letta-code@0.29.6` by [letta-ai/letta-code#3525](https://github.com/letta-ai/letta-code/pull/3525).

Verified with 267 passing tests, typecheck/source checks, a successful package build, direct import from the published package, and a real macOS Seatbelt probe confirming own-memory writes succeed while repository, home, temp, and other-agent access are denied.

👾 Generated with [Letta Code](https://letta.com)