### PR TITLE
feat(permissions): add strict mode support

### DIFF
--- a/src/remote-session-protocol.ts
+++ b/src/remote-session-protocol.ts
@@ -182,7 +182,8 @@ export function normalizePermissionMode(
   if (
     mode === "standard" ||
     mode === "acceptEdits" ||
-    mode === "unrestricted"
+    mode === "unrestricted" ||
+    mode === "strict"
   ) {
     return mode;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -538,7 +538,8 @@ export type CanUseToolCallback = (
 export type PermissionMode =
   | "standard"
   | "acceptEdits"
-  | "unrestricted";
+  | "unrestricted"
+  | "strict";
 
 export type ReasoningEffort =
   | "none"


### PR DESCRIPTION
## Summary

- Adds `"strict"` to `PermissionMode` type
- Updates `normalizePermissionMode` to recognize strict mode

In strict mode, all tools require explicit approval via the `canUseTool` callback — no auto-allows for reads, read-only shell commands, or other normally safe operations.

**Depends on**: letta-ai/letta-code#3533

🐾 Generated with [Letta Code](https://letta.com)