### PR TITLE
feat(cloud): manage persistent agent repositories (LET-10330)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,16 +174,33 @@ const conversations = await client.conversations.list({
 // No open session required — safe for model pickers and settings screens.
 const { entries: models, availableHandles } = await client.models.list();
 
-await client.agents.delete(agents[0].id);
-
 const repository = await client.repositories.create({ name: "inputs" });
 await client.repositories.files.create(repository.id, {
   path: "brief.md",
   content: "# Project brief\n",
 });
+
+// Persistent agent knowledge: attach once during provisioning. This
+// recompiles the agent's default conversation after the relationship is
+// visible, and session.close() will not detach it.
+await client.agents.repositories.attach(agents[0].id, repository.id, {
+  permissions: "read",
+});
+
+// Remove persistent knowledge explicitly during deprovisioning.
+await client.agents.repositories.detach(agents[0].id, repository.id);
+await client.agents.delete(agents[0].id);
 ```
 
-`client.repositories` is available on the `cloud` backend. See [Cloud repositories](https://docs.letta.com/letta-agent-sdk/repositories) for file operations, version history, and session resources.
+`client.repositories` and `client.agents.repositories` are available on the
+`cloud` backend. Persistent agent relationships belong under
+`client.agents.repositories`; use session `resources` only when the session
+should own attachment and cleanup. Attach and detach recompile the agent's
+default conversation by default; pass `{ recompile: false }` only when the
+caller will handle prompt recompilation separately. Existing explicit
+conversations are not silently recompiled. If recompilation fails after a
+successful relationship mutation, the method rejects but the attachment state
+remains changed; retrying is safe. See [Cloud repositories](https://docs.letta.com/letta-agent-sdk/repositories) for file operations, version history, and session resources.
 
 ## Documentation
 

--- a/src/agent-repositories.ts
+++ b/src/agent-repositories.ts
@@ -1,0 +1,159 @@
+import type {
+  AgentRepositoriesClient,
+  AgentRepository,
+  AgentRepositoryRecompileTarget,
+  AttachAgentRepositoryOptions,
+  DetachAgentRepositoryOptions,
+  AgentRepositoryPermissions,
+} from "./management-types.js";
+
+const DEFAULT_VISIBILITY_TIMEOUT_MS = 10_000;
+const DEFAULT_VISIBILITY_POLL_INTERVAL_MS = 100;
+
+export interface AgentRepositoriesTransport {
+  listAgentRepositories(agentId: string): Promise<AgentRepository[]>;
+  attachAgentRepository(
+    agentId: string,
+    repositoryId: string,
+    permissions: AgentRepositoryPermissions | undefined,
+  ): Promise<AgentRepository>;
+  detachAgentRepository(
+    agentId: string,
+    repositoryId: string,
+  ): Promise<void>;
+  recompileAgentSystemPrompt(agentId: string): Promise<void>;
+}
+
+type TransportProvider = () => AgentRepositoriesTransport;
+
+type VisibilityOptions = {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+};
+
+function assertNonEmptyId(value: string, name: string): void {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Invalid ${name}. Expected a non-empty string.`);
+  }
+}
+
+function assertPermissions(
+  permissions: AgentRepositoryPermissions | undefined,
+): void {
+  if (
+    permissions !== undefined &&
+    permissions !== "read" &&
+    permissions !== "read_write"
+  ) {
+    throw new Error(
+      `Invalid repository permissions '${String(permissions)}'. Expected "read" or "read_write".`,
+    );
+  }
+}
+
+function assertRecompileTarget(
+  recompile: AgentRepositoryRecompileTarget | undefined,
+): void {
+  if (recompile !== undefined && recompile !== "default" && recompile !== false) {
+    throw new Error(
+      `Invalid repository recompile target '${String(recompile)}'. Expected "default" or false.`,
+    );
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForRepositoryState(
+  transport: AgentRepositoriesTransport,
+  agentId: string,
+  repositoryId: string,
+  attached: boolean,
+  permissions: AgentRepositoryPermissions | undefined,
+  options: VisibilityOptions,
+): Promise<void> {
+  const deadline = Date.now() +
+    (options.timeoutMs ?? DEFAULT_VISIBILITY_TIMEOUT_MS);
+  while (true) {
+    const repositories = await transport.listAgentRepositories(agentId);
+    const repository = repositories.find(
+      (repository) => repository.id === repositoryId,
+    );
+    const isDesiredState = attached
+      ? repository !== undefined && repository.permissions === permissions
+      : repository === undefined;
+    if (isDesiredState) return;
+    if (Date.now() >= deadline) {
+      const action = attached ? "attach" : "detach";
+      throw new Error(
+        `Cloud ${action} agent repository did not become visible for ${agentId}: ${repositoryId}`,
+      );
+    }
+    await sleep(
+      options.pollIntervalMs ?? DEFAULT_VISIBILITY_POLL_INTERVAL_MS,
+    );
+  }
+}
+
+export function createAgentRepositoriesClient(
+  transportProvider: TransportProvider,
+  visibilityOptions: VisibilityOptions = {},
+): AgentRepositoriesClient {
+  return {
+    list: async (agentId) => {
+      assertNonEmptyId(agentId, "agent id");
+      return transportProvider().listAgentRepositories(agentId);
+    },
+    attach: async (
+      agentId: string,
+      repositoryId: string,
+      options: AttachAgentRepositoryOptions = {},
+    ) => {
+      assertNonEmptyId(agentId, "agent id");
+      assertNonEmptyId(repositoryId, "repository id");
+      assertPermissions(options.permissions);
+      assertRecompileTarget(options.recompile);
+      const transport = transportProvider();
+      const repository = await transport.attachAgentRepository(
+        agentId,
+        repositoryId,
+        options.permissions,
+      );
+      await waitForRepositoryState(
+        transport,
+        agentId,
+        repositoryId,
+        true,
+        repository.permissions,
+        visibilityOptions,
+      );
+      if (options.recompile !== false) {
+        await transport.recompileAgentSystemPrompt(agentId);
+      }
+      return repository;
+    },
+    detach: async (
+      agentId: string,
+      repositoryId: string,
+      options: DetachAgentRepositoryOptions = {},
+    ) => {
+      assertNonEmptyId(agentId, "agent id");
+      assertNonEmptyId(repositoryId, "repository id");
+      assertRecompileTarget(options.recompile);
+      const transport = transportProvider();
+      await transport.detachAgentRepository(agentId, repositoryId);
+      await waitForRepositoryState(
+        transport,
+        agentId,
+        repositoryId,
+        false,
+        undefined,
+        visibilityOptions,
+      );
+      if (options.recompile !== false) {
+        await transport.recompileAgentSystemPrompt(agentId);
+      }
+    },
+  };
+}

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -1,4 +1,5 @@
 import { RepositoriesClient } from "./repositories.js";
+import { createAgentRepositoriesClient } from "./agent-repositories.js";
 import { AppServerManagementTransport } from "./app-server-management.js";
 import {
   AppServerSession,
@@ -18,6 +19,7 @@ import {
   type ManagementTransport,
 } from "./management.js";
 import type {
+  AgentRepositoriesClient,
   AgentsClient,
   ConversationsClient,
   ModelsClient,
@@ -104,6 +106,7 @@ export class LettaAgentClientBase {
   readonly models: ModelsClient;
   protected readonly options: LettaCodeClientOptions;
   private repositoriesClient: RepositoriesClient | null = null;
+  private agentRepositoriesClient: AgentRepositoriesClient | null = null;
   private managementTransport: ManagementTransport | null = null;
 
   constructor(options: LettaCodeClientOptions = {}) {
@@ -117,7 +120,10 @@ export class LettaAgentClientBase {
     this.backend = backend;
     this.environment = getOptionsEnvironment(options);
     this.options = options;
-    this.agents = createAgentsClient(() => this.getManagementTransport());
+    this.agents = createAgentsClient(
+      () => this.getManagementTransport(),
+      () => this.getAgentRepositoriesClient(),
+    );
     this.conversations = createConversationsClient(
       () => this.getManagementTransport(),
     );
@@ -429,6 +435,26 @@ export class LettaAgentClientBase {
     }
     this.repositoriesClient ??= new RepositoriesClient(this.cloudOptions());
     return this.repositoriesClient;
+  }
+
+  private getAgentRepositoriesClient(): AgentRepositoriesClient {
+    if (this.backend !== "cloud") {
+      throw new Error(
+        'client.agents.repositories is only available with backend: "cloud".',
+      );
+    }
+    this.agentRepositoriesClient ??= createAgentRepositoriesClient(
+      () => this.getCloudManagementTransport(),
+    );
+    return this.agentRepositoriesClient;
+  }
+
+  private getCloudManagementTransport(): CloudManagementTransport {
+    const transport = this.getManagementTransport();
+    if (!(transport instanceof CloudManagementTransport)) {
+      throw new Error("Cloud management requested for non-cloud backend.");
+    }
+    return transport;
   }
 
   private getManagementTransport(): ManagementTransport {

--- a/src/cloud-management.ts
+++ b/src/cloud-management.ts
@@ -3,9 +3,11 @@ import type {
   ManagementTransport,
 } from "./management.js";
 import type {
+  AgentRepository,
   ConversationMessagesResult,
   LettaAgent,
   LettaConversation,
+  AgentRepositoryPermissions,
 } from "./management-types.js";
 import type {
   LettaCodeCloudClientOptions,
@@ -79,7 +81,12 @@ function responseErrorMessage(body: unknown, fallback: string): string {
   if (body && typeof body === "object") {
     const record = body as Record<string, unknown>;
     const message = record.message ?? record.error ?? record.detail;
-    if (typeof message === "string" && message.length > 0) return message;
+    const reasonText = record.reason_text;
+    const pieces = [message, reasonText].filter(
+      (value): value is string =>
+        typeof value === "string" && value.length > 0,
+    );
+    if (pieces.length > 0) return pieces.join(": ");
   }
   return fallback;
 }
@@ -123,6 +130,28 @@ function asArray<T>(body: unknown, action: string): T[] {
     throw new Error(`${action} response did not include an array.`);
   }
   return body as T[];
+}
+
+function asAgentRepository(body: unknown, action: string): AgentRepository {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error(`${action} response did not include a repository.`);
+  }
+  const repository = body as Record<string, unknown>;
+  const permissions = repository.permissions;
+  if (
+    typeof repository.id !== "string" ||
+    typeof repository.name !== "string" ||
+    typeof repository.is_primary !== "boolean" ||
+    (permissions !== "read" && permissions !== "read_write")
+  ) {
+    throw new Error(`${action} response included an invalid repository.`);
+  }
+  return {
+    id: repository.id,
+    name: repository.name,
+    isPrimary: repository.is_primary,
+    permissions,
+  };
 }
 
 function cloudModelEntry(
@@ -186,6 +215,80 @@ export class CloudManagementTransport implements ManagementTransport {
       "DELETE",
       undefined,
       "Cloud delete agent",
+    );
+  }
+
+  async listAgentRepositories(agentId: string): Promise<AgentRepository[]> {
+    const body = await this.getObject<Record<string, unknown>>(
+      `/v1/agents/${encodeURIComponent(agentId)}/repositories`,
+      {},
+      "Cloud list agent repositories",
+    );
+    if (!Array.isArray(body.repositories)) {
+      throw new Error(
+        "Cloud list agent repositories response did not include repositories.",
+      );
+    }
+    return body.repositories.map((repository) =>
+      asAgentRepository(repository, "Cloud list agent repositories")
+    );
+  }
+
+  async attachAgentRepository(
+    agentId: string,
+    repositoryId: string,
+    permissions: AgentRepositoryPermissions | undefined,
+  ): Promise<AgentRepository> {
+    const body = await this.requestObject<Record<string, unknown>>(
+      `/v1/agents/${encodeURIComponent(agentId)}/repositories`,
+      "POST",
+      {
+        repository_id: repositoryId,
+        ...(permissions !== undefined ? { permissions } : {}),
+      },
+      "Cloud attach agent repository",
+    );
+    return asAgentRepository(
+      body.repository,
+      "Cloud attach agent repository",
+    );
+  }
+
+  async detachAgentRepository(
+    agentId: string,
+    repositoryId: string,
+  ): Promise<void> {
+    await this.requestUrl(
+      this.url(
+        `/v1/agents/${encodeURIComponent(agentId)}/repositories/${encodeURIComponent(repositoryId)}`,
+      ),
+      "DELETE",
+      undefined,
+      "Cloud detach agent repository",
+      [404],
+    );
+  }
+
+  async recompileAgentSystemPrompt(agentId: string): Promise<void> {
+    await this.requestUrl(
+      this.url(`/v1/agents/${encodeURIComponent(agentId)}/recompile`),
+      "POST",
+      {},
+      "Cloud recompile system prompt",
+    );
+  }
+
+  async recompileConversationSystemPrompt(
+    agentId: string,
+    conversationId: string,
+  ): Promise<void> {
+    await this.requestUrl(
+      this.url(
+        `/v1/conversations/${encodeURIComponent(conversationId)}/recompile`,
+      ),
+      "POST",
+      { agent_id: agentId },
+      "Cloud recompile system prompt",
     );
   }
 
@@ -329,6 +432,7 @@ export class CloudManagementTransport implements ManagementTransport {
     method: string,
     body: Record<string, unknown> | undefined,
     action: string,
+    allowedStatuses: readonly number[] = [],
   ): Promise<unknown> {
     const fetchImpl = (this.options.fetch ?? globalThis.fetch)?.bind(
       globalThis,
@@ -342,7 +446,7 @@ export class CloudManagementTransport implements ManagementTransport {
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     });
     const responseBody = await parseResponse(response);
-    if (!response.ok) {
+    if (!response.ok && !allowedStatuses.includes(response.status)) {
       throw cloudRequestError(
         response,
         responseBody,

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -11,6 +11,7 @@ import {
   registerAppServerControlRequestHandler,
 } from "./app-server-session.js";
 import { createCloudStatusTransportConstructor } from "./cloud-status-transport.js";
+import { CloudManagementTransport } from "./cloud-management.js";
 import {
   RemoteEnvironmentClient,
   type RemoteEnvironmentTarget,
@@ -125,12 +126,6 @@ export class CloudManagedSandboxExpiredError extends Error {
 }
 
 type CloudSessionMode = Extract<RuntimeSessionMode, { kind: "session" }>;
-
-type CloudAgentRepository = {
-  id: string;
-  name?: string;
-  is_primary?: boolean;
-};
 
 function getDefaultApiKey(): string | undefined {
   const env = (globalThis as { process?: { env?: Record<string, string | undefined> } })
@@ -405,6 +400,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   private sandboxLifecycleClosing = false;
   private attachedRepositoryIds = new Set<string>();
   private repositoryIdsRequiringCleanupRecompile = new Set<string>();
+  private readonly repositoryManagement: CloudManagementTransport;
   private readonly cloudMode: CloudSessionMode;
 
   constructor(
@@ -416,6 +412,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       requestTimeoutMs: cloudOptions.requestTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
     });
     this.cloudMode = mode;
+    this.repositoryManagement = new CloudManagementTransport(cloudOptions);
     const tools = mode.options.tools;
     this.externalTools = externalToolsByName(tools);
   }
@@ -615,7 +612,9 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     const resources = this.repositoryResources();
     if (resources.length === 0) return false;
 
-    const existing = await this.listAgentRepositories(agentId);
+    const existing = await this.repositoryManagement.listAgentRepositories(
+      agentId,
+    );
     const existingIds = new Set(existing.map((repository) => repository.id));
 
     try {
@@ -623,7 +622,11 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
         if (existingIds.has(resource.repositoryId) || this.attachedRepositoryIds.has(resource.repositoryId)) {
           continue;
         }
-        await this.linkAgentRepository(agentId, resource.repositoryId);
+        await this.repositoryManagement.attachAgentRepository(
+          agentId,
+          resource.repositoryId,
+          undefined,
+        );
         await this.waitForAgentRepository(agentId, resource.repositoryId);
         this.attachedRepositoryIds.add(resource.repositoryId);
       }
@@ -661,7 +664,10 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     this.repositoryIdsRequiringCleanupRecompile = new Set<string>();
     const recompileAfterDetach = await Promise.all(repositoryIds.map(async (repositoryId) => {
       try {
-        await this.unlinkAgentRepository(agentId, repositoryId);
+        await this.repositoryManagement.detachAgentRepository(
+          agentId,
+          repositoryId,
+        );
         return repositoryIdsRequiringRecompile.has(repositoryId);
       } catch {
         // Best-effort cleanup: only repositories this SDK session attached are removed.
@@ -683,23 +689,15 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     agentId: string,
     conversationId?: string,
   ): Promise<void> {
-    const fetchImpl = getFetch(this.cloudOptions.fetch);
-    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
     const usesAgentPrompt = !conversationId || conversationId === "default";
-    const path = usesAgentPrompt
-      ? `/v1/agents/${encodeURIComponent(agentId)}/recompile`
-      : `/v1/conversations/${encodeURIComponent(conversationId)}/recompile`;
-    const url = `${baseUrl}${path}`;
-    const response = await fetchImpl(
-      url,
-      {
-        method: "POST",
-        headers: cloudHeaders(this.cloudOptions),
-        body: JSON.stringify(usesAgentPrompt ? {} : { agent_id: agentId }),
-      },
+    if (usesAgentPrompt) {
+      await this.repositoryManagement.recompileAgentSystemPrompt(agentId);
+      return;
+    }
+    await this.repositoryManagement.recompileConversationSystemPrompt(
+      agentId,
+      conversationId,
     );
-    const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud recompile system prompt", url);
   }
 
   private repositoryResources(): RepositoryResource[] {
@@ -720,63 +718,18 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     return result;
   }
 
-  private async listAgentRepositories(agentId: string): Promise<CloudAgentRepository[]> {
-    const fetchImpl = getFetch(this.cloudOptions.fetch);
-    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
-    const response = await fetchImpl(
-      `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/repositories`,
-      { headers: cloudHeaders(this.cloudOptions) },
-    );
-    const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud list agent repositories");
-    if (!body || typeof body !== "object") return [];
-    const repositories = (body as Record<string, unknown>).repositories;
-    return Array.isArray(repositories)
-      ? repositories.filter((repository): repository is CloudAgentRepository => (
-        repository !== null &&
-        typeof repository === "object" &&
-        typeof (repository as Record<string, unknown>).id === "string"
-      ))
-      : [];
-  }
-
   private async waitForAgentRepository(agentId: string, repositoryId: string): Promise<void> {
     const deadline = Date.now() + DEFAULT_REPOSITORY_ATTACH_TIMEOUT_MS;
     while (true) {
-      const repositories = await this.listAgentRepositories(agentId);
+      const repositories = await this.repositoryManagement.listAgentRepositories(
+        agentId,
+      );
       if (repositories.some((repository) => repository.id === repositoryId)) return;
       if (Date.now() >= deadline) {
         throw new Error(`Cloud attach agent repository did not become visible for ${agentId}: ${repositoryId}`);
       }
       await sleep(DEFAULT_REPOSITORY_ATTACH_POLL_INTERVAL_MS);
     }
-  }
-
-  private async linkAgentRepository(agentId: string, repositoryId: string): Promise<void> {
-    const fetchImpl = getFetch(this.cloudOptions.fetch);
-    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
-    const response = await fetchImpl(
-      `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/repositories`,
-      {
-        method: "POST",
-        headers: cloudHeaders(this.cloudOptions),
-        body: JSON.stringify({ repository_id: repositoryId }),
-      },
-    );
-    const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud attach agent repository");
-  }
-
-  private async unlinkAgentRepository(agentId: string, repositoryId: string): Promise<void> {
-    const fetchImpl = getFetch(this.cloudOptions.fetch);
-    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
-    const response = await fetchImpl(
-      `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/repositories/${encodeURIComponent(repositoryId)}`,
-      { method: "DELETE", headers: cloudHeaders(this.cloudOptions) },
-    );
-    const body = await parseJsonResponse(response);
-    if (response.status === 404) return;
-    assertOkResponse(response, body, "Cloud detach agent repository");
   }
 
   private async createConversation(agentId: string): Promise<{ id: string; agent_id?: string }> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,10 @@ export type {
   AnyAgentTool,
 } from "./types.js";
 export type {
+  AgentRepositoriesClient,
+  AgentRepository,
+  AgentRepositoryRecompileTarget,
+  AttachAgentRepositoryOptions,
   AgentsClient,
   ConversationsClient,
   LettaAgent,
@@ -158,6 +162,8 @@ export type {
   UpdateConversationOptions,
   ConversationMessagesOptions,
   ConversationMessagesResult,
+  DetachAgentRepositoryOptions,
+  AgentRepositoryPermissions,
 } from "./management-types.js";
 
 export { RepositoriesClient } from "./repositories.js";

--- a/src/management-types.ts
+++ b/src/management-types.ts
@@ -96,7 +96,57 @@ export type ConversationMessagesResult = ListMessagesResult & {
   messages: LettaConversationMessage[];
 };
 
+export type AgentRepositoryPermissions = "read" | "read_write";
+export type AgentRepositoryRecompileTarget = "default" | false;
+
+/** A repository relationship persisted on an agent. */
+export interface AgentRepository {
+  id: string;
+  name: string;
+  isPrimary: boolean;
+  permissions: AgentRepositoryPermissions;
+}
+
+export interface AttachAgentRepositoryOptions {
+  /** Access granted to the agent. Defaults to `read_write` on the server. */
+  permissions?: AgentRepositoryPermissions;
+  /** Recompile the agent's default conversation after attachment. Defaults to `default`. */
+  recompile?: AgentRepositoryRecompileTarget;
+}
+
+export interface DetachAgentRepositoryOptions {
+  /** Recompile the agent's default conversation after detachment. Defaults to `default`. */
+  recompile?: AgentRepositoryRecompileTarget;
+}
+
+/** Persistent agent-repository relationships. Available on the Cloud backend. */
+export interface AgentRepositoriesClient {
+  list(agentId: string): Promise<AgentRepository[]>;
+  /**
+   * Persistently attach a repository, wait for the relationship to become
+   * visible, then recompile the agent's default conversation unless disabled.
+   * If recompilation fails, the relationship remains attached and retrying is safe.
+   */
+  attach(
+    agentId: string,
+    repositoryId: string,
+    options?: AttachAgentRepositoryOptions,
+  ): Promise<AgentRepository>;
+  /**
+   * Persistently detach a repository, wait for the relationship to disappear,
+   * then recompile the agent's default conversation unless disabled. If
+   * recompilation fails, the relationship remains detached and retrying is safe.
+   */
+  detach(
+    agentId: string,
+    repositoryId: string,
+    options?: DetachAgentRepositoryOptions,
+  ): Promise<void>;
+}
+
 export interface AgentsClient {
+  /** Persistent repository relationships for this agent. Cloud only. */
+  readonly repositories: AgentRepositoriesClient;
   list(options?: ListAgentsOptions): Promise<LettaAgent[]>;
   retrieve(agentId: string): Promise<LettaAgent>;
   update(

--- a/src/management.ts
+++ b/src/management.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentRepositoriesClient,
   AgentsClient,
   ConversationsClient,
   ConversationMessagesResult,
@@ -153,8 +154,12 @@ function conversationMessagesQuery(
 
 export function createAgentsClient(
   transport: TransportProvider,
+  repositories: () => AgentRepositoriesClient,
 ): AgentsClient {
   return {
+    get repositories() {
+      return repositories();
+    },
     list: (options = {}) =>
       transport().listAgents(agentListQuery(options)),
     retrieve: (agentId) => transport().retrieveAgent(agentId),

--- a/src/tests/agent-repositories.test.ts
+++ b/src/tests/agent-repositories.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, test } from "bun:test";
+import { createAgentRepositoriesClient } from "../agent-repositories.js";
+import { LettaAgentClient as PortableLettaAgentClient } from "../client-entry.js";
+import { LettaAgentClient as NodeLettaAgentClient } from "../index.js";
+
+type FetchInput = Parameters<typeof fetch>[0];
+
+type RecordedRequest = {
+  url: URL;
+  method: string;
+  body?: unknown;
+};
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function repository(id = "repo-1") {
+  return {
+    id,
+    name: "knowledge-base",
+    is_primary: false,
+    permissions: "read" as const,
+  };
+}
+
+function cloudClient(
+  requests: RecordedRequest[],
+  handler: (
+    url: URL,
+    method: string,
+    body: unknown,
+  ) => Response,
+): PortableLettaAgentClient {
+  const fetchMock = (async (
+    input: FetchInput | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    requests.push({ url, method, body });
+    return handler(url, method, body);
+  }) as typeof fetch;
+  return new PortableLettaAgentClient({
+    backend: "cloud",
+    apiBaseUrl: "https://api.test",
+    apiKey: "sk-test",
+    fetch: fetchMock,
+  });
+}
+
+describe("client.agents.repositories", () => {
+  test("lists and normalizes persistent repository relationships", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(requests, () =>
+      jsonResponse({
+        repositories: [
+          repository(),
+          {
+            id: "repo-memory",
+            name: "memory",
+            is_primary: true,
+            permissions: "read_write",
+          },
+        ],
+      })
+    );
+
+    await expect(client.agents.repositories.list("agent-1")).resolves.toEqual([
+      {
+        id: "repo-1",
+        name: "knowledge-base",
+        isPrimary: false,
+        permissions: "read",
+      },
+      {
+        id: "repo-memory",
+        name: "memory",
+        isPrimary: true,
+        permissions: "read_write",
+      },
+    ]);
+    expect(requests.map(({ url, method }) => ({
+      path: url.pathname,
+      method,
+    }))).toEqual([
+      { path: "/v1/agents/agent-1/repositories", method: "GET" },
+    ]);
+  });
+
+  test("attaches, waits for visibility, then recompiles the default conversation", async () => {
+    const requests: RecordedRequest[] = [];
+    let attached = false;
+    let visibilityChecks = 0;
+    const client = cloudClient(requests, (url, method) => {
+      if (url.pathname.endsWith("/repositories") && method === "POST") {
+        attached = true;
+        return jsonResponse({ success: true, repository: repository() });
+      }
+      if (url.pathname.endsWith("/repositories") && method === "GET") {
+        visibilityChecks += 1;
+        return jsonResponse({
+          repositories:
+            attached
+              ? [{
+                ...repository(),
+                permissions:
+                  visibilityChecks > 1 ? "read" : "read_write",
+              }]
+              : [],
+        });
+      }
+      if (url.pathname.endsWith("/recompile") && method === "POST") {
+        return jsonResponse({ success: true });
+      }
+      return jsonResponse({ message: "not found" }, { status: 404 });
+    });
+
+    await expect(
+      client.agents.repositories.attach("agent-1", "repo-1", {
+        permissions: "read",
+      }),
+    ).resolves.toEqual({
+      id: "repo-1",
+      name: "knowledge-base",
+      isPrimary: false,
+      permissions: "read",
+    });
+
+    expect(requests.map(({ url, method, body }) => ({
+      path: url.pathname,
+      method,
+      body,
+    }))).toEqual([
+      {
+        path: "/v1/agents/agent-1/repositories",
+        method: "POST",
+        body: { repository_id: "repo-1", permissions: "read" },
+      },
+      {
+        path: "/v1/agents/agent-1/repositories",
+        method: "GET",
+        body: undefined,
+      },
+      {
+        path: "/v1/agents/agent-1/repositories",
+        method: "GET",
+        body: undefined,
+      },
+      {
+        path: "/v1/agents/agent-1/recompile",
+        method: "POST",
+        body: {},
+      },
+    ]);
+  });
+
+  test("can attach without recompiling", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(requests, (url, method) => {
+      if (method === "POST") {
+        return jsonResponse({ success: true, repository: repository() });
+      }
+      return jsonResponse({ repositories: [repository()] });
+    });
+
+    await client.agents.repositories.attach("agent-1", "repo-1", {
+      recompile: false,
+    });
+
+    expect(requests.map(({ method }) => method)).toEqual(["POST", "GET"]);
+  });
+
+  test("detaches, waits for absence, then recompiles", async () => {
+    const requests: RecordedRequest[] = [];
+    let attached = true;
+    let visibilityChecks = 0;
+    const client = cloudClient(requests, (url, method) => {
+      if (url.pathname.endsWith("/repositories/repo-1") && method === "DELETE") {
+        attached = false;
+        return jsonResponse({ success: true });
+      }
+      if (url.pathname.endsWith("/repositories") && method === "GET") {
+        visibilityChecks += 1;
+        return jsonResponse({
+          repositories:
+            attached || visibilityChecks === 1 ? [repository()] : [],
+        });
+      }
+      if (url.pathname.endsWith("/recompile") && method === "POST") {
+        return jsonResponse({ success: true });
+      }
+      return jsonResponse({ message: "not found" }, { status: 404 });
+    });
+
+    await expect(
+      client.agents.repositories.detach("agent-1", "repo-1"),
+    ).resolves.toBeUndefined();
+
+    expect(requests.map(({ url, method }) => ({
+      path: url.pathname,
+      method,
+    }))).toEqual([
+      {
+        path: "/v1/agents/agent-1/repositories/repo-1",
+        method: "DELETE",
+      },
+      { path: "/v1/agents/agent-1/repositories", method: "GET" },
+      { path: "/v1/agents/agent-1/repositories", method: "GET" },
+      { path: "/v1/agents/agent-1/recompile", method: "POST" },
+    ]);
+  });
+
+  test("treats an already-detached relationship as success and repairs the prompt", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(requests, (url, method) => {
+      if (method === "DELETE") {
+        return jsonResponse(
+          { message: "Repository link not found" },
+          { status: 404 },
+        );
+      }
+      if (url.pathname.endsWith("/repositories")) {
+        return jsonResponse({ repositories: [] });
+      }
+      return jsonResponse({ success: true });
+    });
+
+    await expect(
+      client.agents.repositories.detach("agent-1", "repo-1"),
+    ).resolves.toBeUndefined();
+    expect(requests.map(({ method }) => method)).toEqual([
+      "DELETE",
+      "GET",
+      "POST",
+    ]);
+  });
+
+  test("propagates recompile failures after the relationship becomes visible", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(requests, (url, method) => {
+      if (url.pathname.endsWith("/repositories") && method === "POST") {
+        return jsonResponse({ success: true, repository: repository() });
+      }
+      if (url.pathname.endsWith("/repositories") && method === "GET") {
+        return jsonResponse({ repositories: [repository()] });
+      }
+      return jsonResponse(
+        {
+          detail: "Prompt compilation failed",
+          reason_text: "Repository projection unavailable",
+        },
+        { status: 500 },
+      );
+    });
+
+    await expect(
+      client.agents.repositories.attach("agent-1", "repo-1"),
+    ).rejects.toThrow(
+      "Cloud recompile system prompt failed — Prompt compilation failed: Repository projection unavailable",
+    );
+    expect(requests.map(({ method }) => method)).toEqual([
+      "POST",
+      "GET",
+      "POST",
+    ]);
+  });
+
+  test("does not poll or recompile when attachment fails", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(requests, () =>
+      jsonResponse({ message: "Repository not found" }, { status: 404 })
+    );
+
+    await expect(
+      client.agents.repositories.attach("agent-1", "repo-missing"),
+    ).rejects.toThrow("Repository not found");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("POST");
+  });
+
+  test("detach remains effective when recompilation fails and is safe to retry", async () => {
+    const requests: RecordedRequest[] = [];
+    let attached = true;
+    const client = cloudClient(requests, (url, method) => {
+      if (method === "DELETE") {
+        if (!attached) {
+          return jsonResponse(
+            { message: "Repository link not found" },
+            { status: 404 },
+          );
+        }
+        attached = false;
+        return jsonResponse({ success: true });
+      }
+      if (url.pathname.endsWith("/repositories")) {
+        return jsonResponse({ repositories: [] });
+      }
+      return jsonResponse(
+        { detail: "Prompt compilation failed" },
+        { status: 500 },
+      );
+    });
+
+    await expect(
+      client.agents.repositories.detach("agent-1", "repo-1"),
+    ).rejects.toThrow("Prompt compilation failed");
+    expect(attached).toBe(false);
+
+    await expect(
+      client.agents.repositories.detach("agent-1", "repo-1", {
+        recompile: false,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("fails before recompiling when relationship visibility times out", async () => {
+    let recompiles = 0;
+    const client = createAgentRepositoriesClient(
+      () => ({
+        listAgentRepositories: async () => [],
+        attachAgentRepository: async () => ({
+          id: "repo-1",
+          name: "knowledge-base",
+          isPrimary: false,
+          permissions: "read_write",
+        }),
+        detachAgentRepository: async () => {},
+        recompileAgentSystemPrompt: async () => {
+          recompiles += 1;
+        },
+      }),
+      { timeoutMs: 0, pollIntervalMs: 0 },
+    );
+
+    await expect(
+      client.attach("agent-1", "repo-1"),
+    ).rejects.toThrow(
+      "Cloud attach agent repository did not become visible for agent-1: repo-1",
+    );
+    expect(recompiles).toBe(0);
+  });
+
+  test("validates ids and permissions before making a request", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(requests, () =>
+      jsonResponse({ repositories: [] })
+    );
+
+    await expect(
+      client.agents.repositories.list(" "),
+    ).rejects.toThrow("Invalid agent id");
+    await expect(
+      client.agents.repositories.attach("agent-1", ""),
+    ).rejects.toThrow("Invalid repository id");
+    await expect(
+      client.agents.repositories.attach("agent-1", "repo-1", {
+        permissions: "owner" as "read",
+      }),
+    ).rejects.toThrow("Invalid repository permissions");
+    await expect(
+      client.agents.repositories.attach("agent-1", "repo-1", {
+        recompile: true as false,
+      }),
+    ).rejects.toThrow("Invalid repository recompile target");
+    expect(requests).toHaveLength(0);
+  });
+
+  test("encodes agent and repository ids", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = cloudClient(requests, (url, method) => {
+      if (method === "DELETE") return jsonResponse({ success: true });
+      if (url.pathname.endsWith("/repositories")) {
+        return jsonResponse({ repositories: [] });
+      }
+      return jsonResponse({ success: true });
+    });
+
+    await client.agents.repositories.detach(
+      "agent/with space",
+      "repo/with space",
+      { recompile: false },
+    );
+
+    expect(requests[0]?.url.pathname).toBe(
+      "/v1/agents/agent%2Fwith%20space/repositories/repo%2Fwith%20space",
+    );
+  });
+
+  test("fails closed on local and remote backends without opening a connection", () => {
+    const remote = new PortableLettaAgentClient({
+      backend: "remote",
+      url: "ws://remote.test/ws",
+    });
+    const local = new NodeLettaAgentClient({ backend: "local" });
+
+    expect(() => remote.agents.repositories).toThrow(
+      'client.agents.repositories is only available with backend: "cloud".',
+    );
+    expect(() => local.agents.repositories).toThrow(
+      'client.agents.repositories is only available with backend: "cloud".',
+    );
+  });
+});

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -181,13 +181,27 @@ function createCloudFetchMock(
         .map((request) => (request.body as { repository_id?: string } | undefined)?.repository_id)
         .filter((id): id is string => typeof id === "string");
       return Promise.resolve(jsonResponse({
-        repositories: postedIds.map((id) => ({ id, name: id, is_primary: false })),
+        repositories: postedIds.map((id) => ({
+          id,
+          name: id,
+          is_primary: false,
+          permissions: "read_write",
+        })),
       }));
     }
 
     if (agentRepositoriesMatch && method === "POST") {
       const body = bodyOf(init) as { repository_id?: string } | undefined;
-      return Promise.resolve(jsonResponse({ success: true, repository: { id: body?.repository_id ?? "repo-1" } }));
+      const id = body?.repository_id ?? "repo-1";
+      return Promise.resolve(jsonResponse({
+        success: true,
+        repository: {
+          id,
+          name: id,
+          is_primary: false,
+          permissions: "read_write",
+        },
+      }));
     }
 
     const agentRepositoryMatch = /^\/v1\/agents\/([^/]+)\/repositories\/([^/]+)$/.exec(parsed.pathname);

--- a/src/types.ts
+++ b/src/types.ts
@@ -674,7 +674,11 @@ export interface CreateSessionOptions {
    */
   approvalRecoveryTimeoutMs?: number;
 
-  /** Cloud repository resources to attach for the lifetime of the SDK session. */
+  /**
+   * Cloud repository resources to attach for the lifetime of the SDK session.
+   * For relationships that should outlive the session, use
+   * `client.agents.repositories.attach()` instead.
+   */
   resources?: RepositoryResource[];
 
 }


### PR DESCRIPTION
## Summary

- add `client.agents.repositories.list/attach/detach` for Cloud repository relationships that persist beyond an SDK session
- wait for attachment, permission, and detachment visibility before recompiling the agent's default conversation; mutations remain idempotent and retry-safe when recompilation fails
- keep session `resources` explicitly temporary while sharing the underlying Cloud repository and recompilation transport with persistent management
- document the lifecycle distinction and cover delayed visibility, permission updates, partial failures, backend gating, cleanup, and timeout behavior

Validated with the full 194-test suite, `bun run check`, and `bun run build`.

👾 Generated with [Letta Code](https://letta.com)
