### PR TITLE
docs(stream): clarify cooked message identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ for await (const message of session.stream()) {
 }
 ```
 
-Assistant and reasoning messages are incremental text fragments. Reconcile
-fragments by `type` and `otid` when `otid` is available; `uuid` is a legacy
-transport identifier and is not a portable lineage key. After reconnecting,
-use `(runId, seqId)` to suppress replayed fragments. Sequence IDs are scoped to
-their run and must not be compared across runs.
-
 An agent is the persistent entity with memory. A conversation is a thread on that agent. A session is the active connection used to send messages, stream events, execute tools, and handle approvals.
 
 - `createSession(agentId)` starts a new conversation.

--- a/src/types.ts
+++ b/src/types.ts
@@ -985,7 +985,7 @@ export interface SDKInitMessage {
 export interface SDKAssistantMessage {
   type: "assistant";
   content: string;
-  /** Legacy transport identifier. Prefer `otid` for message lineage. */
+  /** Top-level message ID when provided by the stream; otherwise an SDK-generated identifier. */
   uuid: string;
   /** Stable lineage key for this typed message slice, when provided. */
   otid?: string | null;
@@ -1020,7 +1020,7 @@ export interface SDKToolResultMessage {
 export interface SDKReasoningMessage {
   type: "reasoning";
   content: string;
-  /** Legacy transport identifier. Prefer `otid` for message lineage. */
+  /** Top-level message ID when provided by the stream; otherwise an SDK-generated identifier. */
   uuid: string;
   /** Stable lineage key for this typed message slice, when provided. */
   otid?: string | null;


### PR DESCRIPTION
## Summary

- remove low-level transcript reconciliation guidance from the README quick start
- correct the `uuid` documentation on cooked assistant/reasoning messages: it is the top-level stream message ID when present, with an SDK-generated fallback when the event has no ID
- keep `otid` documented separately as typed message lineage and `seqId` as the per-run replay cursor

The previous wording described `uuid` as a legacy transport identifier based on a stdio/app-server distinction. That distinction disappeared when the stdio transport was removed in #226, and the platform identifier contract does not define `uuid` as a separate identifier category.

## Validation

- `bun run check`
- `bun test` — 174 passing, 11 skipped
- `bun run build`

👾 Generated with [Letta Code](https://letta.com)