### PR TITLE
fix: prevent implicit server tools on SDK agents

### DIFF
--- a/examples/economics-seminar/presenter.ts
+++ b/examples/economics-seminar/presenter.ts
@@ -105,6 +105,9 @@ export async function createPresenter(
         description: 'Research approach refined over time',
       },
     ],
+    // web_search is server-side, so it has to be attached at creation;
+    // allowedTools alone only gates the harness's client-side tools.
+    baseTools: ['web_search'],
     allowedTools: ['web_search', 'Read', 'Write'],
     permissionMode: 'unrestricted',
   });

--- a/examples/research-team/README.md
+++ b/examples/research-team/README.md
@@ -302,6 +302,8 @@ This will:
 ### Web Search
 The Researcher agent uses the `web_search` tool to find real academic sources. No external API keys needed - it uses Letta's built-in search capability.
 
+`web_search` runs server-side, so it is attached at creation via `baseTools: ['web_search']`. SDK-created agents get no server-side tools unless you ask for them; `allowedTools` only gates the harness's client-side tools (Read, Write, Glob, …).
+
 ### Agent Persistence
 Agent IDs are stored in `output/team-state.json`. Running `--reset` clears this file and creates fresh agents on the next run. This is useful for:
 - Starting over with clean memory

--- a/examples/research-team/agents/researcher.ts
+++ b/examples/research-team/agents/researcher.ts
@@ -120,6 +120,9 @@ export async function createResearcher(
         description: 'Accumulated knowledge of key concepts and influential works',
       },
     ],
+    // web_search is server-side, so it has to be attached at creation;
+    // allowedTools alone only gates the harness's client-side tools.
+    baseTools: ['web_search'],
     allowedTools: ['web_search', 'Glob', 'Read', 'Write'],
     permissionMode: 'unrestricted',
   });

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -174,19 +174,16 @@ export async function createAgentBody(
 
   if (options.embedding !== undefined) body.embedding = options.embedding;
   if (options.hidden !== undefined) body.hidden = options.hidden;
-  // When baseTools is omitted, the harness applies its created-agent
-  // defaults (web_search, fetch_webpage). An explicit list is pinned exactly:
-  // `tools` alone does not suppress the Letta agent type's defaults, so both
-  // default tool attachment and its default tool rules are disabled here.
+  // Agent SDK sessions provide their tools through the harness at runtime, so
+  // never attach the API's server-side base tools implicitly. An explicit list
+  // is pinned exactly instead.
   if (options.baseTools === undefined) {
     delete body.tools;
-    delete body.include_base_tools;
-    delete body.include_base_tool_rules;
   } else {
     body.tools = options.baseTools;
-    body.include_base_tools = false;
-    body.include_base_tool_rules = false;
   }
+  body.include_base_tools = false;
+  body.include_base_tool_rules = false;
 
   if (options.systemPrompt === undefined) {
     if (options.memfs === false) {

--- a/src/tests/app-server-session.test.ts
+++ b/src/tests/app-server-session.test.ts
@@ -23,8 +23,8 @@ describe("createAgentBody", () => {
     expect(body).not.toHaveProperty("description");
     expect(body).not.toHaveProperty("memory_blocks");
     expect(body).not.toHaveProperty("tools");
-    expect(body).not.toHaveProperty("include_base_tools");
-    expect(body).not.toHaveProperty("include_base_tool_rules");
+    expect(body.include_base_tools).toBe(false);
+    expect(body.include_base_tool_rules).toBe(false);
   });
 
   test("uses caller memory as the complete identity without a personality preset", async () => {
@@ -56,8 +56,8 @@ describe("createAgentBody", () => {
       })),
     } as unknown as Record<string, unknown>;
     delete expected.tools;
-    delete expected.include_base_tools;
-    delete expected.include_base_tool_rules;
+    expected.include_base_tools = false;
+    expected.include_base_tool_rules = false;
 
     expect(body).toEqual(expected);
   });

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1433,7 +1433,7 @@ describe("LettaAgentClient", () => {
     });
   });
 
-  test("createAgent leaves server-side tools to the harness defaults when baseTools is omitted", async () => {
+  test("createAgent disables server-side tools when baseTools is omitted", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({
       backend: "remote",
@@ -1448,10 +1448,11 @@ describe("LettaAgentClient", () => {
     const command = fakeControlSocket().sent[0] as {
       create_agent?: { body?: Record<string, unknown> };
     };
-    // The harness applies its created-agent defaults (web_search,
-    // fetch_webpage); the SDK does not pin them client-side.
+    expect(command.create_agent?.body).toMatchObject({
+      include_base_tools: false,
+      include_base_tool_rules: false,
+    });
     expect(command.create_agent?.body).not.toHaveProperty("tools");
-    expect(command.create_agent?.body).not.toHaveProperty("include_base_tools");
   });
 
   test("baseTools: [] attaches no server-side tools", async () => {
@@ -1479,7 +1480,7 @@ describe("LettaAgentClient", () => {
     });
   });
 
-  test("an explicit baseTools list overrides the default server-side tools", async () => {
+  test("an explicit baseTools list attaches only the requested server-side tools", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({
       backend: "remote",
@@ -1504,7 +1505,7 @@ describe("LettaAgentClient", () => {
     });
   });
 
-  test("default toolset contract: harness owns both defaults; SDK only excludes interactive tools", async () => {
+  test("default toolset contract: creation has no server tools and turns use harness client tools", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({
       backend: "remote",
@@ -1512,16 +1513,18 @@ describe("LettaAgentClient", () => {
       WebSocket: FakeAppServerSocket,
     });
 
-    // 1. Creation sends no tool fields — the harness applies its
-    //    created-agent defaults (web_search, fetch_webpage).
+    // 1. Creation explicitly disables server-side base tools.
     const agentId = await client.createAgent({
       model: "anthropic/claude-sonnet-4",
     });
     const createCommand = fakeControlSocket().sent[0] as {
       create_agent?: { body?: Record<string, unknown> };
     };
+    expect(createCommand.create_agent?.body).toMatchObject({
+      include_base_tools: false,
+      include_base_tool_rules: false,
+    });
     expect(createCommand.create_agent?.body).not.toHaveProperty("tools");
-    expect(createCommand.create_agent?.body).not.toHaveProperty("include_base_tools");
 
     // 2. Every turn keeps the harness default toolset (no pinned allowlist)
     //    and excludes interactive user-input tools via the protocol flag.

--- a/src/tests/live.integration.test.ts
+++ b/src/tests/live.integration.test.ts
@@ -373,7 +373,7 @@ describeLive("live integration: letta-agent-sdk", () => {
   );
 
   test(
-    "createAgent attaches exactly the default server-side toolset",
+    "createAgent attaches no server-side tools by default",
     async () => {
       const createdAgentId = await createAgent({
         name: `sdk-toolset-test-${Date.now()}`,
@@ -386,7 +386,7 @@ describeLive("live integration: letta-agent-sdk", () => {
           .map((t) => t?.name)
           .filter((name): name is string => typeof name === "string")
           .sort();
-        expect(toolNames).toEqual(["fetch_webpage", "web_search"]);
+        expect(toolNames).toEqual([]);
       } finally {
         await deleteAgent(createdAgentId);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -921,10 +921,14 @@ export interface CreateAgentOptions {
   hidden?: boolean;
 
   /**
-   * Server-side tools to attach at creation. When omitted, the harness
-   * applies its created-agent defaults (web_search, fetch_webpage). Pass []
-   * for none or an explicit list to override. Client-side tools (Bash,
-   * Edit, …) are provided by the harness at runtime and are unaffected.
+   * Server-side tools to attach at creation. SDK agents attach none by
+   * default — pass an explicit list to opt in. `[]` is the explicit spelling
+   * of the default.
+   *
+   * Note that server-side tools have no client-side equivalent, so agents
+   * that need web access must ask for it here (`["web_search",
+   * "fetch_webpage"]` is what the CLI attaches). Client-side tools (Bash,
+   * Edit, …) come from the harness at runtime and are unaffected.
    */
   baseTools?: string[];
 


### PR DESCRIPTION
## Summary

- immediately stop SDK-created agents from inheriting the API's legacy conversation and block-memory base tools
- preserve exact explicit baseTools lists while leaving runtime client tools unchanged
- correct examples that intentionally require server-side web search
- verify against Letta Cloud that omitted baseTools attaches no server-side tools in this compatibility fix

This is the narrow Agent SDK safeguard for LET-10557. The root cause is broader creation-policy drift: the SDK currently reconstructs and mutates fields after importing Letta Code's personality builder. letta-ai/letta-code#3660 generalizes that export into the single canonical request builder. After that lands in a release, a follow-up SDK PR will consume it and remove the duplicated generic builder and post-processing rather than preserving this local policy as the endpoint.

Validated with bun run check, bun test, bun run build, and the focused live Cloud integration test.

👾 Generated with [Letta Code](https://letta.com)
