### PR TITLE
fix(tests): spawn the MCP fixture from a decoded file path

### DIFF
--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
 import { resolveAppServerChannelUrl } from "@letta-ai/letta-code/app-server-client";
 import * as sdk from "../index.js";
 import { LettaAgentClient } from "../index.js";
@@ -847,12 +848,17 @@ describe("LettaAgentClient", () => {
         fixture: {
           command: process.execPath,
           args: [
-            new URL(
-              "./dist/index.js",
-              import.meta.resolve(
-                "@modelcontextprotocol/server-everything/package.json",
+            // fileURLToPath, not URL.pathname: pathname percent-encodes
+            // spaces and non-ASCII characters in the checkout path, which
+            // breaks spawning the fixture server.
+            fileURLToPath(
+              new URL(
+                "./dist/index.js",
+                import.meta.resolve(
+                  "@modelcontextprotocol/server-everything/package.json",
+                ),
               ),
-            ).pathname,
+            ),
           ],
         },
       },


### PR DESCRIPTION
Small follow-up to the note in #249: the MCP fixture test ("registers session MCP tools through the app-server external-tool protocol") fails on any checkout whose path contains spaces or non-ASCII characters, because `new URL(...).pathname` returns a percent-encoded path. The spawn then fails with `Module not found ".../Code/%E5%BC%80.../..."`, the SDK skips the "broken" server as designed, and the assertion on `init.tools` fails — looks like a real SDK bug until you spot the encoding.

`fileURLToPath` gives back a real filesystem path, and it also handles the drive-letter case on Windows that `pathname` gets wrong (`/C:/...`).

Verified against current `main` (`5b622e5`) on a checkout under a non-ASCII directory: the focused test fails before this change and passes after it. On a clean merge simulation, `bun test` (204 pass, 11 skipped), `bun run check`, and `bun run build` all pass.
