### PR TITLE
fix: expose memory directory in session status

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ approvals when a mobile or web client returns to the foreground:
 ```ts
 const status = await session.getDeviceStatus();
 // status.permissionMode, status.workingDirectory, status.isOnline,
-// status.isProcessing, status.pendingControlRequests, status.raw
+// status.isProcessing, status.memoryDirectory,
+// status.pendingControlRequests, status.raw
 
 const unsubscribe = session.onDeviceStatus((status) => {
   // Called for every device-status update pushed by the runtime.

--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -664,6 +664,10 @@ export function toSessionDeviceStatus(
     isProcessing: status.is_processing,
     permissionMode,
     workingDirectory: status.current_working_directory,
+    memoryDirectory:
+      typeof status.memory_directory === "string"
+        ? status.memory_directory
+        : null,
     pendingControlRequests: pendingControlRequests(status),
     raw: { ...status },
   };

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -278,6 +278,7 @@ function fakeAppServerHandle(
           is_processing: false,
           current_permission_mode: "acceptEdits",
           current_working_directory: "/workspace/project",
+          memory_directory: "/memory/agent-123",
           pending_control_requests: [
             {
               request_id: "approval-1",
@@ -2012,6 +2013,7 @@ describe("LettaAgentClient", () => {
         isProcessing: false,
         permissionMode: "acceptEdits",
         workingDirectory: "/workspace/project",
+        memoryDirectory: "/memory/agent-123",
         pendingControlRequests: [
           {
             requestId: "approval-1",
@@ -2049,6 +2051,7 @@ describe("LettaAgentClient", () => {
       expect(await session.getDeviceStatus()).toMatchObject({
         permissionMode: "acceptEdits",
         workingDirectory: "/workspace/project",
+        memoryDirectory: "/memory/agent-123",
       });
       expect(fakeControlSocket().sent.filter(
         (command) => (command as { type?: string }).type === "sync",

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -320,6 +320,7 @@ class FakeCloudSocket {
             is_processing: false,
             current_permission_mode: "acceptEdits",
             current_working_directory: "/workspace/project",
+            memory_directory: "/memory/cloud-agent",
             pending_control_requests: [
               {
                 request_id: "approval-1",
@@ -1573,6 +1574,7 @@ describe("CloudEnvironmentSession", () => {
         isProcessing: false,
         permissionMode: "acceptEdits",
         workingDirectory: "/workspace/project",
+        memoryDirectory: "/memory/cloud-agent",
         pendingControlRequests: [
           {
             requestId: "approval-1",
@@ -1596,6 +1598,7 @@ describe("CloudEnvironmentSession", () => {
       expect(status.raw).toMatchObject({
         current_permission_mode: "acceptEdits",
         current_working_directory: "/workspace/project",
+        memory_directory: "/memory/cloud-agent",
       });
       expect(statusSyncs()).toHaveLength(2);
 
@@ -1603,6 +1606,7 @@ describe("CloudEnvironmentSession", () => {
       expect(await session.getDeviceStatus()).toMatchObject({
         permissionMode: "acceptEdits",
         workingDirectory: "/workspace/project",
+        memoryDirectory: "/memory/cloud-agent",
       });
       expect(statusSyncs()).toHaveLength(3);
 
@@ -1626,6 +1630,7 @@ describe("CloudEnvironmentSession", () => {
         isProcessing: true,
         permissionMode: "unrestricted",
         workingDirectory: "/workspace/elsewhere",
+        memoryDirectory: null,
         pendingControlRequests: [],
       });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -851,6 +851,8 @@ export interface SessionDeviceStatus {
   permissionMode: PermissionMode;
   /** Working directory currently applied to this runtime scope. */
   workingDirectory: string | null;
+  /** Agent memory checkout on the computer executing this session. */
+  memoryDirectory: string | null;
   /** Approvals the device is still waiting on (foreground-resume UI). */
   pendingControlRequests: SessionPendingControlRequest[];
   /** Full wire `device_status` payload as an escape hatch. */


### PR DESCRIPTION
## Summary

- project the existing `device_status.memory_directory` wire value as typed `SessionDeviceStatus.memoryDirectory`
- return `null` when an older or partial status payload does not include a memory directory
- cover local App Server and Cloud session status normalization and document the field alongside `getDeviceStatus()`

This exposes the path actually resolved by the executing harness, so callers inherit local/API layout, custom memory-root overrides, and computer-specific execution context without duplicating filesystem derivation rules.

Closes #225.

👾 Generated with [Letta Code](https://letta.com)