### PR TITLE
fix(cloud): recompile prompts after repository changes

### DIFF
--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -404,6 +404,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   private sandboxRefreshInFlight: Promise<void> | null = null;
   private sandboxLifecycleClosing = false;
   private attachedRepositoryIds = new Set<string>();
+  private repositoryIdsRequiringCleanupRecompile = new Set<string>();
   private readonly cloudMode: CloudSessionMode;
 
   constructor(
@@ -421,7 +422,15 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
 
   protected override async initializeRuntimeController(): Promise<RuntimeSessionInit> {
     const resolved = await this.resolveRuntime();
-    const connection = await this.resolveConnectionForRuntime(resolved.runtime);
+    const connection = await this.resolveConnectionForRuntime(resolved.runtime).catch(
+      async (error: unknown) => {
+        await this.cleanupSessionRepositories(
+          resolved.runtime.agent_id,
+          resolved.runtime.conversation_id,
+        );
+        throw error;
+      },
+    );
     this.connectionId = connection.connectionId;
 
     const apiKey = getCloudApiKey(this.cloudOptions);
@@ -488,7 +497,10 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       this.removeControlRequestHandler = null;
       client.close();
       await this.cleanupManagedSandbox();
-      await this.cleanupSessionRepositories(resolved.runtime.agent_id);
+      await this.cleanupSessionRepositories(
+        resolved.runtime.agent_id,
+        resolved.runtime.conversation_id,
+      );
       throw error;
     }
   }
@@ -545,7 +557,12 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     this.removeControlRequestHandler?.();
     this.removeControlRequestHandler = null;
     void this.cleanupManagedSandbox();
-    if (this.runtime?.agent_id) void this.cleanupSessionRepositories(this.runtime.agent_id);
+    if (this.runtime?.agent_id) {
+      void this.cleanupSessionRepositories(
+        this.runtime.agent_id,
+        this.runtime.conversation_id,
+      );
+    }
   }
 
   private async resolveRuntime(): Promise<{ runtime: RuntimeScope }> {
@@ -566,27 +583,37 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       );
     }
 
-    await this.attachSessionRepositories(agentId);
+    const shouldRecompileRepositories =
+      await this.attachSessionRepositories(agentId);
 
-    if (this.cloudMode.newConversation) {
-      const conversation = await this.createConversation(agentId);
-      conversationId = conversation.id;
-    } else if (this.cloudMode.defaultConversation) {
-      conversationId = "default";
+    try {
+      if (this.cloudMode.newConversation) {
+        const conversation = await this.createConversation(agentId);
+        conversationId = conversation.id;
+      } else if (this.cloudMode.defaultConversation) {
+        conversationId = "default";
+      }
+
+      if (!conversationId) {
+        throw new Error(
+          "Letta Cloud createSession()/resumeSession() requires an agent id or conversation id.",
+        );
+      }
+
+      if (shouldRecompileRepositories) {
+        await this.recompileSystemPrompt(agentId, conversationId);
+      }
+
+      return { runtime: { agent_id: agentId, conversation_id: conversationId } };
+    } catch (error) {
+      await this.cleanupSessionRepositories(agentId, conversationId);
+      throw error;
     }
-
-    if (!conversationId) {
-      throw new Error(
-        "Letta Cloud createSession()/resumeSession() requires an agent id or conversation id.",
-      );
-    }
-
-    return { runtime: { agent_id: agentId, conversation_id: conversationId } };
   }
 
-  private async attachSessionRepositories(agentId: string): Promise<void> {
+  private async attachSessionRepositories(agentId: string): Promise<boolean> {
     const resources = this.repositoryResources();
-    if (resources.length === 0) return;
+    if (resources.length === 0) return false;
 
     const existing = await this.listAgentRepositories(agentId);
     const existingIds = new Set(existing.map((repository) => repository.id));
@@ -604,18 +631,75 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       await this.cleanupSessionRepositories(agentId);
       throw error;
     }
+
+    // Recompile even when every requested repository was already linked: the
+    // target conversation may still have been compiled before those links
+    // existed. One recompile after the full batch produces the desired state.
+    const shouldRecompile = resources.some(
+      (resource) => resource.recompile !== false,
+    );
+    this.repositoryIdsRequiringCleanupRecompile = new Set(
+      resources
+        .filter(
+          (resource) =>
+            resource.recompile !== false &&
+            this.attachedRepositoryIds.has(resource.repositoryId),
+        )
+        .map((resource) => resource.repositoryId),
+    );
+    return shouldRecompile;
   }
 
-  private async cleanupSessionRepositories(agentId: string): Promise<void> {
+  private async cleanupSessionRepositories(
+    agentId: string,
+    conversationId?: string,
+  ): Promise<void> {
     const repositoryIds = [...this.attachedRepositoryIds];
+    const repositoryIdsRequiringRecompile =
+      this.repositoryIdsRequiringCleanupRecompile;
     this.attachedRepositoryIds.clear();
-    await Promise.all(repositoryIds.map(async (repositoryId) => {
+    this.repositoryIdsRequiringCleanupRecompile = new Set<string>();
+    const recompileAfterDetach = await Promise.all(repositoryIds.map(async (repositoryId) => {
       try {
         await this.unlinkAgentRepository(agentId, repositoryId);
+        return repositoryIdsRequiringRecompile.has(repositoryId);
       } catch {
         // Best-effort cleanup: only repositories this SDK session attached are removed.
+        return false;
       }
     }));
+    // Best-effort recompile after detach so remaining conversations drop stale
+    // repository projections. Errors are swallowed because this runs on close.
+    if (recompileAfterDetach.some(Boolean)) {
+      try {
+        await this.recompileSystemPrompt(agentId, conversationId);
+      } catch {
+        // Best-effort: cleanup must not throw.
+      }
+    }
+  }
+
+  private async recompileSystemPrompt(
+    agentId: string,
+    conversationId?: string,
+  ): Promise<void> {
+    const fetchImpl = getFetch(this.cloudOptions.fetch);
+    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
+    const usesAgentPrompt = !conversationId || conversationId === "default";
+    const path = usesAgentPrompt
+      ? `/v1/agents/${encodeURIComponent(agentId)}/recompile`
+      : `/v1/conversations/${encodeURIComponent(conversationId)}/recompile`;
+    const url = `${baseUrl}${path}`;
+    const response = await fetchImpl(
+      url,
+      {
+        method: "POST",
+        headers: cloudHeaders(this.cloudOptions),
+        body: JSON.stringify(usesAgentPrompt ? {} : { agent_id: agentId }),
+      },
+    );
+    const body = await parseJsonResponse(response);
+    assertOkResponse(response, body, "Cloud recompile system prompt", url);
   }
 
   private repositoryResources(): RepositoryResource[] {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -51,6 +51,8 @@ type CloudFetchMockOptions = {
     sandboxId: string,
     attempt: number,
   ) => Response | Promise<Response> | undefined;
+  /** Override agent-level recompile responses for failure-path tests. */
+  agentRecompileResponse?: (attempt: number) => Response | undefined;
 };
 
 function createCloudFetchMock(
@@ -60,6 +62,7 @@ function createCloudFetchMock(
 ): typeof fetch {
   let sandboxCreates = 0;
   let sandboxRefreshes = 0;
+  let agentRecompiles = 0;
   return ((input: FetchInput | URL, init?: RequestInit) => {
     const url = urlOf(input);
     const parsed = new URL(url);
@@ -170,10 +173,16 @@ function createCloudFetchMock(
 
     const agentRepositoriesMatch = /^\/v1\/agents\/([^/]+)\/repositories$/.exec(parsed.pathname);
     if (agentRepositoriesMatch && method === "GET") {
-      return Promise.resolve(jsonResponse({ repositories: requests.some((request) => {
-        const requestPath = new URL(request.url).pathname;
-        return request.method === "POST" && requestPath === parsed.pathname;
-      }) ? [{ id: "repo-1", name: "repo-1", is_primary: false }] : [] }));
+      const postedIds = requests
+        .filter((request) => {
+          const requestPath = new URL(request.url).pathname;
+          return request.method === "POST" && requestPath === parsed.pathname;
+        })
+        .map((request) => (request.body as { repository_id?: string } | undefined)?.repository_id)
+        .filter((id): id is string => typeof id === "string");
+      return Promise.resolve(jsonResponse({
+        repositories: postedIds.map((id) => ({ id, name: id, is_primary: false })),
+      }));
     }
 
     if (agentRepositoriesMatch && method === "POST") {
@@ -184,6 +193,19 @@ function createCloudFetchMock(
     const agentRepositoryMatch = /^\/v1\/agents\/([^/]+)\/repositories\/([^/]+)$/.exec(parsed.pathname);
     if (agentRepositoryMatch && method === "DELETE") {
       return Promise.resolve(jsonResponse({ success: true }));
+    }
+
+    const agentRecompileMatch = /^\/v1\/agents\/([^/]+)\/recompile$/.exec(parsed.pathname);
+    if (agentRecompileMatch && method === "POST") {
+      agentRecompiles += 1;
+      const responseOverride = options.agentRecompileResponse?.(agentRecompiles);
+      if (responseOverride) return Promise.resolve(responseOverride);
+      return Promise.resolve(jsonResponse("recompiled system prompt"));
+    }
+
+    const conversationRecompileMatch = /^\/v1\/conversations\/([^/]+)\/recompile$/.exec(parsed.pathname);
+    if (conversationRecompileMatch && method === "POST") {
+      return Promise.resolve(jsonResponse("recompiled conversation system prompt"));
     }
 
     if (parsed.pathname === "/v1/environments" && method === "GET") {
@@ -962,10 +984,311 @@ describe("CloudEnvironmentSession", () => {
       url: "https://api.test/v1/agents/agent-1/repositories",
       body: { repository_id: "repo-1" },
     }));
+    // Recompile is issued after attach (default recompile: true).
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "POST",
+      url: "https://api.test/v1/agents/agent-1/recompile",
+      body: {},
+    }));
     expect(requests).toContainEqual(expect.objectContaining({
       method: "DELETE",
       url: "https://api.test/v1/agents/agent-1/repositories/repo-1",
     }));
+    // Recompile is also issued after detach (best-effort, default recompile: true).
+    const recompileRequests = requests.filter((r) =>
+      r.method === "POST" && r.url === "https://api.test/v1/agents/agent-1/recompile",
+    );
+    expect(recompileRequests.length).toBe(2);
+  });
+
+  test("recompile: false skips system-prompt recompile on attach and detach", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { terminateOnClose: false },
+    });
+
+    const session = client.resumeSession("agent-1", {
+      resources: [{ type: "repository", repositoryId: "repo-1", recompile: false }],
+    });
+    await asAdvanced(session).initialize();
+    session.close();
+
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "POST",
+      url: "https://api.test/v1/agents/agent-1/repositories",
+      body: { repository_id: "repo-1" },
+    }));
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "DELETE",
+      url: "https://api.test/v1/agents/agent-1/repositories/repo-1",
+    }));
+    // No recompile requests should be issued.
+    expect(requests.filter((r) =>
+      r.method === "POST" && r.url === "https://api.test/v1/agents/agent-1/recompile",
+    )).toHaveLength(0);
+  });
+
+  test("fails initialization when attach-phase recompilation fails", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests, undefined, {
+        agentRecompileResponse: () =>
+          jsonResponse({ error: "recompile failed" }, { status: 500 }),
+      }),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { terminateOnClose: false },
+    });
+
+    const session = client.resumeSession("agent-1", {
+      resources: [{ type: "repository", repositoryId: "repo-1" }],
+    });
+
+    await expect(asAdvanced(session).initialize()).rejects.toThrow(
+      "Cloud recompile system prompt failed — recompile failed",
+    );
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "DELETE",
+      url: "https://api.test/v1/agents/agent-1/repositories/repo-1",
+    }));
+  });
+
+  test("ignores cleanup recompilation failures after detach", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests, undefined, {
+        agentRecompileResponse: (attempt) =>
+          attempt === 2
+            ? jsonResponse({ error: "cleanup recompile failed" }, { status: 500 })
+            : undefined,
+      }),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { terminateOnClose: false },
+    });
+
+    const session = client.resumeSession("agent-1", {
+      resources: [{ type: "repository", repositoryId: "repo-1" }],
+    });
+    await asAdvanced(session).initialize();
+    session.close();
+
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(requests.filter((request) =>
+      request.method === "POST" &&
+      request.url === "https://api.test/v1/agents/agent-1/recompile",
+    )).toHaveLength(2);
+  });
+
+  test("mixed flags do not recompile cleanup for only opt-out session attachments", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    // Seed repo-2 as an existing attachment; this session only owns repo-1.
+    requests.push({
+      method: "POST",
+      url: "https://api.test/v1/agents/agent-1/repositories",
+      headers: {},
+      body: { repository_id: "repo-2" },
+    });
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { terminateOnClose: false },
+    });
+
+    const session = client.resumeSession("agent-1", {
+      resources: [
+        { type: "repository", repositoryId: "repo-1", recompile: false },
+        { type: "repository", repositoryId: "repo-2" },
+      ],
+    });
+    await asAdvanced(session).initialize();
+    session.close();
+
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    // repo-2 defaults to recompile: true, so the attachment batch recompiles.
+    // Cleanup only removes repo-1, whose resource explicitly opted out.
+    const recompileRequests = requests.filter((r) =>
+      r.method === "POST" && r.url === "https://api.test/v1/agents/agent-1/recompile",
+    );
+    expect(recompileRequests).toHaveLength(1);
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "DELETE",
+      url: "https://api.test/v1/agents/agent-1/repositories/repo-1",
+    }));
+    expect(requests.filter((request) =>
+      request.method === "DELETE" &&
+      request.url.endsWith("/repositories/repo-2"),
+    )).toHaveLength(0);
+  });
+
+  test("batches mixed repository changes into one recompile per lifecycle phase", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { terminateOnClose: false },
+    });
+
+    const session = client.resumeSession("agent-1", {
+      resources: [
+        { type: "repository", repositoryId: "repo-1", recompile: false },
+        { type: "repository", repositoryId: "repo-2" },
+      ],
+    });
+    await asAdvanced(session).initialize();
+    session.close();
+
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(requests.filter((request) =>
+      request.method === "POST" &&
+      request.url === "https://api.test/v1/agents/agent-1/recompile",
+    )).toHaveLength(2);
+    expect(requests.filter((request) =>
+      request.method === "POST" &&
+      request.url === "https://api.test/v1/agents/agent-1/repositories",
+    )).toHaveLength(2);
+    expect(requests.filter((request) =>
+      request.method === "DELETE" &&
+      request.url.includes("/v1/agents/agent-1/repositories/"),
+    )).toHaveLength(2);
+  });
+
+  test("recompiles a resumed conversation after repository attach and detach", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { terminateOnClose: false },
+    });
+
+    const session = client.resumeSession("conv-1", {
+      resources: [{ type: "repository", repositoryId: "repo-1" }],
+    });
+    await asAdvanced(session).initialize();
+    session.close();
+
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const conversationRecompiles = requests.filter((request) =>
+      request.method === "POST" &&
+      request.url === "https://api.test/v1/conversations/conv-1/recompile",
+    );
+    expect(conversationRecompiles).toEqual([
+      expect.objectContaining({ body: { agent_id: "agent-from-conv" } }),
+      expect.objectContaining({ body: { agent_id: "agent-from-conv" } }),
+    ]);
+  });
+
+  test("cleans up repositories when environment resolution fails", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests, undefined, {
+        sandboxConversationEcho: "conv-wrong",
+      }),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+    });
+
+    const session = client.resumeSession("conv-1", {
+      resources: [{ type: "repository", repositoryId: "repo-1" }],
+    });
+
+    await expect(asAdvanced(session).initialize()).rejects.toThrow(
+      "Cloud managed sandbox response conversation mismatch",
+    );
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "DELETE",
+      url: "https://api.test/v1/agents/agent-from-conv/repositories/repo-1",
+    }));
+    expect(requests.filter((request) =>
+      request.method === "POST" &&
+      request.url === "https://api.test/v1/conversations/conv-1/recompile",
+    )).toHaveLength(2);
+  });
+
+  test("recompiles when a requested repository is already linked", async () => {
+    resetFakeCloud();
+    const requests: RecordedRequest[] = [];
+    requests.push({
+      method: "POST",
+      url: "https://api.test/v1/agents/agent-1/repositories",
+      headers: {},
+      body: { repository_id: "repo-1" },
+    });
+    const client = new LettaAgentClient({
+      backend: "cloud",
+      apiBaseUrl: "https://api.test",
+      apiKey: "sk-test",
+      fetch: createCloudFetchMock(requests),
+      WebSocket: FakeCloudSocket,
+      requestTimeoutMs: 1_000,
+      sandbox: { terminateOnClose: false },
+    });
+
+    const session = client.resumeSession("agent-1", {
+      resources: [{ type: "repository", repositoryId: "repo-1" }],
+    });
+    await asAdvanced(session).initialize();
+    session.close();
+
+    expect(requests).toContainEqual(expect.objectContaining({
+      method: "POST",
+      url: "https://api.test/v1/agents/agent-1/recompile",
+      body: {},
+    }));
+    expect(requests.filter((request) =>
+      request.method === "DELETE" &&
+      request.url.endsWith("/repositories/repo-1"),
+    )).toHaveLength(0);
   });
 
   test("uses an explicit environment before using the Remote Client websocket", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -408,6 +408,12 @@ export interface ListRepositoriesResult {
 export interface RepositoryResource {
   type: "repository";
   repositoryId: string;
+  /**
+   * Whether to trigger a system-prompt recompile after attaching (and after
+   * detaching on cleanup) so the session's conversation does not retain
+   * stale repository projections. Defaults to `true`.
+   */
+  recompile?: boolean;
 }
 
 export interface RepositoryFileEntry {


### PR DESCRIPTION
## Summary

- add an optional `recompile` flag to Cloud repository session resources, defaulting to `true`
- refresh the active default or explicit conversation after repository attachment so resumed sessions cannot retain stale projections
- refresh again after successful cleanup of session-owned repositories, while keeping close-time cleanup best-effort
- batch recompilation across multiple repositories, preserve pre-existing links, and support `recompile: false` as an explicit opt-out

Attach-time recompilation is part of session readiness and fails initialization if freshness cannot be established. Cleanup still detaches only repositories attached by that SDK session; detach and cleanup-recompile failures remain non-fatal. Already-linked repositories can still trigger recompilation because the resumed conversation may predate the link.

LET-10327

👾 Generated with [Letta Code](https://letta.com)
