### PR TITLE
chore: bump Letta Code to 0.29.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@letta-ai/letta-agent-sdk",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@letta-ai/letta-agent-sdk",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@letta-ai/letta-client": "^1.12.1",
-        "@letta-ai/letta-code": "0.29.12"
+        "@letta-ai/letta-code": "0.29.13"
       },
       "devDependencies": {
         "@modelcontextprotocol/server-everything": "^2026.7.4",
@@ -1081,9 +1081,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@letta-ai/letta-code": {
-      "version": "0.29.12",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.29.12.tgz",
-      "integrity": "sha512-ZG+N2MyVD4MjXKyjGJKm89Hjiu1tqHhrmYKhIwGBW4xvaW57hokimM7fI7p66fpWoFMnBfJHXNmAYxKVVqErUw==",
+      "version": "0.29.13",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.29.13.tgz",
+      "integrity": "sha512-mX+V/86KVBvbkONKReKA1TwAWzhiRveiplyzCM3bB6qv3zlXIWz9B1t/jBpr+jge3Ddxx+jTkYjGC7YHlOGi6A==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@letta-ai/letta-client": "^1.12.1",
-    "@letta-ai/letta-code": "0.29.12"
+    "@letta-ai/letta-code": "0.29.13"
   },
   "devDependencies": {
     "@modelcontextprotocol/server-everything": "^2026.7.4",


### PR DESCRIPTION
Bumps the Agent SDK runtime dependency from `@letta-ai/letta-code` 0.29.12 to the latest published release, 0.29.13. The lockfile refresh also synchronizes its root package version with the current SDK version, 0.5.7.

Validated with `bun run check`, `bun test` (204 passed, 11 live tests skipped), and `bun run build`.