### PR TITLE
refactor(cloud): route SDK requests through the Letta client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,36 @@ the selected transport adapter.
 Those methods operate at different layers and should not be combined merely
 because they share a name.
 
+## Cloud API ownership
+
+- `@letta-ai/letta-code` owns the agent harness, app-server protocol, runtime
+  lifecycle, and tool execution boundary.
+- `@letta-ai/letta-client` owns Letta API HTTP contracts, authentication,
+  headers, retries, pagination, and API errors. Declare it as a direct
+  dependency when importing it; do not rely on Letta Code's transitive copy.
+- Before adding a Cloud REST call, inspect the installed generated client. Use
+  the generated resource method when it covers the endpoint.
+- When an endpoint is not generated yet, use the shared Letta client's typed
+  `get`/`post`/`patch`/`delete` method and validate the ungenerated response at
+  that boundary. Do not add raw `fetch`, URL/auth/header helpers, response
+  parsers, retry loops, or parallel HTTP error types.
+- `LettaAgentClientBase` owns one lazy Cloud client and injects it into
+  management, repository, environment, and session code. New Cloud REST
+  surfaces should reuse that instance. WebSocket transport remains separate.
+- Keep the public management types portable across Cloud and app-server
+  backends. Generated Cloud types belong at the Cloud transport seam; do not
+  narrow the shared facade to shapes that the app-server protocol cannot
+  promise.
+- Verify generated route paths against the live API before introducing or
+  preserving a generic-request exception. Server routing evolves: a mismatch
+  proven in an older PR may no longer exist. Prefer the generated resource as
+  soon as its live route works, and delete the workaround rather than
+  fossilizing it in new architecture.
+
+After changing this boundary, run `bun run check`, `bun test`, and
+`bun run build`. If path behavior changed, run the narrow live route test too;
+do not infer POST/DELETE slash behavior from a successful GET.
+
 ## Change discipline
 
 - Keep transport parsing out of the session facade.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,11 @@ because they share a name.
   backends. Generated Cloud types belong at the Cloud transport seam; do not
   narrow the shared facade to shapes that the app-server protocol cannot
   promise.
+- Reuse generated Letta entity, request, and response types whenever the SDK
+  contract has the same semantics. Camel-case SDK facades may rename fields,
+  but their value types should derive from the generated params. Do not mirror
+  generated entities as partial `Record<string, unknown>` shapes or rewrite
+  app-server envelopes already exported by `app-server-protocol`.
 - Verify generated route paths against the live API before introducing or
   preserving a generic-request exception. Server routing evolves: a mismatch
   proven in an older PR may no longer exist. Prefer the generated resource as

--- a/build.ts
+++ b/build.ts
@@ -52,8 +52,10 @@ const portableOutput = readFileSync(
   join(__dirname, "dist", "client-entry.js"),
   "utf-8",
 );
-const forbiddenNodeImport = /(?:from\s*|import\s*\()\s*["']node:/;
-if (forbiddenNodeImport.test(portableOutput)) {
+const portableImports = new Bun.Transpiler({ loader: "js" }).scanImports(
+  portableOutput,
+);
+if (portableImports.some(({ path }) => path.startsWith("node:"))) {
   throw new Error(
     'Portable client build contains a Node builtin import. Keep Node-only modules behind the package root.',
   );

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "url": "https://github.com/letta-ai/letta-agent-sdk"
   },
   "dependencies": {
+    "@letta-ai/letta-client": "^1.12.1",
     "@letta-ai/letta-code": "0.29.7"
   },
   "devDependencies": {

--- a/src/app-server-management.ts
+++ b/src/app-server-management.ts
@@ -1,58 +1,42 @@
 import {
   createAppServerClient,
   type AppServerClient,
-  type AppServerRequestCommandWithId,
+  type AppServerRawResponse,
   type AppServerSocketConstructor,
 } from "@letta-ai/letta-code/app-server-client";
 import type {
-  ManagementQuery,
-  ManagementTransport,
-} from "./management.js";
+  AgentDeleteResponseMessage,
+  AgentListResponseMessage,
+  AgentRetrieveResponseMessage,
+  AgentUpdateResponseMessage,
+  ConversationCreateResponseMessage,
+  ConversationListResponseMessage,
+  ConversationMessagesListResponseMessage,
+  ConversationRetrieveResponseMessage,
+  ConversationUpdateResponseMessage,
+  ListModelsResponseMessage,
+} from "@letta-ai/letta-code/app-server-protocol";
+import type {
+  AgentListParams,
+  AgentUpdateParams,
+} from "@letta-ai/letta-client/resources/agents/agents";
+import type {
+  ConversationCreateParams,
+  ConversationListParams,
+  ConversationUpdateParams,
+} from "@letta-ai/letta-client/resources/conversations/conversations";
+import type { MessageListParams } from "@letta-ai/letta-client/resources/conversations/messages";
+import { normalizeAppServerModels } from "./app-server-models.js";
+import type { ManagementTransport } from "./management.js";
 import { applyUniqueRequestIds } from "./request-ids.js";
 import type {
   ConversationMessagesResult,
   LettaAgent,
   LettaConversation,
 } from "./management-types.js";
-import type {
-  LettaCodeModelEntry,
-  LettaCodeRemoteClientOptions,
-  ListModelsResult,
-} from "./types.js";
+import type { LettaCodeRemoteClientOptions, ListModelsResult } from "./types.js";
 
 type OwnedConnection = { url: string; close(): void };
-
-type ManagementResponse = {
-  type: string;
-  success: boolean;
-  error?: string;
-};
-
-type AgentListResponse = ManagementResponse & {
-  agents: LettaAgent[];
-};
-
-type AgentResponse = ManagementResponse & {
-  agent: LettaAgent | null;
-};
-
-type ConversationListResponse = ManagementResponse & {
-  conversations: LettaConversation[];
-};
-
-type ConversationResponse = ManagementResponse & {
-  conversation: LettaConversation | null;
-};
-
-type ConversationMessagesResponse = ManagementResponse & {
-  messages: Record<string, unknown>[];
-};
-
-type ListModelsResponse = ManagementResponse & {
-  entries?: unknown;
-  available_handles?: unknown;
-  byok_provider_aliases?: unknown;
-};
 
 export type AppServerManagementOptions =
   Partial<LettaCodeRemoteClientOptions> & {
@@ -77,39 +61,6 @@ function ensureResponse<T>(
   return value;
 }
 
-function modelEntries(value: unknown): LettaCodeModelEntry[] {
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((entry) => {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
-    const record = entry as Record<string, unknown>;
-    if (
-      typeof record.id !== "string" ||
-      typeof record.handle !== "string" ||
-      typeof record.label !== "string" ||
-      typeof record.description !== "string"
-    ) {
-      return [];
-    }
-    return [{
-      ...record,
-      id: record.id,
-      handle: record.handle,
-      label: record.label,
-      description: record.description,
-    }];
-  });
-}
-
-function stringRecord(value: unknown): Record<string, string> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-  const entries = Object.entries(value as Record<string, unknown>).filter(
-    (entry): entry is [string, string] => typeof entry[1] === "string",
-  );
-  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
-}
-
 /**
  * Management transport that speaks the app-server control protocol.
  *
@@ -125,8 +76,8 @@ export class AppServerManagementTransport
 
   constructor(private readonly options: AppServerManagementOptions) {}
 
-  async listAgents(query: ManagementQuery): Promise<LettaAgent[]> {
-    const response = await this.request<AgentListResponse>(
+  async listAgents(query: AgentListParams): Promise<LettaAgent[]> {
+    const response = await this.request<AgentListResponseMessage>(
       "agent_list",
       { query },
       "agent_list_response",
@@ -138,7 +89,7 @@ export class AppServerManagementTransport
   }
 
   async retrieveAgent(agentId: string): Promise<LettaAgent> {
-    const response = await this.request<AgentResponse>(
+    const response = await this.request<AgentRetrieveResponseMessage>(
       "agent_retrieve",
       { agent_id: agentId },
       "agent_retrieve_response",
@@ -152,9 +103,9 @@ export class AppServerManagementTransport
 
   async updateAgent(
     agentId: string,
-    body: Record<string, unknown>,
+    body: AgentUpdateParams,
   ): Promise<LettaAgent> {
-    const response = await this.request<AgentResponse>(
+    const response = await this.request<AgentUpdateResponseMessage>(
       "agent_update",
       { agent_id: agentId, body },
       "agent_update_response",
@@ -167,7 +118,7 @@ export class AppServerManagementTransport
   }
 
   async deleteAgent(agentId: string): Promise<void> {
-    const response = await this.request<ManagementResponse>(
+    const response = await this.request<AgentDeleteResponseMessage>(
       "agent_delete",
       { agent_id: agentId },
       "agent_delete_response",
@@ -180,33 +131,18 @@ export class AppServerManagementTransport
   async listModels(): Promise<ListModelsResult> {
     // A bare list_models command (no runtime scope) is answered on the
     // control channel, so no session or conversation is required.
-    const response = await this.request<ListModelsResponse>(
+    const response = await this.request<ListModelsResponseMessage>(
       "list_models",
       {},
       "list_models_response",
     );
-    if (!response.success) {
-      throw new Error(response.error ?? "Failed to list models.");
-    }
-    const result: ListModelsResult = {
-      entries: modelEntries(response.entries),
-    };
-    if (response.available_handles === null) {
-      result.availableHandles = null;
-    } else if (Array.isArray(response.available_handles)) {
-      result.availableHandles = response.available_handles.filter(
-        (handle): handle is string => typeof handle === "string",
-      );
-    }
-    const aliases = stringRecord(response.byok_provider_aliases);
-    if (aliases) result.byokProviderAliases = aliases;
-    return result;
+    return normalizeAppServerModels(response);
   }
 
   async listConversations(
-    query: ManagementQuery,
+    query: ConversationListParams,
   ): Promise<LettaConversation[]> {
-    const response = await this.request<ConversationListResponse>(
+    const response = await this.request<ConversationListResponseMessage>(
       "conversation_list",
       { query },
       "conversation_list_response",
@@ -220,7 +156,7 @@ export class AppServerManagementTransport
   async retrieveConversation(
     conversationId: string,
   ): Promise<LettaConversation> {
-    const response = await this.request<ConversationResponse>(
+    const response = await this.request<ConversationRetrieveResponseMessage>(
       "conversation_retrieve",
       { conversation_id: conversationId },
       "conversation_retrieve_response",
@@ -233,9 +169,9 @@ export class AppServerManagementTransport
   }
 
   async createConversation(
-    body: Record<string, unknown>,
+    body: ConversationCreateParams,
   ): Promise<LettaConversation> {
-    const response = await this.request<ConversationResponse>(
+    const response = await this.request<ConversationCreateResponseMessage>(
       "conversation_create",
       { body },
       "conversation_create_response",
@@ -249,9 +185,9 @@ export class AppServerManagementTransport
 
   async updateConversation(
     conversationId: string,
-    body: Record<string, unknown>,
+    body: ConversationUpdateParams,
   ): Promise<LettaConversation> {
-    const response = await this.request<ConversationResponse>(
+    const response = await this.request<ConversationUpdateResponseMessage>(
       "conversation_update",
       { conversation_id: conversationId, body },
       "conversation_update_response",
@@ -265,10 +201,10 @@ export class AppServerManagementTransport
 
   async listConversationMessages(
     conversationId: string,
-    query: ManagementQuery,
+    query: MessageListParams,
   ): Promise<ConversationMessagesResult> {
     const response =
-      await this.request<ConversationMessagesResponse>(
+      await this.request<ConversationMessagesListResponseMessage>(
         "conversation_messages_list",
         { conversation_id: conversationId, query },
         "conversation_messages_list_response",
@@ -294,16 +230,20 @@ export class AppServerManagementTransport
     // counter, while connection identity keeps this pool independent from
     // session clients using the same app-server.
     const { client } = await this.acquireConnection();
-    const command = {
-      type,
-      request_id: client.nextRequestId(type),
-      ...body,
-    } as AppServerRequestCommandWithId;
-    const response = await client.request(command, {
-      predicate: (message): message is typeof message =>
-        message.type === responseType,
-    });
-    return response as unknown as TResponse;
+    return client.requestRaw<TResponse & AppServerRawResponse>(
+      {
+        type,
+        request_id: client.nextRequestId(type),
+        ...body,
+      },
+      {
+        predicate: (message): message is TResponse & AppServerRawResponse =>
+          message !== null &&
+          typeof message === "object" &&
+          "type" in message &&
+          message.type === responseType,
+      },
+    );
   }
 
   private acquireConnection(): Promise<ActiveConnection> {

--- a/src/app-server-models.ts
+++ b/src/app-server-models.ts
@@ -1,0 +1,20 @@
+import type { ListModelsResponseMessage } from "@letta-ai/letta-code/app-server-protocol";
+import type { ListModelsResult } from "./types.js";
+
+export function normalizeAppServerModels(
+  response: ListModelsResponseMessage,
+): ListModelsResult {
+  if (!response.success) {
+    throw new Error(response.error ?? "listModels failed");
+  }
+
+  return {
+    entries: response.entries,
+    ...(response.available_handles !== undefined
+      ? { availableHandles: response.available_handles }
+      : {}),
+    ...(response.byok_provider_aliases !== undefined
+      ? { byokProviderAliases: response.byok_provider_aliases }
+      : {}),
+  };
+}

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -4,12 +4,20 @@ import {
   type AppServerExternalToolCallHandler,
   type AppServerSocketConstructor,
 } from "@letta-ai/letta-code/app-server-client";
+import type {
+  ConversationMessagesListResponseMessage,
+  ConversationRetrieveResponseMessage,
+  ListModelsResponseMessage,
+  RuntimeStartResponseMessage,
+  UpdateModelResponseMessage,
+} from "@letta-ai/letta-code/app-server-protocol";
 import {
   buildCreateAgentRequestForPersonality,
   buildSystemPrompt,
   GIT_MEMORY_ENABLED_TAG,
   LETTA_CODE_ORIGIN_TAG,
 } from "@letta-ai/letta-code/agent-presets";
+import { normalizeAppServerModels } from "./app-server-models.js";
 import {
   buildCanUseToolContext,
   isHeadlessAutoAllowTool,
@@ -46,55 +54,14 @@ import type {
   UpdateModelResult,
 } from "./types.js";
 
-type RuntimeStartResponse = ProtocolMessage & {
-  type: "runtime_start_response";
-  success: boolean;
-  runtime: RuntimeScope | null;
-  agent: (Record<string, unknown> & {
-    id?: string;
-    model?: string | null;
-    model_settings?: Record<string, unknown> | null;
-  }) | null;
-  conversation: (Record<string, unknown> & { id?: string; agent_id?: string }) | null;
-  error?: string;
-};
-
-type ConversationRetrieveResponse = ProtocolMessage & {
-  type: "conversation_retrieve_response";
-  success: boolean;
-  conversation: (Record<string, unknown> & { id?: string; agent_id?: string }) | null;
-  error?: string;
-};
-
-type ConversationMessagesListResponse = ProtocolMessage & {
-  type: "conversation_messages_list_response";
-  success: boolean;
-  messages: unknown[];
-  next_before?: string | null;
+type ConversationMessagesListResponse = ConversationMessagesListResponseMessage &
+  ProtocolMessage & {
   nextBefore?: string | null;
-  has_more?: boolean;
   hasMore?: boolean;
-  error?: string;
 };
 
-type ListModelsResponse = ProtocolMessage & {
-  type: "list_models_response";
-  success: boolean;
-  entries?: unknown;
-  available_handles?: unknown;
-  byok_provider_aliases?: unknown;
-  error?: string;
-};
-
-type UpdateModelResponse = ProtocolMessage & {
-  type: "update_model_response";
-  success: boolean;
-  applied_to?: unknown;
-  model_id?: unknown;
-  model_handle?: unknown;
-  model_settings?: unknown;
-  error?: string;
-};
+type ListModelsResponse = ListModelsResponseMessage & ProtocolMessage;
+type UpdateModelResponse = UpdateModelResponseMessage & ProtocolMessage;
 
 type UpdateModelPayload = {
   model_id?: string;
@@ -104,9 +71,9 @@ type UpdateModelPayload = {
 type RuntimeStartCommand = Parameters<AppServerClient["runtimeStart"]>[0];
 
 export function agentToolNames(
-  agent: Record<string, unknown> | null | undefined,
+  agent: object | null | undefined,
 ): string[] | undefined {
-  const tools = agent?.tools;
+  const tools = agent && "tools" in agent ? agent.tools : undefined;
   if (!Array.isArray(tools)) return undefined;
   return tools.flatMap((tool) => {
     if (typeof tool === "string" && tool.length > 0) return [tool];
@@ -414,82 +381,29 @@ export function toAppServerApprovalDecision(
   };
 }
 
-function stringRecord(value: unknown): Record<string, string> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
-  const record: Record<string, string> = {};
-  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof entry === "string") record[key] = entry;
-  }
-  return record;
-}
-
 function objectRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
   return { ...(value as Record<string, unknown>) };
 }
 
-function normalizeListModelsResponse(response: ListModelsResponse): ListModelsResult {
-  if (!response.success) {
-    throw new Error(response.error ?? "listModels failed");
-  }
-
-  const entries = Array.isArray(response.entries)
-    ? response.entries.flatMap((entry) => {
-        if (!entry || typeof entry !== "object") return [];
-        const record = entry as Record<string, unknown>;
-        if (
-          typeof record.id !== "string" ||
-          typeof record.handle !== "string" ||
-          typeof record.label !== "string" ||
-          typeof record.description !== "string"
-        ) {
-          return [];
-        }
-        const updateArgs = objectRecord(record.updateArgs);
-        return [
-          {
-            id: record.id,
-            handle: record.handle,
-            label: record.label,
-            description: record.description,
-            ...(typeof record.isDefault === "boolean" ? { isDefault: record.isDefault } : {}),
-            ...(typeof record.isFeatured === "boolean" ? { isFeatured: record.isFeatured } : {}),
-            ...(typeof record.free === "boolean" ? { free: record.free } : {}),
-            ...(updateArgs ? { updateArgs } : {}),
-          },
-        ];
-      })
-    : [];
-
-  const result: ListModelsResult = { entries };
-  if (response.available_handles === null) {
-    result.availableHandles = null;
-  } else if (Array.isArray(response.available_handles)) {
-    result.availableHandles = response.available_handles.filter(
-      (handle): handle is string => typeof handle === "string",
-    );
-  }
-  const aliases = stringRecord(response.byok_provider_aliases);
-  if (aliases) result.byokProviderAliases = aliases;
-  return result;
-}
-
-function normalizeUpdateModelResponse(response: UpdateModelResponse): UpdateModelResult {
+function normalizeUpdateModelResponse(
+  response: UpdateModelResponseMessage,
+): UpdateModelResult {
   if (!response.success) {
     throw new Error(response.error ?? "Failed to update model");
   }
-  const result: UpdateModelResult = {};
-  if (response.applied_to === "agent" || response.applied_to === "conversation") {
-    result.appliedTo = response.applied_to;
-  }
-  if (typeof response.model_id === "string") result.modelId = response.model_id;
-  if (typeof response.model_handle === "string") result.modelHandle = response.model_handle;
-  if (response.model_settings === null) {
-    result.modelSettings = null;
-  } else if (response.model_settings && typeof response.model_settings === "object") {
-    result.modelSettings = { ...(response.model_settings as Record<string, unknown>) };
-  }
-  return result;
+  return {
+    ...(response.applied_to !== undefined
+      ? { appliedTo: response.applied_to }
+      : {}),
+    ...(response.model_id !== undefined ? { modelId: response.model_id } : {}),
+    ...(response.model_handle !== undefined
+      ? { modelHandle: response.model_handle }
+      : {}),
+    ...(response.model_settings !== undefined
+      ? { modelSettings: response.model_settings }
+      : {}),
+  };
 }
 
 function runtimeScopeFromMessage(message: ProtocolMessage): RuntimeScope | null {
@@ -603,43 +517,52 @@ export class AppServerRuntimeController implements RemoteClientRuntimeController
     await this.client.abort({ runtime } as Parameters<AppServerClient["abort"]>[0]);
   }
 
-  request(
+  request<TResponse extends ProtocolMessage = ProtocolMessage>(
     type: string,
     body: Record<string, unknown>,
     options: { timeoutMs?: number; predicate?: (message: ProtocolMessage) => boolean } = {},
-  ): Promise<ProtocolMessage> {
-    const request = this.client.request.bind(this.client) as unknown as (
-      commandType: string,
-      commandBody: Record<string, unknown>,
-      requestOptions?: {
-        timeoutMs?: number;
-        predicate?: (message: ProtocolMessage) => boolean;
+  ): Promise<TResponse> {
+    return this.client.requestRaw<TResponse>(
+      {
+        type,
+        request_id: this.client.nextRequestId(type),
+        ...body,
       },
-    ) => Promise<ProtocolMessage>;
-    return request(type, body, options);
+      {
+        ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+        predicate: (message): message is TResponse => {
+          if (!message || typeof message !== "object" || Array.isArray(message)) {
+            return false;
+          }
+          const candidate = message as ProtocolMessage;
+          return typeof candidate.type === "string" &&
+            (options.predicate?.(candidate) ?? true);
+        },
+      },
+    );
   }
 
   async listModels(): Promise<ListModelsResult> {
-    const response = (await this.request(
+    const response = await this.request<ListModelsResponse>(
       "list_models",
       {},
       { predicate: (message) => message.type === "list_models_response" },
-    )) as ListModelsResponse;
-    return normalizeListModelsResponse(response);
+    );
+    return normalizeAppServerModels(response);
   }
 
   async updateModel(
     runtime: RuntimeScope,
     payload: UpdateModelPayload,
   ): Promise<UpdateModelResult> {
-    const response = (await this.request(
+    const response = await this.request<UpdateModelResponse>(
       "update_model",
       {
         runtime,
         payload,
       },
       { predicate: (message) => message.type === "update_model_response" },
-    )) as UpdateModelResponse;
+    );
     return normalizeUpdateModelResponse(response);
   }
 
@@ -677,14 +600,14 @@ export class AppServerRuntimeController implements RemoteClientRuntimeController
     if (options.order !== undefined) query.order = options.order;
     if (options.limit !== undefined) query.limit = options.limit;
 
-    const response = (await this.request(
+    const response = await this.request<ConversationMessagesListResponse>(
       "conversation_messages_list",
       {
         conversation_id: conversationId,
         ...(Object.keys(query).length > 0 ? { query } : {}),
       },
       { predicate: (message) => message.type === "conversation_messages_list_response" },
-    )) as ConversationMessagesListResponse;
+    );
 
     if (!response.success) {
       throw new Error(response.error ?? "listMessages failed");
@@ -784,7 +707,7 @@ export class AppServerSession extends RemoteClientSessionCore {
         ),
         runtime: response.runtime,
         model: typeof response.agent?.model === "string" ? response.agent.model : "",
-        modelSettings: response.agent?.model_settings ?? null,
+        modelSettings: objectRecord(response.agent?.model_settings) ?? null,
         ...(tools !== undefined ? { tools } : {}),
         ...(skillSources !== undefined ? { skillSources: [...skillSources] } : {}),
       };
@@ -822,10 +745,11 @@ export class AppServerSession extends RemoteClientSessionCore {
     return connection.url;
   }
 
-  private async startRuntime(client: AppServerClient): Promise<RuntimeStartResponse> {
+  private async startRuntime(
+    client: AppServerClient,
+  ): Promise<RuntimeStartResponseMessage> {
     const command = await this.buildRuntimeStartCommand(client);
-    const response = (await client.runtimeStart(command)) as unknown as RuntimeStartResponse;
-    return response;
+    return client.runtimeStart(command);
   }
 
   private async buildRuntimeStartCommand(client: AppServerClient): Promise<RuntimeStartCommand> {
@@ -897,16 +821,17 @@ export class AppServerSession extends RemoteClientSessionCore {
     client: AppServerClient,
     conversationId: string,
   ): Promise<string> {
-    const request = client.request.bind(client) as unknown as (
-      commandType: string,
-      commandBody: Record<string, unknown>,
-      options?: { predicate?: (message: ProtocolMessage) => boolean },
-    ) => Promise<ProtocolMessage>;
-    const response = (await request(
-      "conversation_retrieve",
-      { conversation_id: conversationId },
-      { predicate: (message) => message.type === "conversation_retrieve_response" },
-    )) as ConversationRetrieveResponse;
+    const response = await client.request<ConversationRetrieveResponseMessage>(
+      {
+        type: "conversation_retrieve",
+        request_id: client.nextRequestId("conversation_retrieve"),
+        conversation_id: conversationId,
+      },
+      {
+        predicate: (message): message is ConversationRetrieveResponseMessage =>
+          message.type === "conversation_retrieve_response",
+      },
+    );
     if (!response.success || !response.conversation?.agent_id) {
       throw new Error(response.error ?? `Failed to retrieve conversation ${conversationId}`);
     }

--- a/src/client-base.ts
+++ b/src/client-base.ts
@@ -1,3 +1,4 @@
+import type Letta from "@letta-ai/letta-client";
 import { RepositoriesClient } from "./repositories.js";
 import { createAgentRepositoriesClient } from "./agent-repositories.js";
 import { AppServerManagementTransport } from "./app-server-management.js";
@@ -6,6 +7,7 @@ import {
   type AppServerSessionOptions,
 } from "./app-server-session.js";
 import { CloudManagementTransport } from "./cloud-management.js";
+import { createCloudClient } from "./cloud-client.js";
 import {
   CloudEnvironmentSession,
   assertCloudSessionOptionsSupported,
@@ -107,6 +109,7 @@ export class LettaAgentClientBase {
   protected readonly options: LettaCodeClientOptions;
   private repositoriesClient: RepositoriesClient | null = null;
   private agentRepositoriesClient: AgentRepositoriesClient | null = null;
+  private cloudClient: Letta | null = null;
   private managementTransport: ManagementTransport | null = null;
 
   constructor(options: LettaCodeClientOptions = {}) {
@@ -212,7 +215,7 @@ export class LettaAgentClientBase {
       return initMsg.agentId;
     }
     if (this.backend === "cloud") {
-      return createCloudAgent(this.cloudOptions(), options);
+      return createCloudAgent(this.getCloudClient(), options);
     }
     return this.createLocalAgent(options);
   }
@@ -242,12 +245,16 @@ export class LettaAgentClientBase {
       });
     }
     if (this.backend === "cloud") {
-      return new CloudEnvironmentSession(this.cloudOptions(), {
-        kind: "session",
-        agentId,
-        newConversation: true,
-        options,
-      });
+      return new CloudEnvironmentSession(
+        this.cloudOptions(),
+        {
+          kind: "session",
+          agentId,
+          newConversation: true,
+          options,
+        },
+        this.getCloudClient(),
+      );
     }
     return this.createLocalSession(agentId, options);
   }
@@ -283,18 +290,26 @@ export class LettaAgentClientBase {
     }
     if (this.backend === "cloud") {
       if (looksLikeConversationId(id)) {
-        return new CloudEnvironmentSession(this.cloudOptions(), {
-          kind: "session",
-          conversationId: id,
-          options,
-        });
+        return new CloudEnvironmentSession(
+          this.cloudOptions(),
+          {
+            kind: "session",
+            conversationId: id,
+            options,
+          },
+          this.getCloudClient(),
+        );
       }
-      return new CloudEnvironmentSession(this.cloudOptions(), {
-        kind: "session",
-        agentId: id,
-        defaultConversation: true,
-        options,
-      });
+      return new CloudEnvironmentSession(
+        this.cloudOptions(),
+        {
+          kind: "session",
+          agentId: id,
+          defaultConversation: true,
+          options,
+        },
+        this.getCloudClient(),
+      );
     }
     return this.resumeLocalSession(id, options);
   }
@@ -433,7 +448,10 @@ export class LettaAgentClientBase {
     if (this.backend !== "cloud") {
       throw new Error('client.repositories is only available with backend: "cloud".');
     }
-    this.repositoriesClient ??= new RepositoriesClient(this.cloudOptions());
+    this.repositoriesClient ??= new RepositoriesClient(
+      this.cloudOptions(),
+      this.getCloudClient(),
+    );
     return this.repositoriesClient;
   }
 
@@ -457,6 +475,14 @@ export class LettaAgentClientBase {
     return transport;
   }
 
+  private getCloudClient(): Letta {
+    if (this.backend !== "cloud") {
+      throw new Error("Letta client requested for non-cloud backend.");
+    }
+    this.cloudClient ??= createCloudClient(this.cloudOptions());
+    return this.cloudClient;
+  }
+
   private getManagementTransport(): ManagementTransport {
     if (this.managementTransport) return this.managementTransport;
     if (this.backend === "remote") {
@@ -465,7 +491,7 @@ export class LettaAgentClientBase {
       );
     } else if (this.backend === "cloud") {
       this.managementTransport = new CloudManagementTransport(
-        this.cloudOptions(),
+        this.getCloudClient(),
       );
     } else {
       this.managementTransport = this.createLocalManagementTransport();

--- a/src/cloud-client.ts
+++ b/src/cloud-client.ts
@@ -1,0 +1,46 @@
+import Letta from "@letta-ai/letta-client";
+import type { LettaCodeCloudClientOptions } from "./types.js";
+
+const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
+
+function defaultApiKey(): string | undefined {
+  const env = (
+    globalThis as {
+      process?: { env?: Record<string, string | undefined> };
+    }
+  ).process?.env;
+  return env?.LETTA_API_KEY ?? env?.LETTA_CLOUD_API_KEY;
+}
+
+function bearerToken(
+  headers: Record<string, string> | undefined,
+): string | undefined {
+  const authorization = headers?.Authorization ?? headers?.authorization;
+  return authorization?.match(/^Bearer\s+(.+)$/i)?.[1];
+}
+
+export function getCloudApiKey(
+  options: LettaCodeCloudClientOptions,
+): string | undefined {
+  return options.apiKey ?? bearerToken(options.headers) ?? defaultApiKey();
+}
+
+export function normalizeCloudApiBaseUrl(url: string | undefined): string {
+  const parsed = new URL(url ?? DEFAULT_CLOUD_API_BASE_URL);
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+/** Build the canonical Letta API client shared by one Agent SDK client. */
+export function createCloudClient(
+  options: LettaCodeCloudClientOptions,
+): Letta {
+  return new Letta({
+    apiKey: getCloudApiKey(options) ?? null,
+    baseURL: normalizeCloudApiBaseUrl(options.apiBaseUrl),
+    defaultHeaders: options.headers,
+    fetch: options.fetch,
+  });
+}

--- a/src/cloud-management.ts
+++ b/src/cloud-management.ts
@@ -1,136 +1,30 @@
+import type Letta from "@letta-ai/letta-client";
+import { APIError } from "@letta-ai/letta-client/core/error";
+import type {
+  AgentListParams,
+  AgentUpdateParams,
+} from "@letta-ai/letta-client/resources/agents/agents";
+import type {
+  ConversationCreateParams,
+  ConversationListParams,
+  ConversationUpdateParams,
+} from "@letta-ai/letta-client/resources/conversations/conversations";
+import type { MessageListParams } from "@letta-ai/letta-client/resources/conversations/messages";
 import type {
   ManagementQuery,
   ManagementTransport,
 } from "./management.js";
 import type {
   AgentRepository,
+  AgentRepositoryPermissions,
   ConversationMessagesResult,
   LettaAgent,
   LettaConversation,
-  AgentRepositoryPermissions,
 } from "./management-types.js";
 import type {
-  LettaCodeCloudClientOptions,
   LettaCodeModelEntry,
   ListModelsResult,
 } from "./types.js";
-
-const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
-
-function defaultApiKey(): string | undefined {
-  const env = (
-    globalThis as {
-      process?: { env?: Record<string, string | undefined> };
-    }
-  ).process?.env;
-  return env?.LETTA_API_KEY ?? env?.LETTA_CLOUD_API_KEY;
-}
-
-function bearerToken(
-  headers: Record<string, string> | undefined,
-): string | undefined {
-  const authorization = headers?.Authorization ?? headers?.authorization;
-  return authorization?.match(/^Bearer\s+(.+)$/i)?.[1];
-}
-
-function apiBaseUrl(value: string | undefined): string {
-  const url = new URL(value ?? DEFAULT_CLOUD_API_BASE_URL);
-  url.pathname = url.pathname.replace(/\/+$/, "");
-  url.search = "";
-  url.hash = "";
-  return url.toString().replace(/\/$/, "");
-}
-
-function requestHeaders(
-  options: LettaCodeCloudClientOptions,
-): Record<string, string> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    ...(options.headers ?? {}),
-  };
-  const apiKey =
-    options.apiKey ?? bearerToken(options.headers) ?? defaultApiKey();
-  if (apiKey && !headers.Authorization && !headers.authorization) {
-    headers.Authorization = `Bearer ${apiKey}`;
-  }
-  return headers;
-}
-
-function appendQuery(url: URL, query: ManagementQuery): void {
-  for (const [key, value] of Object.entries(query)) {
-    if (value === undefined || value === null) continue;
-    if (Array.isArray(value)) {
-      for (const item of value) url.searchParams.append(key, item);
-    } else {
-      url.searchParams.set(key, String(value));
-    }
-  }
-}
-
-async function parseResponse(response: Response): Promise<unknown> {
-  const text = await response.text();
-  if (!text) return null;
-  try {
-    return JSON.parse(text) as unknown;
-  } catch {
-    return text;
-  }
-}
-
-function responseErrorMessage(body: unknown, fallback: string): string {
-  if (body && typeof body === "object") {
-    const record = body as Record<string, unknown>;
-    const message = record.message ?? record.error ?? record.detail;
-    const reasonText = record.reason_text;
-    const pieces = [message, reasonText].filter(
-      (value): value is string =>
-        typeof value === "string" && value.length > 0,
-    );
-    if (pieces.length > 0) return pieces.join(": ");
-  }
-  return fallback;
-}
-
-function cloudRequestError(
-  response: Response,
-  body: unknown,
-  action: string,
-  url: URL,
-  options: LettaCodeCloudClientOptions,
-): Error {
-  const parts = [
-    `${action} failed`,
-    responseErrorMessage(body, `HTTP ${response.status}`),
-    `URL: ${url.toString()}`,
-  ];
-  if (response.status === 401 || response.status === 403) {
-    const hasApiKey = Boolean(
-      options.apiKey ??
-        bearerToken(options.headers) ??
-        defaultApiKey(),
-    );
-    parts.push(
-      hasApiKey
-        ? "Authentication failed — the API key may be invalid or lack permissions for this resource."
-        : "No API key found. Set LETTA_API_KEY (or pass apiKey in client options).",
-    );
-  }
-  return new Error(parts.join(" — "));
-}
-
-function asObject<T>(body: unknown, action: string): T {
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    throw new Error(`${action} response did not include an object.`);
-  }
-  return body as T;
-}
-
-function asArray<T>(body: unknown, action: string): T[] {
-  if (!Array.isArray(body)) {
-    throw new Error(`${action} response did not include an array.`);
-  }
-  return body as T[];
-}
 
 function asAgentRepository(body: unknown, action: string): AgentRepository {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
@@ -179,50 +73,40 @@ function cloudModelEntry(
   };
 }
 
+function isNotFound(error: unknown): boolean {
+  return error instanceof APIError && error.status === 404;
+}
+
+/** Cloud management backed by the canonical generated Letta TypeScript client. */
 export class CloudManagementTransport implements ManagementTransport {
-  constructor(private readonly options: LettaCodeCloudClientOptions) {}
+  constructor(private readonly client: Letta) {}
 
-  listAgents(query: ManagementQuery): Promise<LettaAgent[]> {
-    return this.getArray("/v1/agents/", query, "Cloud list agents");
+  async listAgents(query: ManagementQuery): Promise<LettaAgent[]> {
+    const page = await this.client.agents.list(query as AgentListParams);
+    return page.items as unknown as LettaAgent[];
   }
 
-  retrieveAgent(agentId: string): Promise<LettaAgent> {
-    return this.getObject(
-      `/v1/agents/${encodeURIComponent(agentId)}`,
-      {},
-      "Cloud retrieve agent",
-    );
+  async retrieveAgent(agentId: string): Promise<LettaAgent> {
+    return await this.client.agents.retrieve(agentId) as unknown as LettaAgent;
   }
 
-  updateAgent(
+  async updateAgent(
     agentId: string,
     body: Record<string, unknown>,
   ): Promise<LettaAgent> {
-    return this.requestObject(
-      `/v1/agents/${encodeURIComponent(agentId)}`,
-      "PATCH",
-      body,
-      "Cloud update agent",
-    );
+    return await this.client.agents.update(
+      agentId,
+      body as AgentUpdateParams,
+    ) as unknown as LettaAgent;
   }
 
   async deleteAgent(agentId: string): Promise<void> {
-    // No trailing slash: the production api.letta.com router 404s
-    // trailing-slash non-GET agent routes (see `POST /v1/agents` in
-    // cloud-session.ts — GET tolerates the slash; DELETE does not).
-    await this.requestUrl(
-      this.url(`/v1/agents/${encodeURIComponent(agentId)}`),
-      "DELETE",
-      undefined,
-      "Cloud delete agent",
-    );
+    await this.client.agents.delete(agentId);
   }
 
   async listAgentRepositories(agentId: string): Promise<AgentRepository[]> {
-    const body = await this.getObject<Record<string, unknown>>(
+    const body = await this.client.get<{ repositories: unknown[] }>(
       `/v1/agents/${encodeURIComponent(agentId)}/repositories`,
-      {},
-      "Cloud list agent repositories",
     );
     if (!Array.isArray(body.repositories)) {
       throw new Error(
@@ -239,14 +123,17 @@ export class CloudManagementTransport implements ManagementTransport {
     repositoryId: string,
     permissions: AgentRepositoryPermissions | undefined,
   ): Promise<AgentRepository> {
-    const body = await this.requestObject<Record<string, unknown>>(
+    const body = await this.client.post<{
+      success: boolean;
+      repository: unknown;
+    }>(
       `/v1/agents/${encodeURIComponent(agentId)}/repositories`,
-      "POST",
       {
-        repository_id: repositoryId,
-        ...(permissions !== undefined ? { permissions } : {}),
+        body: {
+          repository_id: repositoryId,
+          ...(permissions !== undefined ? { permissions } : {}),
+        },
       },
-      "Cloud attach agent repository",
     );
     return asAgentRepository(
       body.repository,
@@ -258,207 +145,84 @@ export class CloudManagementTransport implements ManagementTransport {
     agentId: string,
     repositoryId: string,
   ): Promise<void> {
-    await this.requestUrl(
-      this.url(
+    try {
+      await this.client.delete(
         `/v1/agents/${encodeURIComponent(agentId)}/repositories/${encodeURIComponent(repositoryId)}`,
-      ),
-      "DELETE",
-      undefined,
-      "Cloud detach agent repository",
-      [404],
-    );
+      );
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
   }
 
   async recompileAgentSystemPrompt(agentId: string): Promise<void> {
-    await this.requestUrl(
-      this.url(`/v1/agents/${encodeURIComponent(agentId)}/recompile`),
-      "POST",
-      {},
-      "Cloud recompile system prompt",
-    );
+    await this.client.agents.recompile(agentId);
   }
 
   async recompileConversationSystemPrompt(
     agentId: string,
     conversationId: string,
   ): Promise<void> {
-    await this.requestUrl(
-      this.url(
-        `/v1/conversations/${encodeURIComponent(conversationId)}/recompile`,
-      ),
-      "POST",
-      { agent_id: agentId },
-      "Cloud recompile system prompt",
-    );
+    await this.client.conversations.recompile(conversationId, {
+      agent_id: agentId,
+    });
   }
 
   async listModels(): Promise<ListModelsResult> {
-    // No trailing slash for consistency with the non-GET routes above (the
-    // production router only tolerates trailing slashes on GET).
-    const entries = await this.getArray<Record<string, unknown>>(
-      "/v1/models",
-      {},
-      "Cloud list models",
-    );
+    const entries = await this.client.models.list();
     const normalized = entries.flatMap((entry) => {
-      const model = cloudModelEntry(entry);
+      const model = cloudModelEntry(
+        entry as unknown as Record<string, unknown>,
+      );
       return model ? [model] : [];
     });
     return {
       entries: normalized,
-      // Cloud's authenticated endpoint already returns the models available to
-      // this user, so its catalog is also the authoritative availability set.
       availableHandles: normalized.map((entry) => entry.handle),
     };
   }
 
-  listConversations(
+  async listConversations(
     query: ManagementQuery,
   ): Promise<LettaConversation[]> {
-    return this.getArray(
-      "/v1/conversations/",
-      query,
-      "Cloud list conversations",
-    );
+    return await this.client.conversations.list(
+      query as ConversationListParams,
+    ) as LettaConversation[];
   }
 
-  retrieveConversation(
+  async retrieveConversation(
     conversationId: string,
   ): Promise<LettaConversation> {
-    return this.getObject(
-      `/v1/conversations/${encodeURIComponent(conversationId)}`,
-      {},
-      "Cloud retrieve conversation",
-    );
+    return await this.client.conversations.retrieve(
+      conversationId,
+    ) as LettaConversation;
   }
 
-  createConversation(
+  async createConversation(
     body: Record<string, unknown>,
   ): Promise<LettaConversation> {
-    const { agent_id: agentId, ...requestBody } = body;
-    if (typeof agentId !== "string" || agentId.length === 0) {
-      throw new Error("createConversation() requires a non-empty agentId.");
-    }
-    const url = this.url("/v1/conversations/");
-    url.searchParams.set("agent_id", agentId);
-    return this.requestUrlObject(
-      url,
-      "POST",
-      requestBody,
-      "Cloud create conversation",
-    );
+    return await this.client.conversations.create(
+      body as unknown as ConversationCreateParams,
+    ) as LettaConversation;
   }
 
-  updateConversation(
+  async updateConversation(
     conversationId: string,
     body: Record<string, unknown>,
   ): Promise<LettaConversation> {
-    return this.requestObject(
-      `/v1/conversations/${encodeURIComponent(conversationId)}`,
-      "PATCH",
-      body,
-      "Cloud update conversation",
-    );
+    return await this.client.conversations.update(
+      conversationId,
+      body as ConversationUpdateParams,
+    ) as LettaConversation;
   }
 
   async listConversationMessages(
     conversationId: string,
     query: ManagementQuery,
   ): Promise<ConversationMessagesResult> {
-    const messages = await this.getArray<Record<string, unknown>>(
-      `/v1/conversations/${encodeURIComponent(conversationId)}/messages`,
-      query,
-      "Cloud list conversation messages",
+    const page = await this.client.conversations.messages.list(
+      conversationId,
+      query as MessageListParams,
     );
-    return { messages };
-  }
-
-  private async getArray<T>(
-    path: string,
-    query: ManagementQuery,
-    action: string,
-  ): Promise<T[]> {
-    const body = await this.get(path, query, action);
-    return asArray<T>(body, action);
-  }
-
-  private async getObject<T>(
-    path: string,
-    query: ManagementQuery,
-    action: string,
-  ): Promise<T> {
-    const body = await this.get(path, query, action);
-    return asObject<T>(body, action);
-  }
-
-  private get(
-    path: string,
-    query: ManagementQuery,
-    action: string,
-  ): Promise<unknown> {
-    const url = this.url(path);
-    appendQuery(url, query);
-    return this.requestUrl(url, "GET", undefined, action);
-  }
-
-  private requestObject<T>(
-    path: string,
-    method: string,
-    body: Record<string, unknown>,
-    action: string,
-  ): Promise<T> {
-    return this.requestUrlObject(
-      this.url(path),
-      method,
-      body,
-      action,
-    );
-  }
-
-  private async requestUrlObject<T>(
-    url: URL,
-    method: string,
-    body: Record<string, unknown>,
-    action: string,
-  ): Promise<T> {
-    return asObject<T>(
-      await this.requestUrl(url, method, body, action),
-      action,
-    );
-  }
-
-  private async requestUrl(
-    url: URL,
-    method: string,
-    body: Record<string, unknown> | undefined,
-    action: string,
-    allowedStatuses: readonly number[] = [],
-  ): Promise<unknown> {
-    const fetchImpl = (this.options.fetch ?? globalThis.fetch)?.bind(
-      globalThis,
-    );
-    if (!fetchImpl) {
-      throw new Error("No fetch implementation available for cloud backend.");
-    }
-    const response = await fetchImpl(url, {
-      method,
-      headers: requestHeaders(this.options),
-      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-    });
-    const responseBody = await parseResponse(response);
-    if (!response.ok && !allowedStatuses.includes(response.status)) {
-      throw cloudRequestError(
-        response,
-        responseBody,
-        action,
-        url,
-        this.options,
-      );
-    }
-    return responseBody;
-  }
-
-  private url(path: string): URL {
-    return new URL(`${apiBaseUrl(this.options.apiBaseUrl)}${path}`);
+    return { messages: page.items as unknown as Record<string, unknown>[] };
   }
 }

--- a/src/cloud-management.ts
+++ b/src/cloud-management.ts
@@ -10,10 +10,7 @@ import type {
   ConversationUpdateParams,
 } from "@letta-ai/letta-client/resources/conversations/conversations";
 import type { MessageListParams } from "@letta-ai/letta-client/resources/conversations/messages";
-import type {
-  ManagementQuery,
-  ManagementTransport,
-} from "./management.js";
+import type { ManagementTransport } from "./management.js";
 import type {
   AgentRepository,
   AgentRepositoryPermissions,
@@ -81,23 +78,20 @@ function isNotFound(error: unknown): boolean {
 export class CloudManagementTransport implements ManagementTransport {
   constructor(private readonly client: Letta) {}
 
-  async listAgents(query: ManagementQuery): Promise<LettaAgent[]> {
-    const page = await this.client.agents.list(query as AgentListParams);
-    return page.items as unknown as LettaAgent[];
+  async listAgents(query: AgentListParams): Promise<LettaAgent[]> {
+    const page = await this.client.agents.list(query);
+    return page.items;
   }
 
   async retrieveAgent(agentId: string): Promise<LettaAgent> {
-    return await this.client.agents.retrieve(agentId) as unknown as LettaAgent;
+    return this.client.agents.retrieve(agentId);
   }
 
   async updateAgent(
     agentId: string,
-    body: Record<string, unknown>,
+    body: AgentUpdateParams,
   ): Promise<LettaAgent> {
-    return await this.client.agents.update(
-      agentId,
-      body as AgentUpdateParams,
-    ) as unknown as LettaAgent;
+    return this.client.agents.update(agentId, body);
   }
 
   async deleteAgent(agentId: string): Promise<void> {
@@ -182,47 +176,38 @@ export class CloudManagementTransport implements ManagementTransport {
   }
 
   async listConversations(
-    query: ManagementQuery,
+    query: ConversationListParams,
   ): Promise<LettaConversation[]> {
-    return await this.client.conversations.list(
-      query as ConversationListParams,
-    ) as LettaConversation[];
+    return this.client.conversations.list(query);
   }
 
   async retrieveConversation(
     conversationId: string,
   ): Promise<LettaConversation> {
-    return await this.client.conversations.retrieve(
-      conversationId,
-    ) as LettaConversation;
+    return this.client.conversations.retrieve(conversationId);
   }
 
   async createConversation(
-    body: Record<string, unknown>,
+    body: ConversationCreateParams,
   ): Promise<LettaConversation> {
-    return await this.client.conversations.create(
-      body as unknown as ConversationCreateParams,
-    ) as LettaConversation;
+    return this.client.conversations.create(body);
   }
 
   async updateConversation(
     conversationId: string,
-    body: Record<string, unknown>,
+    body: ConversationUpdateParams,
   ): Promise<LettaConversation> {
-    return await this.client.conversations.update(
-      conversationId,
-      body as ConversationUpdateParams,
-    ) as LettaConversation;
+    return this.client.conversations.update(conversationId, body);
   }
 
   async listConversationMessages(
     conversationId: string,
-    query: ManagementQuery,
+    query: MessageListParams,
   ): Promise<ConversationMessagesResult> {
     const page = await this.client.conversations.messages.list(
       conversationId,
-      query as MessageListParams,
+      query,
     );
-    return { messages: page.items as unknown as Record<string, unknown>[] };
+    return { messages: page.items };
   }
 }

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -1,3 +1,9 @@
+import type Letta from "@letta-ai/letta-client";
+import { APIError } from "@letta-ai/letta-client/core/error";
+import type {
+  AgentCreateParams,
+  AgentState,
+} from "@letta-ai/letta-client/resources/agents/agents";
 import {
   createAppServerClient,
   type AppServerClient,
@@ -12,6 +18,11 @@ import {
 } from "./app-server-session.js";
 import { createCloudStatusTransportConstructor } from "./cloud-status-transport.js";
 import { CloudManagementTransport } from "./cloud-management.js";
+import {
+  createCloudClient,
+  getCloudApiKey,
+  normalizeCloudApiBaseUrl,
+} from "./cloud-client.js";
 import {
   RemoteEnvironmentClient,
   type RemoteEnvironmentTarget,
@@ -39,7 +50,6 @@ import {
   validateCloudSandboxOptions,
 } from "./cloud-sandbox.js";
 
-const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
 const DEFAULT_TURN_TIMEOUT_MS = 120_000;
 const DEFAULT_PING_INTERVAL_MS = 30_000;
 const DEFAULT_SANDBOX_TTL_MINUTES = 5;
@@ -48,8 +58,6 @@ const DEFAULT_SANDBOX_READY_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_REPOSITORY_ATTACH_TIMEOUT_MS = 10_000;
 const DEFAULT_REPOSITORY_ATTACH_POLL_INTERVAL_MS = 250;
 const SDK_AGENT_ORIGIN = "@letta-ai/letta-agent-sdk";
-
-type FetchLike = typeof fetch;
 
 type CloudRuntimeStartResponse = ProtocolMessage & {
   type: "runtime_start_response";
@@ -127,31 +135,6 @@ export class CloudManagedSandboxExpiredError extends Error {
 
 type CloudSessionMode = Extract<RuntimeSessionMode, { kind: "session" }>;
 
-function getDefaultApiKey(): string | undefined {
-  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } })
-    .process?.env;
-  return env?.LETTA_API_KEY ?? env?.LETTA_CLOUD_API_KEY;
-}
-
-function bearerTokenFromHeaders(headers: Record<string, string> | undefined): string | undefined {
-  const authorization = headers?.Authorization ?? headers?.authorization;
-  if (!authorization) return undefined;
-  const match = /^Bearer\s+(.+)$/i.exec(authorization);
-  return match?.[1];
-}
-
-function getCloudApiKey(options: LettaCodeCloudClientOptions): string | undefined {
-  return options.apiKey ?? bearerTokenFromHeaders(options.headers) ?? getDefaultApiKey();
-}
-
-function getFetch(fetchOverride?: FetchLike): FetchLike {
-  const resolved = fetchOverride ?? globalThis.fetch;
-  if (!resolved) {
-    throw new Error("No fetch implementation available for cloud backend.");
-  }
-  return resolved.bind(globalThis) as FetchLike;
-}
-
 function getWebSocketConstructor(
   websocketOverride?: LettaCodeSocketConstructor,
 ): LettaCodeSocketConstructor {
@@ -164,26 +147,6 @@ function getWebSocketConstructor(
   return resolved;
 }
 
-function normalizeCloudApiBaseUrl(url: string | undefined): string {
-  const parsed = new URL(url ?? DEFAULT_CLOUD_API_BASE_URL);
-  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
-  parsed.search = "";
-  parsed.hash = "";
-  return parsed.toString().replace(/\/$/, "");
-}
-
-function cloudHeaders(options: LettaCodeCloudClientOptions): Record<string, string> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    ...(options.headers ?? {}),
-  };
-  const apiKey = getCloudApiKey(options);
-  if (apiKey && !headers.Authorization && !headers.authorization) {
-    headers.Authorization = `Bearer ${apiKey}`;
-  }
-  return headers;
-}
-
 function cloudWebSocketHeaders(options: LettaCodeCloudClientOptions): Record<string, string> | undefined {
   const headers = { ...(options.headers ?? {}) };
   delete headers.authorization;
@@ -193,45 +156,8 @@ function cloudWebSocketHeaders(options: LettaCodeCloudClientOptions): Record<str
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
-async function parseJsonResponse(response: Response): Promise<unknown> {
-  const text = await response.text();
-  if (!text) return null;
-  try {
-    return JSON.parse(text) as unknown;
-  } catch {
-    return text;
-  }
-}
-
-function responseErrorMessage(body: unknown, fallback: string): string {
-  if (body && typeof body === "object") {
-    const record = body as Record<string, unknown>;
-    const message = record.message ?? record.error ?? record.detail;
-    const reasonText = record.reason_text;
-    const pieces = [message, reasonText]
-      .filter((value): value is string => typeof value === "string" && value.length > 0);
-    if (pieces.length > 0) return pieces.join(": ");
-  }
-  return fallback;
-}
-
-function assertOkResponse(response: Response, body: unknown, action: string, url?: string): void {
-  if (!response.ok) {
-    const detail = responseErrorMessage(body, `HTTP ${response.status}`);
-    const parts = [`${action} failed`, detail];
-    if (url) parts.push(`URL: ${url}`);
-    if (response.status === 401 || response.status === 403) {
-      const env = (globalThis as { process?: { env?: Record<string, string | undefined> } })
-        .process?.env;
-      const hasKey = !!(env?.LETTA_API_KEY ?? env?.LETTA_CLOUD_API_KEY);
-      parts.push(
-        hasKey
-          ? "Authentication failed — the API key may be invalid or lack permissions for this resource."
-          : "No API key found. Set LETTA_API_KEY (or pass apiKey in client options).",
-      );
-    }
-    throw new Error(parts.join(" — "));
-  }
+function isNotFound(error: unknown): boolean {
+  return error instanceof APIError && error.status === 404;
 }
 
 function validatePositiveInteger(value: number | undefined, name: string): void {
@@ -352,31 +278,20 @@ function externalToolsByName(tools: AnyAgentTool[] | undefined): Map<string, Any
 }
 
 export async function createCloudAgent(
-  clientOptions: LettaCodeCloudClientOptions,
+  client: Letta,
   agentOptions: CreateAgentOptions,
 ): Promise<string> {
   const body = await createAgentBody(agentOptions);
-
-  // No trailing slash: production api.letta.com 404s `POST /v1/agents/` at
-  // the router (GET tolerates the slash; POST does not).
-  const response = await getFetch(clientOptions.fetch)(
-    `${normalizeCloudApiBaseUrl(clientOptions.apiBaseUrl)}/v1/agents`,
-    {
-      method: "POST",
-      headers: cloudHeaders(clientOptions),
-      body: JSON.stringify(body),
-    },
-  );
-  const responseBody = await parseJsonResponse(response);
-  assertOkResponse(response, responseBody, "Cloud create agent");
-  const agentId =
-    responseBody && typeof responseBody === "object"
-      ? (responseBody as { id?: unknown }).id
-      : undefined;
-  if (typeof agentId !== "string" || agentId.length === 0) {
+  // The generated `agents.create()` currently emits `/v1/agents/`, while the
+  // production POST route requires the slashless form. Keep the canonical
+  // client transport and generated contract without using that broken path.
+  const agent = await client.post<AgentState>("/v1/agents", {
+    body: body as AgentCreateParams,
+  });
+  if (typeof agent.id !== "string" || agent.id.length === 0) {
     throw new Error("Cloud create agent response did not include an agent id.");
   }
-  return agentId;
+  return agent.id;
 }
 
 export function assertCloudSessionOptionsSupported(
@@ -406,13 +321,14 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   constructor(
     private readonly cloudOptions: LettaCodeCloudClientOptions,
     mode: CloudSessionMode,
+    private readonly apiClient: Letta = createCloudClient(cloudOptions),
   ) {
     super(mode, {
       label: "cloud",
       requestTimeoutMs: cloudOptions.requestTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
     });
     this.cloudMode = mode;
-    this.repositoryManagement = new CloudManagementTransport(cloudOptions);
+    this.repositoryManagement = new CloudManagementTransport(apiClient);
     const tools = mode.options.tools;
     this.externalTools = externalToolsByName(tools);
   }
@@ -733,36 +649,23 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   }
 
   private async createConversation(agentId: string): Promise<{ id: string; agent_id?: string }> {
-    const fetchImpl = getFetch(this.cloudOptions.fetch);
-    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
-    const url = new URL(`${baseUrl}/v1/conversations/`);
-    url.searchParams.set("agent_id", agentId);
-    const response = await fetchImpl(url, {
-      method: "POST",
-      headers: cloudHeaders(this.cloudOptions),
-      body: JSON.stringify({}),
+    const conversation = await this.apiClient.conversations.create({
+      agent_id: agentId,
     });
-    const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud createSession()", url.toString());
-    if (!isCloudConversation(body)) {
+    if (!isCloudConversation(conversation)) {
       throw new Error("Cloud createSession() response did not include a conversation id.");
     }
-    return { id: body.id, agent_id: body.agent_id };
+    return { id: conversation.id, agent_id: conversation.agent_id };
   }
 
   private async retrieveConversation(conversationId: string): Promise<{ id: string; agent_id?: string }> {
-    const fetchImpl = getFetch(this.cloudOptions.fetch);
-    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
-    const response = await fetchImpl(
-      `${baseUrl}/v1/conversations/${encodeURIComponent(conversationId)}`,
-      { headers: cloudHeaders(this.cloudOptions) },
+    const conversation = await this.apiClient.conversations.retrieve(
+      conversationId,
     );
-    const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud resumeSession()", `${baseUrl}/v1/conversations/${encodeURIComponent(conversationId)}`);
-    if (!isCloudConversation(body)) {
+    if (!isCloudConversation(conversation)) {
       throw new Error(`Cloud resumeSession() could not retrieve conversation ${conversationId}.`);
     }
-    return { id: body.id, agent_id: body.agent_id };
+    return { id: conversation.id, agent_id: conversation.agent_id };
   }
 
   private async resolveConnectionForRuntime(
@@ -824,25 +727,19 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     agentId: string,
     conversationId?: string,
   ): Promise<ManagedCloudSandbox> {
-    const fetchImpl = getFetch(this.cloudOptions.fetch);
-    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
     const sandboxOptions = this.resolvedSandboxOptions();
     const githubRepositories = sandboxOptions.githubRepositories;
-    const response = await fetchImpl(
-      `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/sandboxes`,
+    const body = await this.apiClient.post<unknown>(
+      `/v1/agents/${encodeURIComponent(agentId)}/sandboxes`,
       {
-        method: "POST",
-        headers: cloudHeaders(this.cloudOptions),
-        body: JSON.stringify({
+        body: {
           ...(conversationId ? { conversationId } : {}),
           ...(githubRepositories && githubRepositories.length > 0
             ? { githubRepositories }
             : {}),
-        }),
+        },
       },
     );
-    const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud create managed sandbox", `${baseUrl}/v1/agents/${encodeURIComponent(agentId)}/sandboxes`);
     if (!isCloudAgentSandbox(body)) {
       throw new Error("Cloud create managed sandbox response did not include sandbox connection details.");
     }
@@ -900,22 +797,17 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   }
 
   private async refreshManagedSandboxOnce(sandbox: ManagedCloudSandbox): Promise<void> {
-    const fetchImpl = getFetch(this.cloudOptions.fetch);
-    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
-
     if (sandbox.conversationId) {
       // Conversation-scoped sandboxes refresh by id — no "latest active"
       // indirection, so ownership changes are structurally impossible.
-      const response = await fetchImpl(
-        `${baseUrl}/v1/sandboxes/${encodeURIComponent(sandbox.sandboxId)}/refresh`,
-        {
-          method: "POST",
-          headers: cloudHeaders(this.cloudOptions),
-          body: JSON.stringify({ ttlMinutes: sandbox.ttlMinutes }),
-        },
-      );
-      if (response.status === 404) {
-        await parseJsonResponse(response);
+      let body: unknown;
+      try {
+        body = await this.apiClient.post(
+          `/v1/sandboxes/${encodeURIComponent(sandbox.sandboxId)}/refresh`,
+          { body: { ttlMinutes: sandbox.ttlMinutes } },
+        );
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
         // The current control and stream WebSockets are bound to this
         // sandbox's ephemeral connection id. Recreating only the sandbox would
         // leave both sockets targeting the dead connection, so surface a
@@ -926,24 +818,18 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
           sandbox.conversationId,
         );
       }
-      const body = await parseJsonResponse(response);
-      assertOkResponse(response, body, "Cloud refresh managed sandbox");
       if (!isCloudAgentSandboxRefresh(body) || !body.success) {
         throw new Error("Cloud refresh managed sandbox response did not confirm refresh.");
       }
       return;
     }
 
-    const response = await fetchImpl(
-      `${baseUrl}/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes/refresh`,
+    const body = await this.apiClient.post<unknown>(
+      `/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes/refresh`,
       {
-        method: "POST",
-        headers: cloudHeaders(this.cloudOptions),
-        body: JSON.stringify({ ttlMinutes: sandbox.ttlMinutes }),
+        body: { ttlMinutes: sandbox.ttlMinutes },
       },
     );
-    const body = await parseJsonResponse(response);
-    assertOkResponse(response, body, "Cloud refresh managed sandbox", `${baseUrl}/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes/refresh`);
     if (!isCloudAgentSandboxRefresh(body) || !body.success) {
       throw new Error("Cloud refresh managed sandbox response did not confirm refresh.");
     }
@@ -955,23 +841,17 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   }
 
   private async terminateManagedSandbox(sandbox: ManagedCloudSandbox): Promise<void> {
-    const fetchImpl = getFetch(this.cloudOptions.fetch);
-    const baseUrl = normalizeCloudApiBaseUrl(this.cloudOptions.apiBaseUrl);
-
     if (sandbox.conversationId) {
       // Terminate exactly this sandbox — the agent-scoped DELETE targets the
       // agent's "latest active" sandbox, which may not be ours.
-      const response = await fetchImpl(
-        `${baseUrl}/v1/sandboxes/${encodeURIComponent(sandbox.sandboxId)}/terminate`,
-        {
-          method: "POST",
-          headers: cloudHeaders(this.cloudOptions),
-          body: JSON.stringify({}),
-        },
-      );
-      const body = await parseJsonResponse(response);
-      if (response.status === 404) return;
-      assertOkResponse(response, body, "Cloud terminate managed sandbox");
+      try {
+        await this.apiClient.post(
+          `/v1/sandboxes/${encodeURIComponent(sandbox.sandboxId)}/terminate`,
+          { body: {} },
+        );
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
       return;
     }
 
@@ -979,16 +859,13 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
     // "latest active" sandbox the DELETE will target is still ours.
     await this.refreshManagedSandbox(sandbox);
 
-    const response = await fetchImpl(
-      `${baseUrl}/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes`,
-      {
-        method: "DELETE",
-        headers: cloudHeaders(this.cloudOptions),
-      },
-    );
-    const body = await parseJsonResponse(response);
-    if (response.status === 404) return;
-    assertOkResponse(response, body, "Cloud terminate managed sandbox", `${baseUrl}/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes`);
+    try {
+      await this.apiClient.delete(
+        `/v1/agents/${encodeURIComponent(sandbox.agentId)}/sandboxes`,
+      );
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
   }
 
   private async waitForManagedSandboxConnection(
@@ -1064,12 +941,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
   }
 
   private remoteEnvironmentClient(): RemoteEnvironmentClient {
-    return new RemoteEnvironmentClient({
-      baseUrl: this.cloudOptions.apiBaseUrl,
-      apiKey: getCloudApiKey(this.cloudOptions),
-      headers: this.cloudOptions.headers,
-      fetch: this.cloudOptions.fetch,
-    });
+    return new RemoteEnvironmentClient({}, this.apiClient);
   }
 
   private effectiveEnvironment(): LettaCodeEnvironment | undefined {

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -1,9 +1,6 @@
 import type Letta from "@letta-ai/letta-client";
 import { APIError } from "@letta-ai/letta-client/core/error";
-import type {
-  AgentCreateParams,
-  AgentState,
-} from "@letta-ai/letta-client/resources/agents/agents";
+import type { AgentCreateParams } from "@letta-ai/letta-client/resources/agents/agents";
 import {
   createAppServerClient,
   type AppServerClient,
@@ -282,12 +279,7 @@ export async function createCloudAgent(
   agentOptions: CreateAgentOptions,
 ): Promise<string> {
   const body = await createAgentBody(agentOptions);
-  // The generated `agents.create()` currently emits `/v1/agents/`, while the
-  // production POST route requires the slashless form. Keep the canonical
-  // client transport and generated contract without using that broken path.
-  const agent = await client.post<AgentState>("/v1/agents", {
-    body: body as AgentCreateParams,
-  });
+  const agent = await client.agents.create(body as AgentCreateParams);
   if (typeof agent.id !== "string" || agent.id.length === 0) {
     throw new Error("Cloud create agent response did not include an agent id.");
   }

--- a/src/management-types.ts
+++ b/src/management-types.ts
@@ -1,100 +1,93 @@
+import type {
+  AgentListParams,
+  AgentState,
+  AgentUpdateParams,
+} from "@letta-ai/letta-client/resources/agents/agents";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  Conversation,
+  ConversationCreateParams,
+  ConversationListParams,
+  ConversationUpdateParams,
+} from "@letta-ai/letta-client/resources/conversations/conversations";
+import type { MessageListParams } from "@letta-ai/letta-client/resources/conversations/messages";
 import type { ListMessagesResult, ListModelsResult } from "./types.js";
 
 /** Agent state returned by either the Cloud API or Letta Code app-server. */
-export type LettaAgent = Record<string, unknown> & {
-  id: string;
-  name: string;
-  description?: string | null;
-  model?: string | null;
-  model_settings?: Record<string, unknown> | null;
-  tags?: string[];
-  created_at?: string | null;
-  updated_at?: string | null;
-};
+export type LettaAgent = AgentState;
 
 /** Conversation state returned by either the Cloud API or Letta Code app-server. */
-export type LettaConversation = Record<string, unknown> & {
-  id: string;
-  agent_id: string;
-  summary?: string | null;
-  description?: string | null;
-  model?: string | null;
-  model_settings?: Record<string, unknown> | null;
-  archived?: boolean;
-  created_at?: string | null;
-  updated_at?: string | null;
-  last_message_at?: string | null;
-};
+export type LettaConversation = Conversation;
 
 /** Raw Letta API message returned from conversation history. */
-export type LettaConversationMessage = Record<string, unknown>;
+export type LettaConversationMessage = Message;
+
+type Present<T> = Exclude<T, null | undefined>;
 
 export interface ListAgentsOptions {
-  before?: string;
-  after?: string;
-  limit?: number;
+  before?: Present<AgentListParams["before"]>;
+  after?: Present<AgentListParams["after"]>;
+  limit?: Present<AgentListParams["limit"]>;
   order?: "asc" | "desc";
   orderBy?: "createdAt" | "lastRunCompletion";
   /** Search agent names. */
-  query?: string;
+  query?: Present<AgentListParams["query_text"]>;
   /** Match one exact agent name. */
-  name?: string;
-  tags?: string[];
-  matchAllTags?: boolean;
+  name?: Present<AgentListParams["name"]>;
+  tags?: Present<AgentListParams["tags"]>;
+  matchAllTags?: Present<AgentListParams["match_all_tags"]>;
   /** Relationships to hydrate in each returned agent. */
-  include?: string[];
+  include?: Present<AgentListParams["include"]>;
 }
 
 export interface UpdateAgentOptions {
-  name?: string | null;
-  description?: string | null;
-  model?: string | null;
-  modelSettings?: Record<string, unknown> | null;
-  system?: string | null;
-  tags?: string[] | null;
-  hidden?: boolean | null;
-  contextWindowLimit?: number | null;
+  name?: AgentUpdateParams["name"];
+  description?: AgentUpdateParams["description"];
+  model?: AgentUpdateParams["model"];
+  modelSettings?: AgentUpdateParams["model_settings"];
+  system?: AgentUpdateParams["system"];
+  tags?: AgentUpdateParams["tags"];
+  hidden?: AgentUpdateParams["hidden"];
+  contextWindowLimit?: AgentUpdateParams["context_window_limit"];
 }
 
 export interface ListConversationsOptions {
-  agentId?: string;
-  after?: string;
-  limit?: number;
-  order?: "asc" | "desc";
+  agentId?: Present<ConversationListParams["agent_id"]>;
+  after?: Present<ConversationListParams["after"]>;
+  limit?: Present<ConversationListParams["limit"]>;
+  order?: Present<ConversationListParams["order"]>;
   orderBy?: "createdAt" | "lastRunCompletion" | "lastMessageAt";
-  archiveStatus?: "unarchived" | "archived" | "all";
-  summarySearch?: string;
+  archiveStatus?: Present<ConversationListParams["archive_status"]>;
+  summarySearch?: Present<ConversationListParams["summary_search"]>;
 }
 
 export interface CreateConversationOptions {
-  agentId: string;
-  summary?: string | null;
-  description?: string | null;
-  model?: string | null;
-  modelSettings?: Record<string, unknown> | null;
-  contextWindowLimit?: number | null;
-  hidden?: boolean;
+  agentId: ConversationCreateParams["agent_id"];
+  summary?: ConversationCreateParams["summary"];
+  description?: ConversationCreateParams["description"];
+  model?: ConversationCreateParams["model"];
+  modelSettings?: ConversationCreateParams["model_settings"];
+  contextWindowLimit?: ConversationCreateParams["context_window_limit"];
+  hidden?: ConversationCreateParams["hidden"];
 }
 
 export interface UpdateConversationOptions {
-  summary?: string | null;
-  description?: string | null;
-  model?: string | null;
-  modelSettings?: Record<string, unknown> | null;
-  contextWindowLimit?: number | null;
-  archived?: boolean | null;
+  summary?: ConversationUpdateParams["summary"];
+  description?: ConversationUpdateParams["description"];
+  model?: ConversationUpdateParams["model"];
+  modelSettings?: ConversationUpdateParams["model_settings"];
+  contextWindowLimit?: ConversationUpdateParams["context_window_limit"];
+  archived?: ConversationUpdateParams["archived"];
 }
 
 export interface ConversationMessagesOptions {
-  before?: string;
-  after?: string;
+  before?: Present<MessageListParams["before"]>;
+  after?: Present<MessageListParams["after"]>;
   order?: "asc" | "desc";
-  limit?: number;
+  limit?: Present<MessageListParams["limit"]>;
 }
 
-export type ConversationMessagesResult = ListMessagesResult & {
-  messages: LettaConversationMessage[];
-};
+export type ConversationMessagesResult = ListMessagesResult;
 
 export type AgentRepositoryPermissions = "read" | "read_write";
 export type AgentRepositoryRecompileTarget = "default" | false;

--- a/src/management.ts
+++ b/src/management.ts
@@ -1,4 +1,14 @@
 import type {
+  AgentListParams,
+  AgentUpdateParams,
+} from "@letta-ai/letta-client/resources/agents/agents";
+import type {
+  ConversationCreateParams,
+  ConversationListParams,
+  ConversationUpdateParams,
+} from "@letta-ai/letta-client/resources/conversations/conversations";
+import type { MessageListParams } from "@letta-ai/letta-client/resources/conversations/messages";
+import type {
   AgentRepositoriesClient,
   AgentsClient,
   ConversationsClient,
@@ -15,48 +25,35 @@ import type {
 } from "./management-types.js";
 import type { ListModelsResult } from "./types.js";
 
-export type ManagementQuery = Record<
-  string,
-  string | number | boolean | string[] | null | undefined
->;
-
 export interface ManagementTransport {
-  listAgents(query: ManagementQuery): Promise<LettaAgent[]>;
+  listAgents(query: AgentListParams): Promise<LettaAgent[]>;
   retrieveAgent(agentId: string): Promise<LettaAgent>;
   updateAgent(
     agentId: string,
-    body: Record<string, unknown>,
+    body: AgentUpdateParams,
   ): Promise<LettaAgent>;
   deleteAgent(agentId: string): Promise<void>;
   listModels(): Promise<ListModelsResult>;
   listConversations(
-    query: ManagementQuery,
+    query: ConversationListParams,
   ): Promise<LettaConversation[]>;
   retrieveConversation(
     conversationId: string,
   ): Promise<LettaConversation>;
   createConversation(
-    body: Record<string, unknown>,
+    body: ConversationCreateParams,
   ): Promise<LettaConversation>;
   updateConversation(
     conversationId: string,
-    body: Record<string, unknown>,
+    body: ConversationUpdateParams,
   ): Promise<LettaConversation>;
   listConversationMessages(
     conversationId: string,
-    query: ManagementQuery,
+    query: MessageListParams,
   ): Promise<ConversationMessagesResult>;
 }
 
 type TransportProvider = () => ManagementTransport;
-
-function definedEntries(
-  values: Record<string, unknown>,
-): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(values).filter(([, value]) => value !== undefined),
-  );
-}
 
 function assertNonEmptyId(value: string, name: string): void {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -64,11 +61,12 @@ function assertNonEmptyId(value: string, name: string): void {
   }
 }
 
-function agentListQuery(options: ListAgentsOptions): ManagementQuery {
-  const orderBy = options.orderBy?.replace(
-    /[A-Z]/g,
-    (character) => `_${character.toLowerCase()}`,
-  );
+function agentListQuery(options: ListAgentsOptions): AgentListParams {
+  const orderBy = options.orderBy === "createdAt"
+    ? "created_at"
+    : options.orderBy === "lastRunCompletion"
+      ? "last_run_completion"
+      : undefined;
   return {
     before: options.before,
     after: options.after,
@@ -83,8 +81,8 @@ function agentListQuery(options: ListAgentsOptions): ManagementQuery {
   };
 }
 
-function agentUpdateBody(options: UpdateAgentOptions): Record<string, unknown> {
-  return definedEntries({
+function agentUpdateBody(options: UpdateAgentOptions): AgentUpdateParams {
+  return {
     name: options.name,
     description: options.description,
     model: options.model,
@@ -93,16 +91,20 @@ function agentUpdateBody(options: UpdateAgentOptions): Record<string, unknown> {
     tags: options.tags,
     hidden: options.hidden,
     context_window_limit: options.contextWindowLimit,
-  });
+  };
 }
 
 function conversationListQuery(
   options: ListConversationsOptions,
-): ManagementQuery {
-  const orderBy = options.orderBy?.replace(
-    /[A-Z]/g,
-    (character) => `_${character.toLowerCase()}`,
-  );
+): ConversationListParams {
+  const orderBy: ConversationListParams["order_by"] =
+    options.orderBy === "createdAt"
+      ? "created_at"
+      : options.orderBy === "lastRunCompletion"
+        ? "last_run_completion"
+        : options.orderBy === "lastMessageAt"
+          ? "last_message_at"
+          : undefined;
   return {
     agent_id: options.agentId,
     after: options.after,
@@ -116,8 +118,8 @@ function conversationListQuery(
 
 function conversationCreateBody(
   options: CreateConversationOptions,
-): Record<string, unknown> {
-  return definedEntries({
+): ConversationCreateParams {
+  return {
     agent_id: options.agentId,
     summary: options.summary,
     description: options.description,
@@ -125,25 +127,25 @@ function conversationCreateBody(
     model_settings: options.modelSettings,
     context_window_limit: options.contextWindowLimit,
     hidden: options.hidden,
-  });
+  };
 }
 
 function conversationUpdateBody(
   options: UpdateConversationOptions,
-): Record<string, unknown> {
-  return definedEntries({
+): ConversationUpdateParams {
+  return {
     summary: options.summary,
     description: options.description,
     model: options.model,
     model_settings: options.modelSettings,
     context_window_limit: options.contextWindowLimit,
     archived: options.archived,
-  });
+  };
 }
 
 function conversationMessagesQuery(
   options: ConversationMessagesOptions,
-): ManagementQuery {
+): MessageListParams {
   return {
     before: options.before,
     after: options.after,

--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -71,11 +71,11 @@ export interface RemoteClientRuntimeController {
     options: RuntimeSendTurnOptions,
   ): void;
   abort(runtime: RuntimeScope): Promise<void>;
-  request(
+  request<TResponse extends ProtocolMessage = ProtocolMessage>(
     type: string,
     body: Record<string, unknown>,
     options?: RuntimeRequestOptions,
-  ): Promise<ProtocolMessage>;
+  ): Promise<TResponse>;
   recoverPendingApprovals(
     runtime: RuntimeScope,
     options?: RecoverPendingApprovalsOptions,

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,3 +1,6 @@
+import type Letta from "@letta-ai/letta-client";
+import { createCloudClient } from "./cloud-client.js";
+
 export type RemoteEnvironmentTarget =
   | { connectionId: string }
   | { environmentId: string }
@@ -43,35 +46,6 @@ export interface ResolvedRemoteEnvironment {
   target: RemoteEnvironmentTarget;
 }
 
-type RemoteFetch = typeof fetch;
-
-function getDefaultApiKey(): string | undefined {
-  if (typeof process === "undefined") {
-    return undefined;
-  }
-  return process.env.LETTA_API_KEY;
-}
-
-function createHeaders(options: RemoteEnvironmentClientOptions): Record<string, string> {
-  const apiKey = options.apiKey ?? getDefaultApiKey();
-  return {
-    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
-    ...(options.headers ?? {}),
-  };
-}
-
-function getFetch(options: RemoteEnvironmentClientOptions): RemoteFetch {
-  const fetchImpl = options.fetch ?? globalThis.fetch;
-  if (!fetchImpl) {
-    throw new Error("Remote environments require a fetch implementation");
-  }
-  return fetchImpl.bind(globalThis) as RemoteFetch;
-}
-
-function normalizeBaseUrl(baseUrl?: string): string {
-  return (baseUrl ?? "https://api.letta.com").replace(/\/$/, "");
-}
-
 function ensureOnline(
   environment: RemoteEnvironmentConnection,
   target: RemoteEnvironmentTarget,
@@ -95,47 +69,29 @@ function ensureOnline(
   };
 }
 
-async function parseJsonResponse<T>(response: Response): Promise<T> {
-  const text = await response.text();
-  const body = text ? JSON.parse(text) : null;
-
-  if (!response.ok) {
-    const message =
-      body && typeof body === "object" && "message" in body
-        ? String((body as { message: unknown }).message)
-        : response.statusText;
-    throw new Error(`Letta API request failed (${response.status}): ${message}`);
-  }
-
-  return body as T;
-}
-
 /**
- * Small Cloud API helper for resolving explicit Letta Code environments.
+ * Resolve explicit Letta Code environments through the generated Letta client.
  */
 export class RemoteEnvironmentClient {
-  private readonly baseUrl: string;
-  private readonly fetchImpl: RemoteFetch;
-
-  constructor(private readonly options: RemoteEnvironmentClientOptions = {}) {
-    this.baseUrl = normalizeBaseUrl(options.baseUrl);
-    this.fetchImpl = getFetch(options);
-  }
+  constructor(
+    options: RemoteEnvironmentClientOptions = {},
+    private readonly client: Letta = createCloudClient({
+      backend: "cloud",
+      apiBaseUrl: options.baseUrl,
+      apiKey: options.apiKey,
+      headers: options.headers,
+      fetch: options.fetch,
+    }),
+  ) {}
 
   async listEnvironments(): Promise<RemoteEnvironmentListResult> {
-    const url = new URL(`${this.baseUrl}/v1/environments`);
-    const response = await this.fetchImpl(url, {
-      headers: createHeaders(this.options),
-    });
-    return parseJsonResponse<RemoteEnvironmentListResult>(response);
+    return await this.client.environments.list() as RemoteEnvironmentListResult;
   }
 
   async getEnvironmentByDeviceId(deviceId: string): Promise<RemoteEnvironmentConnection> {
-    const response = await this.fetchImpl(
-      `${this.baseUrl}/v1/environments/${encodeURIComponent(deviceId)}`,
-      { headers: createHeaders(this.options) },
-    );
-    return parseJsonResponse<RemoteEnvironmentConnection>(response);
+    return await this.client.environments.retrieve(
+      deviceId,
+    ) as RemoteEnvironmentConnection;
   }
 
   async resolveEnvironment(target: RemoteEnvironmentTarget): Promise<ResolvedRemoteEnvironment> {
@@ -173,5 +129,4 @@ export class RemoteEnvironmentClient {
     }
     return ensureOnline(match, target);
   }
-
 }

--- a/src/repositories.ts
+++ b/src/repositories.ts
@@ -1,3 +1,5 @@
+import type Letta from "@letta-ai/letta-client";
+import { createCloudClient } from "./cloud-client.js";
 import type {
   CreateRepositoryFileParams,
   CreateRepositoryParams,
@@ -16,81 +18,6 @@ import type {
   RepositoryVersion,
   UpdateRepositoryFileParams,
 } from "./types.js";
-
-const DEFAULT_CLOUD_API_BASE_URL = "https://api.letta.com";
-
-type FetchLike = typeof fetch;
-
-function getDefaultApiKey(): string | undefined {
-  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } })
-    .process?.env;
-  return env?.LETTA_API_KEY ?? env?.LETTA_CLOUD_API_KEY;
-}
-
-function bearerTokenFromHeaders(headers: Record<string, string> | undefined): string | undefined {
-  const authorization = headers?.Authorization ?? headers?.authorization;
-  if (!authorization) return undefined;
-  const match = /^Bearer\s+(.+)$/i.exec(authorization);
-  return match?.[1];
-}
-
-function getCloudApiKey(options: LettaCodeCloudClientOptions): string | undefined {
-  return options.apiKey ?? bearerTokenFromHeaders(options.headers) ?? getDefaultApiKey();
-}
-
-function getFetch(fetchOverride?: FetchLike): FetchLike {
-  const resolved = fetchOverride ?? globalThis.fetch;
-  if (!resolved) throw new Error("No fetch implementation available for cloud backend.");
-  return resolved.bind(globalThis) as FetchLike;
-}
-
-function normalizeCloudApiBaseUrl(url: string | undefined): string {
-  const parsed = new URL(url ?? DEFAULT_CLOUD_API_BASE_URL);
-  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
-  parsed.search = "";
-  parsed.hash = "";
-  return parsed.toString().replace(/\/$/, "");
-}
-
-function cloudHeaders(options: LettaCodeCloudClientOptions): Record<string, string> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    ...(options.headers ?? {}),
-  };
-  const apiKey = getCloudApiKey(options);
-  if (apiKey && !headers.Authorization && !headers.authorization) {
-    headers.Authorization = `Bearer ${apiKey}`;
-  }
-  return headers;
-}
-
-async function parseJsonResponse(response: Response): Promise<unknown> {
-  const text = await response.text();
-  if (!text) return null;
-  try {
-    return JSON.parse(text) as unknown;
-  } catch {
-    return text;
-  }
-}
-
-function responseErrorMessage(body: unknown, fallback: string): string {
-  if (body && typeof body === "object") {
-    const record = body as Record<string, unknown>;
-    const message = record.message ?? record.error ?? record.detail;
-    const reasonText = record.reason_text;
-    const pieces = [message, reasonText]
-      .filter((value): value is string => typeof value === "string" && value.length > 0);
-    if (pieces.length > 0) return pieces.join(": ");
-  }
-  return fallback;
-}
-
-function assertOkResponse(response: Response, body: unknown, action: string): void {
-  if (!response.ok) {
-    throw new Error(responseErrorMessage(body, `${action} failed with HTTP ${response.status}`));
-  }
-}
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
@@ -131,17 +58,20 @@ function addOptionalSearchParam(url: URL, key: string, value: string | number | 
 }
 
 export class RepositoriesClient {
-  constructor(private readonly options: LettaCodeCloudClientOptions) {}
+  constructor(
+    options: LettaCodeCloudClientOptions,
+    private readonly client: Letta = createCloudClient(options),
+  ) {}
 
   async create(params: CreateRepositoryParams): Promise<Repository> {
-    return toRepository(await this.request("/v1/repositories", "POST", { name: params.name }, "Cloud create repository"));
+    return toRepository(await this.request("/v1/repositories", "POST", { name: params.name }));
   }
 
   async list(params: ListRepositoriesParams = {}): Promise<ListRepositoriesResult> {
     const url = this.url("/v1/repositories");
     addOptionalSearchParam(url, "limit", params.limit);
     addOptionalSearchParam(url, "offset", params.offset);
-    const body = await this.requestUrl(url, "GET", undefined, "Cloud list repositories");
+    const body = await this.requestUrl(url, "GET", undefined);
     if (!body || typeof body !== "object") {
       throw new Error("Cloud list repositories response did not include repositories.");
     }
@@ -156,7 +86,7 @@ export class RepositoriesClient {
   }
 
   async get(repositoryId: string): Promise<Repository> {
-    return toRepository(await this.request(`/v1/repositories/${encodeURIComponent(repositoryId)}`, "GET", undefined, "Cloud get repository"));
+    return toRepository(await this.request(`/v1/repositories/${encodeURIComponent(repositoryId)}`, "GET", undefined));
   }
 
   /**
@@ -169,7 +99,6 @@ export class RepositoriesClient {
       `/v1/repositories/${encodeURIComponent(repositoryId)}`,
       "DELETE",
       undefined,
-      "Cloud delete repository",
     );
   }
 
@@ -182,7 +111,7 @@ export class RepositoriesClient {
       addOptionalSearchParam(url, "path_prefix", params.pathPrefix);
       addOptionalSearchParam(url, "depth", params.depth);
       addOptionalSearchParam(url, "ref", params.ref);
-      const body = await this.requestUrl(url, "GET", undefined, "Cloud list repository files");
+      const body = await this.requestUrl(url, "GET", undefined);
       if (!body || typeof body !== "object") {
         throw new Error("Cloud list repository files response did not include files.");
       }
@@ -210,14 +139,13 @@ export class RepositoriesClient {
       `/v1/repositories/${encodeURIComponent(repositoryId)}/files`,
       "POST",
       { path: params.path, content: params.content },
-      "Cloud create repository file",
     )),
 
     read: async (repositoryId: string, params: { path: string; ref?: string }): Promise<RepositoryFile> => {
       const url = this.url(`/v1/repositories/${encodeURIComponent(repositoryId)}/files/content`);
       url.searchParams.set("path", params.path);
       addOptionalSearchParam(url, "ref", params.ref);
-      const body = await this.requestUrl(url, "GET", undefined, "Cloud read repository file");
+      const body = await this.requestUrl(url, "GET", undefined);
       if (!body || typeof body !== "object") {
         throw new Error("Cloud read repository file response did not include file content.");
       }
@@ -249,7 +177,6 @@ export class RepositoriesClient {
           }
           : {}),
       },
-      "Cloud update repository file",
     )),
 
     delete: async (
@@ -260,7 +187,6 @@ export class RepositoriesClient {
         `/v1/repositories/${encodeURIComponent(repositoryId)}/files/content`,
         "DELETE",
         { path: params.path },
-        "Cloud delete repository file",
       );
       if (!body || typeof body !== "object") {
         throw new Error("Cloud delete repository file response did not include delete details.");
@@ -278,7 +204,7 @@ export class RepositoriesClient {
       const url = this.url(`/v1/repositories/${encodeURIComponent(repositoryId)}/versions`);
       addOptionalSearchParam(url, "path", params.path);
       addOptionalSearchParam(url, "limit", params.limit);
-      const body = await this.requestUrl(url, "GET", undefined, "Cloud list repository versions");
+      const body = await this.requestUrl(url, "GET", undefined);
       if (Array.isArray(body)) return body as RepositoryVersion[];
       if (body && typeof body === "object") {
         const record = body as Record<string, unknown>;
@@ -295,7 +221,7 @@ export class RepositoriesClient {
     ): Promise<RepositoryFile> => {
       const url = this.url(`/v1/repositories/${encodeURIComponent(repositoryId)}/versions/${encodeURIComponent(sha)}`);
       url.searchParams.set("path", params.path);
-      const body = await this.requestUrl(url, "GET", undefined, "Cloud get repository version");
+      const body = await this.requestUrl(url, "GET", undefined);
       if (!body || typeof body !== "object") {
         throw new Error("Cloud get repository version response did not include file content.");
       }
@@ -310,31 +236,32 @@ export class RepositoriesClient {
   };
 
   private url(path: string): URL {
-    return new URL(`${normalizeCloudApiBaseUrl(this.options.apiBaseUrl)}${path}`);
+    return new URL(`${this.client.baseURL}${path}`);
   }
 
   private async request(
     path: string,
     method: string,
     body: unknown,
-    action: string,
   ): Promise<unknown> {
-    return this.requestUrl(this.url(path), method, body, action);
+    return this.requestUrl(this.url(path), method, body);
   }
 
   private async requestUrl(
     url: URL,
     method: string,
     body: unknown,
-    action: string,
   ): Promise<unknown> {
-    const response = await getFetch(this.options.fetch)(url, {
-      method,
-      headers: cloudHeaders(this.options),
-      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-    });
-    const parsed = await parseJsonResponse(response);
-    assertOkResponse(response, parsed, action);
-    return parsed;
+    const options = body !== undefined ? { body } : undefined;
+    switch (method) {
+      case "GET":
+        return this.client.get(url.toString(), options);
+      case "POST":
+        return this.client.post(url.toString(), options);
+      case "DELETE":
+        return this.client.delete(url.toString(), options);
+      default:
+        throw new Error(`Unsupported repository request method: ${method}`);
+    }
   }
 }

--- a/src/tests/agent-repositories.test.ts
+++ b/src/tests/agent-repositories.test.ts
@@ -155,7 +155,7 @@ describe("client.agents.repositories", () => {
       {
         path: "/v1/agents/agent-1/recompile",
         method: "POST",
-        body: {},
+        body: undefined,
       },
     ]);
   });
@@ -262,13 +262,15 @@ describe("client.agents.repositories", () => {
     await expect(
       client.agents.repositories.attach("agent-1", "repo-1"),
     ).rejects.toThrow(
-      "Cloud recompile system prompt failed — Prompt compilation failed: Repository projection unavailable",
+      '500 {"detail":"Prompt compilation failed","reason_text":"Repository projection unavailable"}',
     );
-    expect(requests.map(({ method }) => method)).toEqual([
+    expect(requests.slice(0, 2).map(({ method }) => method)).toEqual([
       "POST",
       "GET",
-      "POST",
     ]);
+    expect(requests.slice(2).every(({ url, method }) =>
+      method === "POST" && url.pathname.endsWith("/recompile")
+    )).toBe(true);
   });
 
   test("does not poll or recompile when attachment fails", async () => {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -74,8 +74,7 @@ function createCloudFetchMock(
       body: bodyOf(init),
     });
 
-    // Mirrors production routing: `POST /v1/agents/` (trailing slash) 404s.
-    if (parsed.pathname === "/v1/agents" && method === "POST") {
+    if (parsed.pathname === "/v1/agents/" && method === "POST") {
       return Promise.resolve(jsonResponse({ id: "agent-created" }));
     }
 
@@ -1939,8 +1938,7 @@ describe("CloudEnvironmentSession", () => {
 
     expect(requests).toHaveLength(1);
     expect(requests[0]).toMatchObject({
-      // No trailing slash — production 404s `POST /v1/agents/`.
-      url: "https://api.test/v1/agents",
+      url: "https://api.test/v1/agents/",
       method: "POST",
       headers: {
         authorization: "Bearer sk-test",

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import {
   CloudManagedSandboxExpiredError,
   LettaAgentClient,
@@ -15,6 +16,13 @@ type RecordedRequest = {
   method: string;
   headers: Record<string, string>;
   body?: unknown;
+};
+
+const RUNTIME_MESSAGE_FIXTURE: Message = {
+  id: "msg-from-runtime",
+  content: "hello",
+  date: "2026-07-28T00:00:00Z",
+  message_type: "user_message",
 };
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -377,7 +385,7 @@ class FakeCloudSocket {
         request_id: command.request_id,
         runtime: command.runtime,
         success: true,
-        messages: [{ id: "msg-from-runtime" }],
+        messages: [RUNTIME_MESSAGE_FIXTURE],
       });
       return;
     }
@@ -1728,7 +1736,7 @@ describe("CloudEnvironmentSession", () => {
     const session = client.resumeSession("agent-1");
     try {
       const page = await session.listMessages({ limit: 1 });
-      expect(page.messages).toEqual([{ id: "msg-from-runtime" }]);
+      expect(page.messages).toEqual([RUNTIME_MESSAGE_FIXTURE]);
       expect(page.hasMore).toBeUndefined();
       expect(page.nextBefore).toBeUndefined();
       expect(requests.some((request) =>
@@ -1760,7 +1768,7 @@ describe("CloudEnvironmentSession", () => {
     const session = client.resumeSession("conv-1");
     try {
       const page = await session.listMessages({ limit: 2, order: "desc" });
-      expect(page.messages).toEqual([{ id: "msg-from-runtime" }]);
+      expect(page.messages).toEqual([RUNTIME_MESSAGE_FIXTURE]);
       expect(
         requests.some((request) =>
           new URL(request.url).pathname === "/v1/conversations/conv-1/messages"
@@ -1797,7 +1805,7 @@ describe("CloudEnvironmentSession", () => {
         session.listMessages({ limit: 1 }),
         session.send("hello"),
       ]);
-      expect(page.messages).toEqual([{ id: "msg-from-runtime" }]);
+      expect(page.messages).toEqual([RUNTIME_MESSAGE_FIXTURE]);
 
       // A single control+stream pair and a single runtime_start: the second
       // caller joins the in-flight initialize instead of reconnecting.
@@ -1826,7 +1834,7 @@ describe("CloudEnvironmentSession", () => {
     const session = client.resumeSession("agent-1");
     try {
       const page = await session.listMessages({ conversationId: "conv-explicit", limit: 1 });
-      expect(page.messages).toEqual([{ id: "msg-from-runtime" }]);
+      expect(page.messages).toEqual([RUNTIME_MESSAGE_FIXTURE]);
       expect(
         requests.some((request) =>
           new URL(request.url).pathname === "/v1/conversations/conv-explicit/messages"
@@ -1863,7 +1871,7 @@ describe("CloudEnvironmentSession", () => {
       expect(state).toMatchObject({
         agentId: "agent-from-conv",
         conversationId: "conv-1",
-        messages: [{ id: "msg-from-runtime" }],
+        messages: [RUNTIME_MESSAGE_FIXTURE],
       });
       expect(state.hasMore).toBeUndefined();
       expect(state.nextBefore).toBeUndefined();

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1003,7 +1003,7 @@ describe("CloudEnvironmentSession", () => {
     expect(requests).toContainEqual(expect.objectContaining({
       method: "POST",
       url: "https://api.test/v1/agents/agent-1/recompile",
-      body: {},
+      body: undefined,
     }));
     expect(requests).toContainEqual(expect.objectContaining({
       method: "DELETE",
@@ -1075,7 +1075,7 @@ describe("CloudEnvironmentSession", () => {
     });
 
     await expect(asAdvanced(session).initialize()).rejects.toThrow(
-      "Cloud recompile system prompt failed — recompile failed",
+      '500 {"error":"recompile failed"}',
     );
     expect(requests).toContainEqual(expect.objectContaining({
       method: "DELETE",
@@ -1298,7 +1298,7 @@ describe("CloudEnvironmentSession", () => {
     expect(requests).toContainEqual(expect.objectContaining({
       method: "POST",
       url: "https://api.test/v1/agents/agent-1/recompile",
-      body: {},
+      body: undefined,
     }));
     expect(requests.filter((request) =>
       request.method === "DELETE" &&

--- a/src/tests/list-messages.test.ts
+++ b/src/tests/list-messages.test.ts
@@ -11,7 +11,15 @@
  * Real end-to-end tests with a live CLI are in the manual smoke suite.
  */
 import { describe, expect, test } from "bun:test";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import type { ListMessagesOptions, ListMessagesResult } from "../types.js";
+
+const USER_MESSAGE_FIXTURE: Message = {
+  id: "msg-1",
+  content: "hello",
+  date: "2026-07-28T00:00:00Z",
+  message_type: "user_message",
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 1. Type shapes
@@ -47,7 +55,7 @@ describe("ListMessagesOptions type", () => {
 describe("ListMessagesResult type", () => {
   test("well-formed success result with messages", () => {
     const result: ListMessagesResult = {
-      messages: [{ id: "msg-1", message_type: "user_message" }],
+      messages: [USER_MESSAGE_FIXTURE],
       nextBefore: "msg-1",
       hasMore: false,
     };
@@ -68,7 +76,10 @@ describe("ListMessagesResult type", () => {
 
   test("partial page — hasMore is true", () => {
     const result: ListMessagesResult = {
-      messages: new Array(50).fill({ id: "x" }),
+      messages: Array.from({ length: 50 }, (_, index) => ({
+        ...USER_MESSAGE_FIXTURE,
+        id: `msg-${index + 1}`,
+      })),
       nextBefore: "msg-50",
       hasMore: true,
     };

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -346,11 +346,10 @@ describeLive("live integration: letta-agent-sdk", () => {
   );
 
   test(
-    "cloud createAgent uses a route production accepts",
+    "cloud createAgent uses the generated route accepted by production",
     async () => {
-      // Guards the REST create path against server routing drift: production
-      // 404s `POST /v1/agents/` (trailing slash) while accepting
-      // `POST /v1/agents` — a mocked fetch cannot catch this class of bug.
+      // Guards the generated agents.create() path against server routing drift.
+      // A mocked fetch cannot catch this class of integration failure.
       const client = new LettaAgentClient({
         backend: "cloud",
         apiKey: API_KEY!,

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -293,19 +293,18 @@ function hasRenderableContent(messages: SDKMessage[]): boolean {
 
 function pickAnyMessageId(page: ListMessagesResult): string | null {
   for (const item of page.messages) {
-    if (item && typeof item === "object") {
-      const obj = item as Record<string, unknown>;
-      if (typeof obj.id === "string") return obj.id;
-    }
+    if (typeof item.id === "string") return item.id;
   }
   return null;
 }
 
 function assertRawMessageShape(page: ListMessagesResult): void {
   for (const item of page.messages) {
-    expect(item && typeof item === "object").toBe(true);
-    const obj = item as Record<string, unknown>;
-    const discriminator = obj.message_type ?? obj.type;
+    const discriminator = "message_type" in item
+      ? item.message_type
+      : "type" in item
+        ? item.type
+        : undefined;
     expect(typeof discriminator === "string").toBe(true);
   }
 }

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import { AppServerManagementTransport } from "../app-server-management.js";
 import { LettaAgentClient as PortableLettaAgentClient } from "../client-entry.js";
 import { LettaAgentClient as NodeLettaAgentClient } from "../index.js";
@@ -12,6 +14,26 @@ type RecordedRequest = {
   url: URL;
   method: string;
   body?: unknown;
+};
+
+const AGENT_FIXTURE: AgentState = {
+  id: "agent-1",
+  name: "Memo",
+  agent_type: "letta_v1_agent",
+  blocks: [],
+  llm_config: {} as AgentState["llm_config"],
+  memory: {} as AgentState["memory"],
+  sources: [],
+  system: "",
+  tags: [],
+  tools: [],
+};
+
+const USER_MESSAGE_FIXTURE: Message = {
+  id: "message-1",
+  content: "hello",
+  date: "2026-07-28T00:00:00Z",
+  message_type: "user_message",
 };
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -39,13 +61,13 @@ function createManagementFetch(
     requests.push({ url, method, body });
 
     if (url.pathname === "/v1/agents/" && method === "GET") {
-      return jsonResponse([{ id: "agent-1", name: "Memo" }]);
+      return jsonResponse([AGENT_FIXTURE]);
     }
     if (url.pathname === "/v1/agents/agent-1" && method === "GET") {
-      return jsonResponse({ id: "agent-1", name: "Memo" });
+      return jsonResponse(AGENT_FIXTURE);
     }
     if (url.pathname === "/v1/agents/agent-1" && method === "PATCH") {
-      return jsonResponse({ id: "agent-1", name: "Renamed", ...body as object });
+      return jsonResponse({ ...AGENT_FIXTURE, name: "Renamed", ...body as object });
     }
     if (url.pathname === "/v1/agents/agent-1" && method === "DELETE") {
       return new Response(null, { status: 204 });
@@ -97,7 +119,7 @@ function createManagementFetch(
       url.pathname === "/v1/conversations/conv-1/messages" &&
       method === "GET"
     ) {
-      return jsonResponse([{ id: "message-1", message_type: "user_message" }]);
+      return jsonResponse([USER_MESSAGE_FIXTURE]);
     }
     return jsonResponse({ detail: "not found" }, { status: 404 });
   }) as typeof fetch;
@@ -146,14 +168,14 @@ class ManagementSocket {
   protected respond(command: Record<string, unknown>): void {
     const responses: Record<string, Record<string, unknown>> = {
       agent_list: {
-        agents: [{ id: "agent-1", name: "Memo" }],
+        agents: [AGENT_FIXTURE],
       },
       agent_retrieve: {
-        agent: { id: command.agent_id, name: "Memo" },
+        agent: AGENT_FIXTURE,
       },
       agent_update: {
         agent: {
-          id: command.agent_id,
+          ...AGENT_FIXTURE,
           ...(command.body as object),
         },
       },
@@ -199,7 +221,7 @@ class ManagementSocket {
         },
       },
       conversation_messages_list: {
-        messages: [{ id: "message-1", message_type: "user_message" }],
+        messages: [USER_MESSAGE_FIXTURE],
       },
     };
     const type = String(command.type);
@@ -233,7 +255,7 @@ async function exerciseManagementApi(
       limit: 20,
       orderBy: "lastRunCompletion",
     }),
-  ).resolves.toEqual([{ id: "agent-1", name: "Memo" }]);
+  ).resolves.toEqual([AGENT_FIXTURE]);
   await expect(client.agents.retrieve("agent-1")).resolves.toMatchObject({
     id: "agent-1",
   });
@@ -293,7 +315,7 @@ async function exerciseManagementApi(
       order: "desc",
     }),
   ).resolves.toEqual({
-    messages: [{ id: "message-1", message_type: "user_message" }],
+    messages: [USER_MESSAGE_FIXTURE],
   });
 }
 
@@ -479,7 +501,7 @@ describe("portable management namespaces", () => {
     });
 
     await expect(client.agents.list()).resolves.toEqual([
-      { id: "agent-1", name: "Memo" },
+      AGENT_FIXTURE,
     ]);
     expect(
       ManagementSocket.instances.flatMap((socket) => socket.sent),
@@ -644,7 +666,7 @@ describe("app-server management connection lifecycle", () => {
     });
 
     await expect(transport.listAgents({})).resolves.toEqual([
-      { id: "agent-1", name: "Memo" },
+      AGENT_FIXTURE,
     ]);
     const socketCount = ManagementSocket.instances.length;
     expect(socketCount).toBeGreaterThan(0);

--- a/src/tests/management.test.ts
+++ b/src/tests/management.test.ts
@@ -50,7 +50,7 @@ function createManagementFetch(
     if (url.pathname === "/v1/agents/agent-1" && method === "DELETE") {
       return new Response(null, { status: 204 });
     }
-    if (url.pathname === "/v1/models" && method === "GET") {
+    if (url.pathname === "/v1/models/" && method === "GET") {
       return jsonResponse([
         {
           handle: "anthropic/claude-haiku-4-5",
@@ -351,7 +351,7 @@ describe("portable management namespaces", () => {
         body: undefined,
       },
       {
-        path: "/v1/models",
+        path: "/v1/models/",
         query: {},
         method: "GET",
         body: undefined,
@@ -516,7 +516,7 @@ describe("portable management namespaces", () => {
     );
   });
 
-  test("includes Cloud action, URL, and authentication guidance in errors", async () => {
+  test("surfaces canonical Letta API errors", async () => {
     const client = new PortableLettaAgentClient({
       backend: "cloud",
       apiBaseUrl: "https://api.test",
@@ -529,7 +529,7 @@ describe("portable management namespaces", () => {
     });
 
     await expect(client.agents.list()).rejects.toThrow(
-      "Cloud list agents failed — Unauthorized — URL: https://api.test/v1/agents/ — Authentication failed",
+      '401 {"detail":"Unauthorized"}',
     );
   });
 });

--- a/src/tests/remote.test.ts
+++ b/src/tests/remote.test.ts
@@ -63,9 +63,9 @@ describe("RemoteEnvironmentClient", () => {
     });
 
     expect(requests).toHaveLength(1);
-    expect(requests[0]!.init?.headers).toMatchObject({
-      Authorization: "Bearer sk-test",
-    });
+    expect(new Headers(requests[0]!.init?.headers).get("authorization")).toBe(
+      "Bearer sk-test",
+    );
   });
 
   test("rejects ambiguous connection names instead of guessing", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,11 @@
  */
 
 import type { PersonalityId } from "@letta-ai/letta-code/agent-presets";
+import type { ListModelsResponseModelEntry } from "@letta-ai/letta-code/app-server-protocol";
+import type { Message as LettaMessage } from "@letta-ai/letta-client/resources/agents/messages";
+import type { CreateBlock } from "@letta-ai/letta-client/resources/blocks/blocks";
 import type { LettaCodeCloudSandboxOptions } from "./cloud-sandbox.js";
+export type { CreateBlock } from "@letta-ai/letta-client/resources/blocks/blocks";
 export type {
   GitHubRepositoryRef,
   LettaCodeCloudSandboxOptions,
@@ -14,26 +18,6 @@ export type {
 
 /** Letta Code personality preset used to seed a new agent. */
 export type LettaCodePersonalityId = PersonalityId;
-
-/** Custom memory block definition accepted when creating agents. */
-export interface CreateBlock {
-  label: string;
-  value: string;
-  base_template_id?: string | null;
-  deployment_id?: string | null;
-  description?: string | null;
-  entity_id?: string | null;
-  hidden?: boolean | null;
-  is_template?: boolean;
-  limit?: number;
-  metadata?: Record<string, unknown> | null;
-  preserve_on_migration?: boolean | null;
-  project_id?: string | null;
-  read_only?: boolean;
-  tags?: string[] | null;
-  template_id?: string | null;
-  template_name?: string | null;
-}
 
 export interface LettaCodeSocketLike {
   readyState: number;
@@ -564,16 +548,7 @@ export type ReasoningEffort =
   | "high"
   | "xhigh";
 
-export type LettaCodeModelEntry = Record<string, unknown> & {
-  id: string;
-  handle: string;
-  label: string;
-  description: string;
-  isDefault?: boolean;
-  isFeatured?: boolean;
-  free?: boolean;
-  updateArgs?: Record<string, unknown>;
-};
+export type LettaCodeModelEntry = ListModelsResponseModelEntry;
 
 export interface ListModelsResult {
   entries: LettaCodeModelEntry[];
@@ -1223,7 +1198,7 @@ export interface ListMessagesOptions {
  * authoritative pagination answer.
  */
 export interface ListMessagesResult {
-  messages: unknown[];
+  messages: LettaMessage[];
   /** ID of the oldest message in this page; use as `before` for the next page when present. */
   nextBefore?: string | null;
   /** Whether more pages exist in the requested direction, when known. */
@@ -1263,7 +1238,7 @@ export interface BootstrapStateResult {
   /** Whether memfs (git-backed memory) is enabled, when known. */
   memfsEnabled?: boolean;
   /** Initial history page (same shape as listMessages.messages). */
-  messages: unknown[];
+  messages: LettaMessage[];
   /** Cursor to fetch older messages. Null when the backend knows there are no more pages. */
   nextBefore?: string | null;
   /** Whether more history pages exist, when known. */


### PR DESCRIPTION
## Summary

- declare `@letta-ai/letta-client` as a direct dependency and share one cached API client across each Cloud SDK client
- use generated agents, conversations, messages, models, environments, and recompile resources instead of maintaining parallel request contracts
- route only repository and sandbox endpoints that are not yet generated through the client’s typed generic request methods
- reuse generated Letta entities and request types plus Letta Code’s exported app-server response types instead of handwritten partial records and protocol envelopes
- remove duplicate auth, fetch, response parsing, retry, error, and model-normalization plumbing across Cloud management, sessions, environments, and repositories
- document the API ownership and type-reuse boundaries in `AGENTS.md`, including the rule to revalidate and delete stale transport exceptions
- parse portable bundle imports structurally so dependency error-message text cannot trigger the Node-import guard

This follows up the persistent agent-repository work in LET-10330 by making the official TypeScript client the single Cloud HTTP transport and the generated contracts the shared type authority across Cloud and app-server backends. The refactor removes 500+ net lines while preserving the portable browser build and adopts canonical API errors and retries.

Validated with all 194 unit tests, type/source-size checks, both package builds, and a live production test through the generated `agents.create()` resource.

👾 Generated with [Letta Code](https://letta.com)