### PR TITLE
chore: bump Letta Code to 0.29.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@letta-ai/letta-client": "^1.12.1",
-    "@letta-ai/letta-code": "0.29.7"
+    "@letta-ai/letta-code": "0.29.8"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary

- update `@letta-ai/letta-code` from 0.29.7 to the latest published release, 0.29.8
- verify the Agent SDK against the updated harness dependency

Validated with all 194 unit tests, type/source-size checks, and both portable and Node package builds.

👾 Generated with [Letta Code](https://letta.com)