### PR TITLE
fix(permissions): preserve delayed approval continuations

### DIFF
--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -411,56 +411,110 @@ function runtimeScopeFromMessage(message: ProtocolMessage): RuntimeScope | null 
   return null;
 }
 
-export function registerAppServerControlRequestHandler(config: {
-  client: AppServerClient;
-  getRuntime: () => RuntimeScope | null;
-  getOptions: () => AppServerApprovalOptions;
-}): () => void {
-  return config.client.onMessage((rawMessage, channel) => {
-    const message = rawMessage as unknown as ProtocolMessage;
-    if (channel !== "control" || message.type !== "control_request") return;
-    void respondToAppServerControlRequest(config, message).catch(() => {
-      // Permission callback failures are converted into deny responses by resolveAppServerToolApproval().
-    });
-  });
-}
+type ParsedToolApprovalRequest = {
+  key: string;
+  runtime: RuntimeScope;
+  requestId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  context: CanUseToolContext;
+};
 
-async function respondToAppServerControlRequest(
-  config: {
-    client: AppServerClient;
-    getRuntime: () => RuntimeScope | null;
-    getOptions: () => AppServerApprovalOptions;
-  },
+type CachedToolApproval = {
+  decision: Promise<CanUseToolResponse>;
+  sent: boolean;
+  request: ParsedToolApprovalRequest;
+};
+
+const MAX_CACHED_TOOL_APPROVALS = 256;
+
+function parseToolApprovalRequest(
   message: ProtocolMessage,
-): Promise<void> {
-  const runtime = runtimeScopeFromMessage(message) ?? config.getRuntime();
-  if (!runtime) return;
-
-  const requestId = typeof message.request_id === "string" ? message.request_id : undefined;
+  fallbackRuntime: RuntimeScope | null,
+): ParsedToolApprovalRequest | null {
+  const runtime = runtimeScopeFromMessage(message) ?? fallbackRuntime;
+  const requestId = typeof message.request_id === "string" ? message.request_id : null;
   const request = message.request;
-  if (!requestId || !request || typeof request !== "object") return;
-  const requestRecord = request as Record<string, unknown>;
-  if (requestRecord.subtype !== "can_use_tool") return;
+  if (!runtime || !requestId || !request || typeof request !== "object") return null;
 
+  const requestRecord = request as Record<string, unknown>;
+  if (requestRecord.subtype !== "can_use_tool") return null;
   const toolName = typeof requestRecord.tool_name === "string" ? requestRecord.tool_name : "unknown";
   const toolInput =
     requestRecord.input && typeof requestRecord.input === "object" && !Array.isArray(requestRecord.input)
       ? (requestRecord.input as Record<string, unknown>)
       : {};
-  const decision = await resolveAppServerToolApproval(
-    config.getOptions(),
+  return {
+    key: JSON.stringify([runtime.agent_id, runtime.conversation_id, requestId]),
+    runtime,
+    requestId,
     toolName,
     toolInput,
-    buildCanUseToolContext(requestRecord, requestId),
-  );
-  config.client.input({
-    runtime,
+    context: buildCanUseToolContext(requestRecord, requestId),
+  };
+}
+
+function sendToolApprovalResponse(
+  client: AppServerClient,
+  request: ParsedToolApprovalRequest,
+  decision: CanUseToolResponse,
+): void {
+  client.input({
+    runtime: request.runtime,
     payload: {
       kind: "approval_response",
-      request_id: requestId,
+      request_id: request.requestId,
       decision: toAppServerApprovalDecision(decision),
     },
   } as Parameters<AppServerClient["input"]>[0]);
+}
+
+export function registerAppServerControlRequestHandler(config: {
+  client: AppServerClient;
+  getRuntime: () => RuntimeScope | null;
+  getOptions: () => AppServerApprovalOptions;
+}): () => void {
+  // Recovery and cross-socket delivery can replay the same request. Resolve the
+  // host callback once, while retaining its decision for a later replay.
+  const approvals = new Map<string, CachedToolApproval>();
+  return config.client.onMessage((rawMessage, channel) => {
+    const message = rawMessage as unknown as ProtocolMessage;
+    if (channel !== "control" || message.type !== "control_request") return;
+    const request = parseToolApprovalRequest(message, config.getRuntime());
+    if (!request) return;
+
+    const cached = approvals.get(request.key);
+    if (cached) {
+      if (cached.sent) {
+        void cached.decision
+          .then((decision) => sendToolApprovalResponse(config.client, cached.request, decision))
+          .catch(() => undefined);
+      }
+      return;
+    }
+
+    if (approvals.size >= MAX_CACHED_TOOL_APPROVALS) {
+      const oldest = approvals.keys().next().value;
+      if (oldest !== undefined) approvals.delete(oldest);
+    }
+    const entry: CachedToolApproval = {
+      decision: resolveAppServerToolApproval(
+        config.getOptions(),
+        request.toolName,
+        request.toolInput,
+        request.context,
+      ),
+      sent: false,
+      request,
+    };
+    approvals.set(request.key, entry);
+    void entry.decision
+      .then((decision) => {
+        entry.sent = true;
+        sendToolApprovalResponse(config.client, request, decision);
+      })
+      .catch(() => approvals.delete(request.key));
+  });
 }
 
 export class AppServerRuntimeController implements RemoteClientRuntimeController {

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -92,6 +92,8 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     this.turns = new RemoteTurnCoordinator({
       label: config.label,
       requestTimeoutMs: config.requestTimeoutMs,
+      autoHandlesToolApprovals:
+        mode.kind === "session" && typeof mode.options.canUseTool === "function",
       onDeviceStatus: (status) => this.emitDeviceStatus(status),
     });
   }

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -35,6 +35,7 @@ import {
 type RemoteTurnCoordinatorConfig = {
   label: string;
   requestTimeoutMs?: number;
+  autoHandlesToolApprovals?: boolean;
   onDeviceStatus(status: SessionDeviceStatus): void;
 };
 
@@ -48,6 +49,7 @@ type RemoteTurnCoordinatorConfig = {
 export class RemoteTurnCoordinator {
   private readonly label: string;
   private readonly requestTimeoutMs: number | undefined;
+  private readonly autoHandlesToolApprovals: boolean;
   private readonly onDeviceStatus: (status: SessionDeviceStatus) => void;
   private streamQueue: SDKMessage[] = [];
   private streamResolvers: Array<(message: SDKMessage | null) => void> = [];
@@ -62,6 +64,7 @@ export class RemoteTurnCoordinator {
   constructor(config: RemoteTurnCoordinatorConfig) {
     this.label = config.label;
     this.requestTimeoutMs = config.requestTimeoutMs;
+    this.autoHandlesToolApprovals = config.autoHandlesToolApprovals === true;
     this.onDeviceStatus = config.onDeviceStatus;
   }
 
@@ -239,6 +242,9 @@ export class RemoteTurnCoordinator {
       active.observedTurnEvidence || active.observedRequiresApprovalStop;
     if (!hadTurnEvidence) return;
     if (status === "WAITING_ON_APPROVAL") {
+      // Loop status and approval requests arrive on different sockets. Keep a
+      // callback-backed turn open until its control request continues the turn.
+      if (this.autoHandlesToolApprovals) return;
       this.completeActiveTurn({
         runtime: active.runtime,
         stopReason: "requires_approval",

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -35,6 +35,7 @@ class FakeAppServerSocket {
   static inputScenario:
     | "normal"
     | "autoApprovalContinuation"
+    | "delayedApprovalRequest"
     | "manualApprovalWait"
     | "queuedSecond"
     | "hang" = "normal";
@@ -500,6 +501,102 @@ function fakeAppServerHandle(
           stop_reason: "end_turn",
           run_id: "run-final",
         },
+      });
+      return;
+    }
+
+    if (FakeAppServerSocket.inputScenario === "delayedApprovalRequest") {
+      const payload = command.payload as { kind?: string };
+      if (payload.kind === "approval_response") {
+        emitStream({
+          type: "update_loop_status",
+          runtime,
+          loop_status: {
+            status: "EXECUTING_CLIENT_SIDE_TOOL",
+            active_run_ids: ["run-approval"],
+          },
+        });
+        emitStream({
+          type: "stream_delta",
+          runtime,
+          delta: {
+            id: "tool-result-1",
+            message_type: "tool_return_message",
+            tool_call_id: "call-1",
+            tool_return: "ok",
+            status: "success",
+            run_id: "run-approval",
+          },
+        });
+        emitStream({
+          type: "stream_delta",
+          runtime,
+          delta: {
+            id: "msg-after-tool",
+            message_type: "assistant_message",
+            content: "done after delayed approval",
+            run_id: "run-final",
+          },
+        });
+        emitStream({
+          type: "stream_delta",
+          runtime,
+          delta: {
+            message_type: "stop_reason",
+            stop_reason: "end_turn",
+            run_id: "run-final",
+          },
+        });
+        return;
+      }
+
+      emitStream({
+        type: "stream_delta",
+        runtime,
+        delta: {
+          id: "tool-call-1",
+          message_type: "approval_request_message",
+          tool_calls: [
+            {
+              tool_call_id: "call-1",
+              name: "Read",
+              arguments: '{"file_path":"/workspace/readme.md"}',
+            },
+          ],
+          run_id: "run-approval",
+        },
+      });
+      emitStream({
+        type: "stream_delta",
+        runtime,
+        delta: {
+          message_type: "stop_reason",
+          stop_reason: "requires_approval",
+          run_id: "run-approval",
+        },
+      });
+      emitStream({
+        type: "update_loop_status",
+        runtime,
+        loop_status: {
+          status: "WAITING_ON_APPROVAL",
+          active_run_ids: ["run-approval"],
+        },
+      });
+      const request = {
+        type: "control_request",
+        request_id: "approval-delayed-1",
+        runtime,
+        request: {
+          subtype: "can_use_tool",
+          tool_name: "Read",
+          tool_call_id: "call-1",
+          input: { file_path: "/workspace/readme.md" },
+        },
+      };
+      queueMicrotask(() => {
+        control.serverMessage(request);
+        control.serverMessage(request);
       });
       return;
     }
@@ -1023,6 +1120,49 @@ describe("LettaAgentClient", () => {
         }),
       );
       expect(result.stopReason).not.toBe("requires_approval");
+    } finally {
+      FakeAppServerSocket.inputScenario = "normal";
+      session.close();
+    }
+  });
+
+  test("websocket protocol sessions wait for delayed auto-handled approval requests", async () => {
+    FakeAppServerSocket.instances = [];
+    FakeAppServerSocket.inputScenario = "delayedApprovalRequest";
+    const decisions: Array<{ toolName: string; input: Record<string, unknown> }> = [];
+    const client = new LettaAgentClient({
+      backend: "remote",
+      url: "http://127.0.0.1:4500",
+      WebSocket: FakeAppServerSocket,
+    });
+
+    const session = client.createSession("agent-123", {
+      canUseTool: (toolName, input) => {
+        decisions.push({ toolName, input });
+        return { behavior: "allow" };
+      },
+    });
+    try {
+      await asAdvanced(session).initialize();
+      const result = await asAdvanced(session).runTurn("read a file");
+
+      expect(result).toMatchObject({
+        type: "result",
+        success: true,
+        stopReason: "end_turn",
+        result: "done after delayed approval",
+      });
+      expect(decisions).toEqual([
+        {
+          toolName: "Read",
+          input: { file_path: "/workspace/readme.md" },
+        },
+      ]);
+      const approvalResponses = fakeControlSocket().sent.filter((command) => {
+        const payload = (command as { payload?: { kind?: string } }).payload;
+        return payload?.kind === "approval_response";
+      });
+      expect(approvalResponses).toHaveLength(1);
     } finally {
       FakeAppServerSocket.inputScenario = "normal";
       session.close();


### PR DESCRIPTION
## Summary
- keep callback-backed tool approvals in the active turn when approval status arrives before the control request on a separate socket
- resolve replayed approval requests once and reuse the cached decision instead of invoking host callbacks repeatedly
- add a deterministic cross-socket ordering regression that fails with a premature `requires_approval` result on the prior implementation
- tracked by LET-10278

## Test plan
- [x] `bun run check`
- [x] `bun test` (197 passed, 11 live tests skipped)
- [x] `bun run build`
- [x] live Cloud smoke: one allowed workspace read, one denied outside-workspace read, one callback each, final `end_turn`

👾 Generated with [Letta Code](https://letta.com)