### PR TITLE
feat!: make createAgent personality presets explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,16 @@ const client = new LettaAgentClient({
 
 const agentId = await client.createAgent({
   model: "anthropic/claude-opus-4-8",
-  persona: "You are a proactive research assistant.",
-  human: "The user prefers concise summaries with sources and next steps.",
+  memory: [
+    {
+      label: "persona",
+      value: "You are a proactive research assistant.",
+    },
+    {
+      label: "human",
+      value: "The user prefers concise summaries with sources and next steps.",
+    },
+  ],
 });
 
 await using session = client.createSession(agentId);
@@ -43,6 +51,10 @@ for await (const message of session.stream()) {
   }
 }
 ```
+
+`createAgent()` uses the supplied memory as the agent's identity. Letta Code
+personality presets are opt-in: pass `personality: "memo"` (or another preset)
+only when you want that preset's name, description, and memory blocks.
 
 An agent is the persistent entity with memory. A conversation is a thread on that agent. A session is the active connection used to send messages, stream events, execute tools, and handle approvals.
 

--- a/src/agent-creation.ts
+++ b/src/agent-creation.ts
@@ -1,0 +1,66 @@
+import {
+  buildCreatedAgentTags,
+  buildCreateAgentRequestForPersonality,
+  buildSystemPrompt,
+  LETTA_CODE_AGENT_TYPE,
+  MODEL_PRESETS,
+} from "@letta-ai/letta-code/agent-presets";
+import type { CreateAgentOptions } from "./types.js";
+
+const DEFAULT_MODEL_ID = "auto";
+const DEFAULT_SUMMARIZATION_MODEL = "letta/auto";
+
+function resolveModel(modelIdentifier: string): string {
+  const preset = MODEL_PRESETS.find(
+    (model) =>
+      model.id === modelIdentifier || model.handle === modelIdentifier,
+  );
+  if (preset) return preset.handle;
+
+  // Preserve support for model handles supplied by self-hosted servers even
+  // when they are not present in the bundled catalog.
+  if (modelIdentifier.includes("/")) return modelIdentifier;
+
+  throw new Error(`Unknown model: ${modelIdentifier}`);
+}
+
+/**
+ * Build the standard harness portion of a create-agent request.
+ *
+ * Personality presets are explicit opt-ins. Without one, the SDK builds a
+ * generic agent and lets the caller's memory blocks define its identity.
+ */
+export async function buildInitialAgentBody(
+  options: CreateAgentOptions,
+): Promise<Record<string, unknown>> {
+  if (options.personality !== undefined) {
+    return {
+      ...(await buildCreateAgentRequestForPersonality({
+        personalityId: options.personality,
+        ...(options.name !== undefined ? { name: options.name } : {}),
+        ...(options.description !== undefined
+          ? { description: options.description }
+          : {}),
+        ...(options.model !== undefined ? { model: options.model } : {}),
+        ...(options.tags !== undefined ? { extraTags: options.tags } : {}),
+      })),
+    };
+  }
+
+  return {
+    agent_type: LETTA_CODE_AGENT_TYPE,
+    ...(options.name !== undefined ? { name: options.name } : {}),
+    ...(options.description !== undefined
+      ? { description: options.description }
+      : {}),
+    model: resolveModel(options.model ?? DEFAULT_MODEL_ID),
+    system: buildSystemPrompt("default", "memfs"),
+    tags: buildCreatedAgentTags({
+      enableMemfs: true,
+      tags: options.tags ?? [],
+    }),
+    initial_message_sequence: [],
+    parallel_tool_calls: true,
+    compaction_settings: { model: DEFAULT_SUMMARIZATION_MODEL },
+  };
+}

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -12,11 +12,11 @@ import type {
   UpdateModelResponseMessage,
 } from "@letta-ai/letta-code/app-server-protocol";
 import {
-  buildCreateAgentRequestForPersonality,
   buildSystemPrompt,
   GIT_MEMORY_ENABLED_TAG,
   LETTA_CODE_ORIGIN_TAG,
 } from "@letta-ai/letta-code/agent-presets";
+import { buildInitialAgentBody } from "./agent-creation.js";
 import { normalizeAppServerModels } from "./app-server-models.js";
 import {
   buildCanUseToolContext,
@@ -156,17 +156,7 @@ export async function createAgentBody(
   assertRemoteCreateAgentOptionsSupported(options);
 
   const includeOriginTag = settings.includeSdkOriginTag ?? true;
-  const body: Record<string, unknown> = {
-    ...(await buildCreateAgentRequestForPersonality({
-      personalityId: options.personality ?? "memo",
-      ...(options.name !== undefined ? { name: options.name } : {}),
-      ...(options.description !== undefined
-        ? { description: options.description }
-        : {}),
-      ...(options.model !== undefined ? { model: options.model } : {}),
-      ...(options.tags !== undefined ? { extraTags: options.tags } : {}),
-    })),
-  };
+  const body = await buildInitialAgentBody(options);
 
   if (Array.isArray(body.tags)) {
     body.tags = body.tags.filter(
@@ -207,6 +197,11 @@ export async function createAgentBody(
     }
   }
 
+  const hasMemoryConfiguration =
+    Array.isArray(body.memory_blocks) ||
+    options.memory !== undefined ||
+    options.persona !== undefined ||
+    options.human !== undefined;
   const memoryBlocks = Array.isArray(body.memory_blocks)
     ? body.memory_blocks
         .filter(
@@ -238,7 +233,7 @@ export async function createAgentBody(
   if (options.human !== undefined) {
     upsertMemoryBlock(memoryBlocks, { label: "human", value: options.human });
   }
-  body.memory_blocks = memoryBlocks;
+  if (hasMemoryConfiguration) body.memory_blocks = memoryBlocks;
   if (blockIds.length > 0) body.block_ids = blockIds;
 
   return body;

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,16 +188,18 @@ export {
  *
  * @example
  * ```typescript
- * // Create agent with default settings.
- * const agentId = await createAgent();
- *
- * // Create agent with custom memory
+ * // Create a generic agent with custom memory.
  * const agentId = await createAgent({
- *   memory: ['persona', 'project'],
- *   persona: 'You are a helpful coding assistant',
+ *   memory: [
+ *     { label: 'persona', value: 'You are a helpful coding assistant' },
+ *     { label: 'project', value: 'Use Bun for JavaScript projects' },
+ *   ],
  *   model: 'claude-sonnet-4',
  *   tags: ['project:docs']
  * });
+ *
+ * // Personality presets are explicit opt-ins.
+ * const memoAgentId = await createAgent({ personality: 'memo' });
  *
  * // Then resume the default conversation:
  * const session = resumeSession(agentId);

--- a/src/tests/app-server-session.test.ts
+++ b/src/tests/app-server-session.test.ts
@@ -1,10 +1,54 @@
 import { describe, expect, test } from "bun:test";
-import { buildCreateAgentRequestForPersonality } from "@letta-ai/letta-code/agent-presets";
+import {
+  buildCreateAgentRequestForPersonality,
+  buildSystemPrompt,
+  LETTA_CODE_AGENT_TYPE,
+} from "@letta-ai/letta-code/agent-presets";
 import { createAgentBody } from "../app-server-session.js";
 
 describe("createAgentBody", () => {
-  test("matches the centralized payload while leaving tool defaults to the harness", async () => {
+  test("builds a generic harness agent when personality is omitted", async () => {
     const body = await createAgentBody({ model: "openai/gpt-5.2" });
+
+    expect(body).toMatchObject({
+      agent_type: LETTA_CODE_AGENT_TYPE,
+      model: "openai/gpt-5.2",
+      system: buildSystemPrompt("default", "memfs"),
+      tags: ["origin:letta-code", "git-memory-enabled"],
+      initial_message_sequence: [],
+      parallel_tool_calls: true,
+      compaction_settings: { model: "letta/auto" },
+    });
+    expect(body).not.toHaveProperty("name");
+    expect(body).not.toHaveProperty("description");
+    expect(body).not.toHaveProperty("memory_blocks");
+    expect(body).not.toHaveProperty("tools");
+    expect(body).not.toHaveProperty("include_base_tools");
+    expect(body).not.toHaveProperty("include_base_tool_rules");
+  });
+
+  test("uses caller memory as the complete identity without a personality preset", async () => {
+    const memory = [
+      { label: "persona", value: "You are Ezra." },
+      { label: "human", value: "The human reads the docs." },
+      { label: "instructions", value: "Answer from official sources." },
+    ];
+    const body = await createAgentBody({
+      name: "Ezra",
+      description: "Letta documentation assistant.",
+      memory,
+    });
+
+    expect(body.name).toBe("Ezra");
+    expect(body.description).toBe("Letta documentation assistant.");
+    expect(body.memory_blocks).toEqual(memory);
+  });
+
+  test("applies a personality only when explicitly requested", async () => {
+    const body = await createAgentBody({
+      personality: "memo",
+      model: "openai/gpt-5.2",
+    });
     const expected = {
       ...(await buildCreateAgentRequestForPersonality({
         personalityId: "memo",
@@ -16,9 +60,6 @@ describe("createAgentBody", () => {
     delete expected.include_base_tool_rules;
 
     expect(body).toEqual(expected);
-    expect(body).not.toHaveProperty("tools");
-    expect(body).not.toHaveProperty("include_base_tools");
-    expect(body).not.toHaveProperty("include_base_tool_rules");
   });
 
   test("preserves custom prompts", async () => {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1960,11 +1960,22 @@ describe("CloudEnvironmentSession", () => {
         ]),
       },
     });
-    expect((requests[0]!.body as { tags: string[] }).tags).toEqual([
+    const createBody = requests[0]!.body as {
+      tags: string[];
+      memory_blocks: Array<{ label: string; value: string }>;
+      name?: string;
+      description?: string;
+    };
+    expect(createBody.tags).toEqual([
       "origin:letta-code",
       "git-memory-enabled",
       "team:sdk",
     ]);
+    expect(createBody.memory_blocks).toEqual([
+      { label: "project", value: "Use Bun." },
+    ]);
+    expect(createBody).not.toHaveProperty("name");
+    expect(createBody).not.toHaveProperty("description");
 
     await expect(client.createAgent({
       model: "anthropic/claude-sonnet-4",

--- a/src/types.ts
+++ b/src/types.ts
@@ -829,8 +829,9 @@ export interface SessionDeviceStatus {
  */
 export interface CreateAgentOptions {
   /**
-   * Letta Code personality preset. Defaults to "memo". The creation payload
-   * is built by `@letta-ai/letta-code/agent-presets`, matching Chat/Desktop.
+   * Optional Letta Code personality preset. Presets are explicit: when this is
+   * omitted, createAgent() uses the supplied memory blocks directly without
+   * adding personality-derived identity, name, or description fields.
    */
   personality?: LettaCodePersonalityId;
 


### PR DESCRIPTION
## Summary

- build generic agents directly from caller-supplied memory instead of silently seeding every createAgent request from the memo personality
- preserve the standard harness system, model resolution, MemFS tags, and compaction defaults; explicit personality requests remain byte-compatible with the existing preset builder
- document the breaking behavior change and pin both generic-memory and explicit-personality payloads in tests

Breaking change: omitting personality no longer implies personality: "memo". Callers that want a preset must request it explicitly.

## Creation behavior

The creation modes are now explicit:

```ts
// No personality and no memory blocks. The server generates the name.
await client.createAgent({});

// Exactly the caller-provided memory blocks; no preset identity is added.
await client.createAgent({
  name: "Ezra",
  memory: [
    { label: "persona", value: "You are Ezra." },
    { label: "human", value: "The human reads the docs." },
  ],
});

// The memo preset supplies its name, description, and memory blocks.
await client.createAgent({ personality: "memo" });
```

`createAgent({})` intentionally omits `memory_blocks`; MemFS remains enabled, but the agent starts with zero memory blocks. Passing `memory: []` is likewise an explicit zero-block request.

## Test plan

- [x] bun run check
- [x] bun test (196 passed, 11 live-only skipped)
- [x] bun run build
- [x] production Cloud route create/delete smoke test
- [x] production zero-option smoke test verified a server-generated name and zero memory blocks
- [x] production custom-memory smoke test verified exactly persona, human, and instructions blocks with no preset identity blocks

👾 Generated with [Letta Code](https://letta.com)