### PR TITLE
fix: fail sessions when the app-server transport drops

### DIFF
--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -779,6 +779,8 @@ export class AppServerSession extends RemoteClientSessionCore {
         throw new Error(response.error ?? "Failed to start app-server runtime");
       }
 
+      this.watchTransportDisconnect(client);
+
       const tools = agentToolNames(response.agent);
       const skillSources = options.skillSources;
       const clientToolset = "toolset" in options ? options.toolset : undefined;

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -398,6 +398,8 @@ export class CloudEnvironmentSession extends RemoteClientSessionCore {
         throw new Error(response.error ?? "Failed to start Cloud status runtime");
       }
 
+      this.watchTransportDisconnect(client);
+
       const tools = agentToolNames(response.agent);
       const skillSources = options.skillSources;
       const clientToolset = "toolset" in options ? options.toolset : undefined;

--- a/src/remote-client-session-core.ts
+++ b/src/remote-client-session-core.ts
@@ -77,6 +77,7 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
   private readonly requestTimeoutMs: number | undefined;
   private initializePromise: Promise<SDKInitMessage> | null = null;
   private removeMessageHandler: (() => void) | null = null;
+  private detachTransportDisconnect: (() => void) | null = null;
   private readonly turns: RemoteTurnCoordinator;
   private toolNames: string[] | undefined;
   private deviceStatusListeners = new Set<(status: SessionDeviceStatus) => void>();
@@ -188,6 +189,8 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
   private cleanupFailedInitialize(): void {
     this.removeMessageHandler?.();
     this.removeMessageHandler = null;
+    this.detachTransportDisconnect?.();
+    this.detachTransportDisconnect = null;
     this.controller?.close();
     this.controller = null;
     // Subclass-owned resources (spawned connections, sandboxes, handlers)
@@ -543,6 +546,8 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
     this.closed = true;
     this.removeMessageHandler?.();
     this.removeMessageHandler = null;
+    this.detachTransportDisconnect?.();
+    this.detachTransportDisconnect = null;
     this.turns.close();
     for (const cancel of [...this.deviceStatusRefreshCancels]) {
       cancel(new Error(`Session closed while waiting for ${this.label} device status`));
@@ -618,6 +623,35 @@ export abstract class RemoteClientSessionCore implements LettaCodeSession {
   }
 
   protected abstract initializeRuntimeController(): Promise<RuntimeSessionInit>;
+
+  /**
+   * Fail the session when its transport drops unexpectedly.
+   *
+   * Without this an in-flight turn parks forever: nextMessage() only settles
+   * through the coordinator, and the socket's own pending-request rejection
+   * covers request/response commands, not streaming turns.
+   *
+   * The session is not revived — the runtime lived on the dead socket. The
+   * caller observes the error and rebuilds via resumeSession().
+   *
+   * Subclasses call this only once their runtime is live: a drop before that
+   * already surfaces as a rejected connect or runtime-start, and failing the
+   * session there would defeat initialize()'s retry path. Explicit closes do
+   * not notify, so this fires for faults only. Detaching stays here so every
+   * teardown path — clean close and failed initialize alike — covers it.
+   */
+  protected watchTransportDisconnect(client: {
+    onDisconnect(handler: () => void): () => void;
+  }): void {
+    this.detachTransportDisconnect?.();
+    this.detachTransportDisconnect = client.onDisconnect(() => {
+      if (this.closed) return;
+      this.turns.closeWithError(
+        `The ${this.label} connection closed unexpectedly; resume the conversation to continue.`,
+      );
+      this.close();
+    });
+  }
 
   protected async afterRuntimeInitialized(): Promise<void> {
     // Optional hook for subclasses to send transport-specific startup frames.

--- a/src/remote-turn-coordinator.ts
+++ b/src/remote-turn-coordinator.ts
@@ -160,6 +160,33 @@ export class RemoteTurnCoordinator {
     });
   }
 
+  /**
+   * Close after the transport dropped, surfacing the failure to stream
+   * consumers first.
+   *
+   * A plain close() resolves waiting consumers with `null`, which is
+   * indistinguishable from a conversation ending normally. A dead socket
+   * cannot deliver a turn-scoped failure of its own, so the error is
+   * synthesized here before the queue drains.
+   */
+  closeWithError(detail: string): void {
+    if (this.closed) return;
+    const active = this.activeTurn;
+    if (active) {
+      this.failTurn(active, detail);
+    } else {
+      this.enqueue({
+        type: "error",
+        message: detail,
+        errorCode: "error",
+        stopReason: "error",
+        errorDetail: detail,
+        recoverable: false,
+      });
+    }
+    this.close();
+  }
+
   close(): void {
     if (this.closed) return;
     this.closed = true;

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1135,6 +1135,55 @@ describe("LettaAgentClient", () => {
     }
   });
 
+  // Regression: an app-server restart used to leave stream() parked forever on
+  // a resolve-only promise, because sessions never subscribed to the
+  // disconnect signal the transport already exposed.
+  test(
+    "an app-server disconnect ends a parked stream instead of hanging",
+    async () => {
+      FakeAppServerSocket.instances = [];
+      FakeAppServerSocket.inputScenario = "hang";
+      // No requestTimeoutMs: on the default path no per-turn timer is armed,
+      // so the disconnect is the only thing that can settle the turn.
+      const client = new LettaAgentClient({
+        backend: "remote",
+        url: "http://127.0.0.1:4500",
+        WebSocket: FakeAppServerSocket,
+      });
+
+      const session = client.createSession("agent-123");
+      try {
+        await asAdvanced(session).initialize();
+        await session.send("this turn never comes back");
+
+        const messages: unknown[] = [];
+        const drained = (async () => {
+          for await (const message of session.stream()) messages.push(message);
+        })();
+        // Let the consumer park in nextMessage() before the socket dies.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // A server-side drop, not a client close: the SDK never asked for it.
+        fakeStreamSocket().close();
+        await drained;
+
+        expect(messages[0]).toMatchObject({
+          type: "error",
+          stopReason: "error",
+        });
+        expect(messages.at(-1)).toMatchObject({
+          type: "result",
+          success: false,
+          errorCode: "error",
+        });
+      } finally {
+        FakeAppServerSocket.inputScenario = "normal";
+        session.close();
+      }
+    },
+    5000,
+  );
+
   test("websocket protocol sessions wait through auto-handled requires_approval stops", async () => {
     FakeAppServerSocket.instances = [];
     FakeAppServerSocket.inputScenario = "autoApprovalContinuation";


### PR DESCRIPTION
Fixes #252.

## Problem

A cached session left pointing at a dead socket hangs the next turn indefinitely — no error, no timeout, no self-healing on retry.

`stream()` awaits `turns.nextMessage()` (`remote-turn-coordinator.ts:154`), which parks on a promise that can only ever be *resolved*. The only thing that settles those resolvers is `coordinator.close()` → `resolveAll(null)`, and its sole caller was `session.close()` — i.e. it ran only when the *caller* closed the session, never when the socket died. `AppServerClient.handleDisconnect()` does call `rejectAllPending()`, but `pending` only holds request/response commands keyed by `request_id`; a streaming turn isn't in that map.

There was no backstop either: `activateTurn` arms a per-turn timer only when `requestTimeoutMs !== undefined`, and `AppServerSession` forwards `remoteOptions.requestTimeoutMs`, which is undefined by default. So on the default path the wait is genuinely unbounded.

The transport already exposed the needed signal (`AppServerClient.onDisconnect`) and the SDK already consumed it — but only for the management pool (`app-server-management.ts:255`), never for sessions. `git log -S onDisconnect -- src/app-server-session.ts` returned zero commits.

## Fix

Subscribe to the disconnect signal once the runtime is live and fail the session on an unexpected drop.

**The stream terminates with an error, not a silent `null`.** Resolving with `null` is indistinguishable from a conversation ending normally, which would turn the hang into silent truncation. `RemoteTurnCoordinator.closeWithError()` synthesizes a terminal failure first — reusing the existing `failTurn` path when a turn is active — so consumers get an explicit `error` message plus a failed `result`. `sendAndWaitForResult()` gets the real error instead of its `stream_closed` fallback.

The session is not revived: its runtime lived on the dead socket. Callers detect the drop and rebuild via `resumeSession(conversationId)`, which recovers with context intact.

**Lifecycle lives in the core.** Both `AppServerSession` and `CloudEnvironmentSession` build their own client and had the identical gap, so `watchTransportDisconnect()` sits in `RemoteClientSessionCore` and each subclass opts in with one call. Detaching happens in both `close()` and `cleanupFailedInitialize()`, so a `performInitialize()` failure *after* the runtime came up is covered too.

Subscription happens after runtime start deliberately: an earlier drop already surfaces as a rejected `connect()`/`startRuntime()`, and failing the session there would defeat `initialize()`'s retry path. Explicit closes don't notify (`explicitlyClosed` guard in the client), so this fires for faults only.

## Test

`an app-server disconnect ends a parked stream instead of hanging` drives the real bug: a turn is sent with the `hang` scenario and no `requestTimeoutMs`, the consumer is allowed to park in `nextMessage()`, then the socket is closed server-side. Verified it times out at 5s against `main` and passes with the fix.

`bun run check`, `bun test` (206 pass / 0 fail), and `bun run build` all pass.

## Note for reviewers

Cloud sessions got the same wiring since the defect is identical, but I only exercised the app-server path in tests — the Cloud transport (`cloud-status-transport.ts`) also emits `close` without auto-reconnecting, so the same reasoning applies, but a second pair of eyes there is worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)