### PR TITLE
feat: add session-scoped client toolsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,25 @@ await using session = client.createSession(agentId, {
 
 Local execution (embedded Letta Code harness / app server) requires Node.js 22.19 or newer.
 
+### Built-in client toolsets
+
+Use `toolset` to select a request-scoped harness preset and add bundled client
+tools. `allowedTools` remains the final visibility boundary across bundled and
+custom tools.
+
+```ts
+await using session = client.createSession(agentId, {
+  toolset: {
+    base: "none",
+    include: ["Read", "LS", "Glob", "Grep"],
+  },
+  allowedTools: ["Read", "LS", "Glob", "Grep"],
+});
+```
+
+The override applies to this SDK session's turns without changing the agent's
+persisted harness toolset preference.
+
 ### MCP tools
 
 Pass MCP servers by name in session options. The SDK supports local stdio,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@letta-ai/letta-agent-sdk",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@letta-ai/letta-agent-sdk",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@letta-ai/letta-client": "^1.12.1",
-        "@letta-ai/letta-code": "0.29.13"
+        "@letta-ai/letta-code": "0.30.0"
       },
       "devDependencies": {
         "@modelcontextprotocol/server-everything": "^2026.7.4",
@@ -1081,9 +1081,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@letta-ai/letta-code": {
-      "version": "0.29.13",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.29.13.tgz",
-      "integrity": "sha512-mX+V/86KVBvbkONKReKA1TwAWzhiRveiplyzCM3bB6qv3zlXIWz9B1t/jBpr+jge3Ddxx+jTkYjGC7YHlOGi6A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.30.0.tgz",
+      "integrity": "sha512-APyWY99eQ0JwvkO1fjTcIsmuysqTxIerjEz96AX5rA6VLIyKxGI9HgQEnBn90Bod1e65lVGDj6uhhf5V8qp7yg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1094,6 +1094,7 @@
         "@pierre/diffs": "1.2.2",
         "@scarf/scarf": "^1.4.0",
         "cron-parser": "^5.6.1",
+        "cross-spawn": "^7.0.6",
         "glob": "^13.0.0",
         "ink-link": "^5.0.0",
         "node-pty": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@letta-ai/letta-client": "^1.12.1",
-    "@letta-ai/letta-code": "0.29.13"
+    "@letta-ai/letta-code": "0.30.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/server-everything": "^2026.7.4",

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -46,6 +46,7 @@ import type {
   AnyAgentTool,
   CanUseToolContext,
   CanUseToolResponse,
+  ClientToolsetConfig,
   CreateAgentOptions,
   LettaCodeRemoteClientOptions,
   LettaCodeClientSessionOptions,
@@ -528,6 +529,7 @@ export class AppServerRuntimeController implements RemoteClientRuntimeController
     private readonly client: AppServerClient,
     private readonly options: AppServerSessionOptions,
     private readonly clientToolAllowlist?: readonly string[],
+    private readonly clientToolset?: ClientToolsetConfig,
   ) {}
 
   onMessage(handler: (message: ProtocolMessage, channel?: string) => void): () => void {
@@ -557,6 +559,16 @@ export class AppServerRuntimeController implements RemoteClientRuntimeController
     };
     if (this.clientToolAllowlist !== undefined) {
       payload.client_tool_allowlist = [...new Set(this.clientToolAllowlist)];
+    }
+    if (this.clientToolset !== undefined) {
+      payload.client_toolset = {
+        ...(this.clientToolset.base !== undefined
+          ? { base: this.clientToolset.base }
+          : {}),
+        ...(this.clientToolset.include !== undefined
+          ? { include: [...new Set(this.clientToolset.include)] }
+          : {}),
+      };
     }
     // SDK sessions are headless: interactive user-input tools are always
     // excluded from the toolset (harnesses without support ignore the flag
@@ -768,10 +780,11 @@ export class AppServerSession extends RemoteClientSessionCore {
       }
 
       const tools = agentToolNames(response.agent);
-      const skillSources = this.currentOptions().skillSources;
+      const skillSources = options.skillSources;
+      const clientToolset = "toolset" in options ? options.toolset : undefined;
       const mcpToolNames = this.mcpBridge?.tools.map((tool) => tool.name) ?? [];
       const allowedTools = expandMcpToolWildcards(
-        this.currentOptions().allowedTools,
+        options.allowedTools,
         mcpToolNames,
       );
       const availableTools =
@@ -783,6 +796,7 @@ export class AppServerSession extends RemoteClientSessionCore {
           client,
           this.remoteOptions,
           allowedTools,
+          clientToolset,
         ),
         runtime: response.runtime,
         model: typeof response.agent?.model === "string" ? response.agent.model : "",

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -399,10 +399,11 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
       }
 
       const tools = agentToolNames(response.agent);
-      const skillSources = this.currentOptions().skillSources;
+      const skillSources = options.skillSources;
+      const clientToolset = "toolset" in options ? options.toolset : undefined;
       const mcpToolNames = this.mcpBridge?.tools.map((tool) => tool.name) ?? [];
       const allowedTools = expandMcpToolWildcards(
-        this.currentOptions().allowedTools,
+        options.allowedTools,
         mcpToolNames,
       );
       const availableTools =
@@ -416,6 +417,7 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
             requestTimeoutMs: this.cloudOptions.requestTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
           },
           allowedTools,
+          clientToolset,
         ),
         runtime: response.runtime,
         model: typeof response.agent?.model === "string" ? response.agent.model : "",

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -930,7 +930,11 @@ describe("LettaAgentClient", () => {
 
     const session = client.createSession("agent-123", {
       cwd: "/tmp/project",
-      allowedTools: ["Bash", "Read", "Write", "Edit", "Read"],
+      toolset: {
+        base: "none",
+        include: ["Read", "LS", "Glob", "Grep", "Read"],
+      },
+      allowedTools: ["Read", "LS", "Glob", "Grep", "Read"],
     });
     try {
       const init = await asAdvanced(session).initialize();
@@ -957,7 +961,11 @@ describe("LettaAgentClient", () => {
         runtime: { agent_id: "agent-123", conversation_id: "conv-created" },
         payload: {
           kind: "create_message",
-          client_tool_allowlist: ["Bash", "Read", "Write", "Edit"],
+          client_tool_allowlist: ["Read", "LS", "Glob", "Grep"],
+          client_toolset: {
+            base: "none",
+            include: ["Read", "LS", "Glob", "Grep"],
+          },
         },
       });
       const payload = inputCommand?.payload as Record<string, unknown> | undefined;
@@ -988,6 +996,7 @@ describe("LettaAgentClient", () => {
       const payload = inputCommand?.payload as Record<string, unknown> | undefined;
       // No allowlist by default — the harness default toolset applies…
       expect(payload).not.toHaveProperty("client_tool_allowlist");
+      expect(payload).not.toHaveProperty("client_toolset");
       // …with interactive user-input tools excluded via the protocol flag.
       expect(payload?.exclude_interactive_tools).toBe(true);
     } finally {

--- a/src/tests/cloud-session.test.ts
+++ b/src/tests/cloud-session.test.ts
@@ -1331,6 +1331,11 @@ describe("CloudEnvironmentSession", () => {
       cwd: "/repo",
       permissionMode: "unrestricted",
       skillSources: [],
+      toolset: {
+        base: "none",
+        include: ["Read", "LS", "Glob", "Grep"],
+      },
+      allowedTools: ["Read", "LS", "Glob", "Grep"],
       dreaming: { trigger: "step-count", stepCount: 3 },
     });
     const init = await asAdvanced(session).initialize();
@@ -1409,6 +1414,11 @@ describe("CloudEnvironmentSession", () => {
       payload: {
         kind: "create_message",
         messages: [expect.objectContaining({ role: "user", content: "hello" })],
+        client_tool_allowlist: ["Read", "LS", "Glob", "Grep"],
+        client_toolset: {
+          base: "none",
+          include: ["Read", "LS", "Glob", "Grep"],
+        },
       },
     });
     expect(inputCommand.payload).not.toHaveProperty("supports_control_response");

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -13,6 +13,10 @@ describe("validation", () => {
         maxApprovalRecoveryAttempts: 2,
         approvalRecoveryTimeoutMs: 3000,
         reasoningEffort: "high",
+        toolset: {
+          base: "none",
+          include: ["Read", "LS", "Glob", "Grep"],
+        },
       }),
     ).not.toThrow();
   });
@@ -32,6 +36,20 @@ describe("validation", () => {
         mcpServers: [{ name: "old", command: "node" }],
       } as never),
     ).toThrow("Expected an object keyed by server name");
+  });
+
+  test("rejects invalid client toolset configuration", () => {
+    expect(() =>
+      validateCreateSessionOptions({
+        toolset: { base: "invented" },
+      } as never),
+    ).toThrow("Invalid toolset.base");
+
+    expect(() =>
+      validateCreateSessionOptions({
+        toolset: { include: ["Read", ""] },
+      }),
+    ).toThrow("Invalid toolset.include");
   });
 
   test("rejects invalid session reasoning effort", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -635,6 +635,22 @@ export interface SendCommandOptions<TResponseType extends string = string> {
   predicate?: (message: SDKProtocolMessage) => boolean;
 }
 
+export type ClientToolsetBase =
+  | "auto"
+  | "codex"
+  | "codex_snake"
+  | "default"
+  | "gemini"
+  | "gemini_snake"
+  | "none";
+
+export interface ClientToolsetConfig {
+  /** Request-scoped base toolset. Omitted preserves the harness preference. */
+  base?: ClientToolsetBase;
+  /** Additional bundled client tools to load before applying allowedTools. */
+  include?: string[];
+}
+
 /**
  * Options for createSession() and resumeSession() restricted to settings that
  * can be applied to existing agents.
@@ -654,6 +670,13 @@ export interface CreateSessionOptions {
    * excluded for SDK sessions.
    */
   allowedTools?: string[];
+
+  /**
+   * Request-scoped built-in client toolset selection. The base chooses a
+   * harness preset without changing persisted settings; include adds bundled
+   * tools before allowedTools is applied.
+   */
+  toolset?: ClientToolsetConfig;
 
   /** Permission mode */
   permissionMode?: PermissionMode;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -22,6 +22,16 @@ const VALID_SKILL_SOURCES: SkillSource[] = [
   "project",
 ];
 
+const VALID_TOOLSET_BASES = [
+  "auto",
+  "codex",
+  "codex_snake",
+  "default",
+  "gemini",
+  "gemini_snake",
+  "none",
+] as const;
+
 const VALID_REASONING_EFFORTS = [
   "none",
   "minimal",
@@ -111,6 +121,34 @@ function validateSystemPromptPreset(preset: string): void {
     throw new Error(
       `Invalid system prompt preset '${preset}'. ` +
         `Valid presets: ${validPresets.join(", ")}`
+    );
+  }
+}
+
+function validateClientToolset(
+  toolset: CreateSessionOptions["toolset"],
+): void {
+  if (toolset === undefined) return;
+  if (!toolset || typeof toolset !== "object" || Array.isArray(toolset)) {
+    throw new Error("Invalid toolset. Expected an object with optional base and include fields.");
+  }
+  if (
+    toolset.base !== undefined &&
+    !VALID_TOOLSET_BASES.includes(toolset.base)
+  ) {
+    throw new Error(
+      `Invalid toolset.base '${String(toolset.base)}'. Valid values: ${VALID_TOOLSET_BASES.join(", ")}`,
+    );
+  }
+  if (
+    toolset.include !== undefined &&
+    (!Array.isArray(toolset.include) ||
+      toolset.include.some(
+        (toolName) => typeof toolName !== "string" || toolName.length === 0,
+      ))
+  ) {
+    throw new Error(
+      "Invalid toolset.include. Expected an array of non-empty bundled tool names.",
     );
   }
 }
@@ -207,6 +245,7 @@ function validateMcpServers(servers: McpServers | undefined): void {
  * Validate CreateSessionOptions (used by createSession and resumeSession).
  */
 export function validateCreateSessionOptions(options: CreateSessionOptions): void {
+  validateClientToolset(options.toolset);
   validateSkillSources(options.skillSources);
   validateMcpServers(options.mcpServers);
   validateReasoningEffort(options.reasoningEffort);


### PR DESCRIPTION
## Summary
- add a typed toolset session option for selecting a request-scoped base preset and bundled client tools
- forward the exact configuration through remote app-server and Cloud transports while keeping allowedTools as the final visibility boundary
- bump the Letta Code dependency to 0.30.0, the first published harness release with request-scoped client toolset support
- validate and document the public API, with transport coverage for both execution paths

Verified with bun run check, bun test, and bun run build.

👾 Generated with [Letta Code](https://letta.com)