### PR TITLE
fix(agents): support managed system prompt appends

### DIFF
--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -51,6 +51,8 @@ import type {
   RecoverPendingApprovalsOptions,
   RecoverPendingApprovalsResult,
   SendMessage,
+  SystemPromptPreset,
+  SystemPromptConfig,
   UpdateModelResult,
 } from "./types.js";
 
@@ -99,16 +101,41 @@ export type AppServerSessionOptions = Partial<LettaCodeRemoteClientOptions> & {
 
 export type AppServerSessionMode = RuntimeSessionMode;
 
-function isPresetSystemPrompt(value: string): boolean {
-  return [
-    "default",
-    "letta-claude",
-    "letta-codex",
-    "letta-gemini",
-    "claude",
-    "codex",
-    "gemini",
-  ].includes(value);
+const SYSTEM_PROMPT_PRESET_IDS = {
+  default: "default",
+  letta: "letta",
+  "source-claude": "source-claude",
+  "source-codex": "source-codex",
+  "source-gemini": "source-gemini",
+  "letta-claude": "letta",
+  "letta-codex": "letta",
+  "letta-gemini": "letta",
+  claude: "source-claude",
+  codex: "source-codex",
+  gemini: "source-gemini",
+} as const satisfies Record<SystemPromptPreset, string>;
+
+function isPresetSystemPrompt(value: string): value is SystemPromptPreset {
+  return Object.hasOwn(SYSTEM_PROMPT_PRESET_IDS, value);
+}
+
+function resolveSystemPrompt(
+  config: SystemPromptConfig,
+  memoryMode: "memfs" | "standard",
+): string {
+  if (typeof config === "string") {
+    return isPresetSystemPrompt(config)
+      ? buildSystemPrompt(SYSTEM_PROMPT_PRESET_IDS[config], memoryMode)
+      : config;
+  }
+
+  const base = buildSystemPrompt(
+    SYSTEM_PROMPT_PRESET_IDS[config.preset],
+    memoryMode,
+  );
+  return config.append === undefined || config.append.length === 0
+    ? base
+    : `${base}\n\n${config.append}`;
 }
 
 function assertRemoteCreateAgentOptionsSupported(options: CreateAgentOptions): void {
@@ -187,14 +214,10 @@ export async function createAgentBody(
       body.system = buildSystemPrompt("default", "standard");
     }
   } else {
-    if (typeof options.systemPrompt === "string") {
-      if (isPresetSystemPrompt(options.systemPrompt)) {
-        throw new Error("createAgent() does not yet support system prompt presets for this backend.");
-      }
-      body.system = options.systemPrompt;
-    } else {
-      throw new Error("createAgent() does not yet support system prompt preset objects for this backend.");
-    }
+    body.system = resolveSystemPrompt(
+      options.systemPrompt,
+      options.memfs === false ? "standard" : "memfs",
+    );
   }
 
   const hasMemoryConfiguration =

--- a/src/tests/app-server-session.test.ts
+++ b/src/tests/app-server-session.test.ts
@@ -70,4 +70,29 @@ describe("createAgentBody", () => {
       })).system,
     ).toBe("You are a focused research assistant.");
   });
+
+  test("resolves managed prompt presets for Cloud and app-server creation", async () => {
+    expect(
+      (await createAgentBody({ systemPrompt: "default" })).system,
+    ).toBe(buildSystemPrompt("default", "memfs"));
+    expect(
+      (
+        await createAgentBody({
+          memfs: false,
+          systemPrompt: "letta-codex",
+        })
+      ).system,
+    ).toBe(buildSystemPrompt("letta", "standard"));
+  });
+
+  test("appends caller instructions to a managed prompt without replacing it", async () => {
+    const append = "Do not send progress updates in the embedded widget.";
+    const body = await createAgentBody({
+      systemPrompt: { type: "preset", preset: "default", append },
+    });
+
+    expect(body.system).toBe(
+      `${buildSystemPrompt("default", "memfs")}\n\n${append}`,
+    );
+  });
 });

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { buildSystemPrompt } from "@letta-ai/letta-code/agent-presets";
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import {
   CloudManagedSandboxExpiredError,
@@ -1977,12 +1978,16 @@ describe("CloudEnvironmentSession", () => {
     expect(createBody).not.toHaveProperty("name");
     expect(createBody).not.toHaveProperty("description");
 
-    await expect(client.createAgent({
-      model: "anthropic/claude-sonnet-4",
-      systemPrompt: "default",
-    })).rejects.toThrow(
-      "createAgent() does not yet support system prompt presets for this backend",
-    );
+    const append = "Do not send progress updates in the embedded widget.";
+    await expect(
+      client.createAgent({
+        model: "anthropic/claude-sonnet-4",
+        systemPrompt: { type: "preset", preset: "default", append },
+      }),
+    ).resolves.toBe("agent-created");
+    expect(requests[1]?.body).toMatchObject({
+      system: `${buildSystemPrompt("default", "memfs")}\n\n${append}`,
+    });
   });
 
   test("uses the Letta Code default model for Cloud createAgent", async () => {

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -99,6 +99,28 @@ describe("validation", () => {
     }
   });
 
+  test("accepts current and legacy system prompt preset names", () => {
+    for (const preset of [
+      "default",
+      "letta",
+      "source-claude",
+      "source-codex",
+      "source-gemini",
+      "letta-claude",
+      "letta-codex",
+      "letta-gemini",
+      "claude",
+      "codex",
+      "gemini",
+    ] as const) {
+      expect(() =>
+        validateCreateAgentOptions({
+          systemPrompt: { type: "preset", preset, append: "Extra guidance." },
+        }),
+      ).not.toThrow();
+    }
+  });
+
   test("rejects invalid agent skill source", () => {
     expect(() =>
       validateCreateAgentOptions({

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,13 +162,23 @@ export interface EffectiveDreamingSettings {
  * Available system prompt presets.
  */
 export type SystemPromptPreset =
-  | "default" // Alias for letta-claude
-  | "letta-claude" // Full Letta Code prompt (Claude-optimized)
-  | "letta-codex" // Full Letta Code prompt (Codex-optimized)
-  | "letta-gemini" // Full Letta Code prompt (Gemini-optimized)
-  | "claude" // Basic Claude (no skills/memory instructions)
-  | "codex" // Basic Codex
-  | "gemini"; // Basic Gemini
+  | "default"
+  | "letta"
+  | "source-claude"
+  | "source-codex"
+  | "source-gemini"
+  /** @deprecated Use `letta`. */
+  | "letta-claude"
+  /** @deprecated Use `letta`. */
+  | "letta-codex"
+  /** @deprecated Use `letta`. */
+  | "letta-gemini"
+  /** @deprecated Use `source-claude`. */
+  | "claude"
+  /** @deprecated Use `source-codex`. */
+  | "codex"
+  /** @deprecated Use `source-gemini`. */
+  | "gemini";
 
 /**
  * System prompt preset configuration.

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -99,6 +99,10 @@ function validateRemovedSessionOptions(options: CreateSessionOptions): void {
 function validateSystemPromptPreset(preset: string): void {
   const validPresets = [
     "default",
+    "letta",
+    "source-claude",
+    "source-codex",
+    "source-gemini",
     "letta-claude",
     "letta-codex",
     "letta-gemini",
@@ -220,6 +224,10 @@ export function validateCreateAgentOptions(options: CreateAgentOptions): void {
     // Check if it's a preset name (if so, validate it)
     const validPresets = [
       "default",
+      "letta",
+      "source-claude",
+      "source-codex",
+      "source-gemini",
       "letta-claude",
       "letta-codex",
       "letta-gemini",


### PR DESCRIPTION
## Summary

- compile managed system-prompt presets before Cloud and App Server agent creation
- support appending narrow application guidance without replacing the maintained harness prompt
- align current preset names while preserving legacy aliases

Verified with the full 200-test suite, type/source-size checks, package build, and a live Cloud agent turn using the appended response contract.

👾 Generated with [Letta Code](https://letta.com)