### PR TITLE
fix: consolidate SDK agent creation policy [LET-10557]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@letta-ai/letta-client": "^1.12.1",
-        "@letta-ai/letta-code": "0.30.0"
+        "@letta-ai/letta-code": "0.30.5"
       },
       "devDependencies": {
         "@modelcontextprotocol/server-everything": "^2026.7.4",
@@ -1040,9 +1040,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@letta-ai/letta-code": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.30.0.tgz",
-      "integrity": "sha512-APyWY99eQ0JwvkO1fjTcIsmuysqTxIerjEz96AX5rA6VLIyKxGI9HgQEnBn90Bod1e65lVGDj6uhhf5V8qp7yg==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.30.5.tgz",
+      "integrity": "sha512-aDwiMSaP65RK/v/kX6EkzeC3N0O5KQ1wMIUewXiQC+IqP5AU4adnXWTQl7vXMpDhKzTzFNzAZWADIQ+l+TENGw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@letta-ai/letta-client": "^1.12.1",
-    "@letta-ai/letta-code": "0.30.0"
+    "@letta-ai/letta-code": "0.30.5"
   },
   "devDependencies": {
     "@modelcontextprotocol/server-everything": "^2026.7.4",

--- a/src/agent-creation.ts
+++ b/src/agent-creation.ts
@@ -1,66 +1,104 @@
 import {
-  buildCreatedAgentTags,
-  buildCreateAgentRequestForPersonality,
-  buildSystemPrompt,
-  LETTA_CODE_AGENT_TYPE,
-  MODEL_PRESETS,
+  buildCreateAgentRequest,
+  type CreateAgentMemoryBlock,
+  type CreateAgentRequest,
 } from "@letta-ai/letta-code/agent-presets";
 import type { CreateAgentOptions } from "./types.js";
 
-const DEFAULT_MODEL_ID = "auto";
-const DEFAULT_SUMMARIZATION_MODEL = "letta/auto";
-
-function resolveModel(modelIdentifier: string): string {
-  const preset = MODEL_PRESETS.find(
-    (model) =>
-      model.id === modelIdentifier || model.handle === modelIdentifier,
-  );
-  if (preset) return preset.handle;
-
-  // Preserve support for model handles supplied by self-hosted servers even
-  // when they are not present in the bundled catalog.
-  if (modelIdentifier.includes("/")) return modelIdentifier;
-
-  throw new Error(`Unknown model: ${modelIdentifier}`);
+function isPresetSystemPrompt(value: string): boolean {
+  return [
+    "default",
+    "letta-claude",
+    "letta-codex",
+    "letta-gemini",
+    "claude",
+    "codex",
+    "gemini",
+  ].includes(value);
 }
 
-/**
- * Build the standard harness portion of a create-agent request.
- *
- * Personality presets are explicit opt-ins. Without one, the SDK builds a
- * generic agent and lets the caller's memory blocks define its identity.
- */
-export async function buildInitialAgentBody(
+function assertCreateAgentOptionsSupported(options: CreateAgentOptions): void {
+  if (
+    options.allowedTools !== undefined ||
+    options.disallowedTools !== undefined
+  ) {
+    throw new Error(
+      "App-server createAgent() does not yet support allowedTools/disallowedTools.",
+    );
+  }
+  if (options.canUseTool !== undefined) {
+    throw new Error(
+      "App-server createAgent() does not yet support canUseTool callbacks.",
+    );
+  }
+  if (options.systemInfoReminder !== undefined) {
+    throw new Error(
+      "App-server createAgent() does not yet support systemInfoReminder overrides.",
+    );
+  }
+  if (options.dreaming?.behavior !== undefined) {
+    throw new Error(
+      "App-server createAgent() does not yet support dreaming.behavior overrides.",
+    );
+  }
+}
+
+/** Translate SDK convenience options into the canonical Letta Code request. */
+export async function createAgentBody(
   options: CreateAgentOptions,
-): Promise<Record<string, unknown>> {
-  if (options.personality !== undefined) {
-    return {
-      ...(await buildCreateAgentRequestForPersonality({
-        personalityId: options.personality,
-        ...(options.name !== undefined ? { name: options.name } : {}),
-        ...(options.description !== undefined
-          ? { description: options.description }
-          : {}),
-        ...(options.model !== undefined ? { model: options.model } : {}),
-        ...(options.tags !== undefined ? { extraTags: options.tags } : {}),
-      })),
-    };
+): Promise<CreateAgentRequest> {
+  assertCreateAgentOptionsSupported(options);
+
+  let system: string | undefined;
+  if (options.systemPrompt !== undefined) {
+    if (
+      typeof options.systemPrompt !== "string" ||
+      isPresetSystemPrompt(options.systemPrompt)
+    ) {
+      throw new Error(
+        "createAgent() does not yet support system prompt presets for this backend.",
+      );
+    }
+    system = options.systemPrompt;
   }
 
-  return {
-    agent_type: LETTA_CODE_AGENT_TYPE,
-    ...(options.name !== undefined ? { name: options.name } : {}),
-    ...(options.description !== undefined
-      ? { description: options.description }
-      : {}),
-    model: resolveModel(options.model ?? DEFAULT_MODEL_ID),
-    system: buildSystemPrompt("default", "memfs"),
-    tags: buildCreatedAgentTags({
-      enableMemfs: true,
-      tags: options.tags ?? [],
-    }),
-    initial_message_sequence: [],
-    parallel_tool_calls: true,
-    compaction_settings: { model: DEFAULT_SUMMARIZATION_MODEL },
-  };
+  const memoryBlocks: CreateAgentMemoryBlock[] = [];
+  const blockIds: string[] = [];
+  for (const item of options.memory ?? []) {
+    if (typeof item === "string") {
+      throw new Error(
+        "App-server createAgent() does not yet support memory preset names.",
+      );
+    }
+    if ("blockId" in item) {
+      blockIds.push(item.blockId);
+    } else {
+      memoryBlocks.push({ ...item });
+    }
+  }
+  if (options.persona !== undefined) {
+    memoryBlocks.push({ label: "persona", value: options.persona });
+  }
+  if (options.human !== undefined) {
+    memoryBlocks.push({ label: "human", value: options.human });
+  }
+  const hasMemoryConfiguration =
+    options.memory !== undefined ||
+    options.persona !== undefined ||
+    options.human !== undefined;
+
+  return buildCreateAgentRequest({
+    personalityId: options.personality,
+    name: options.name,
+    description: options.description,
+    model: options.model,
+    system,
+    memoryBlocks: hasMemoryConfiguration ? memoryBlocks : undefined,
+    blockIds,
+    extraTags: options.tags,
+    enableMemfs: options.memfs ?? true,
+    baseTools: options.baseTools,
+    embedding: options.embedding,
+    hidden: options.hidden,
+  });
 }

--- a/src/app-server-session.ts
+++ b/src/app-server-session.ts
@@ -11,12 +11,7 @@ import type {
   RuntimeStartResponseMessage,
   UpdateModelResponseMessage,
 } from "@letta-ai/letta-code/app-server-protocol";
-import {
-  buildSystemPrompt,
-  GIT_MEMORY_ENABLED_TAG,
-  LETTA_CODE_ORIGIN_TAG,
-} from "@letta-ai/letta-code/agent-presets";
-import { buildInitialAgentBody } from "./agent-creation.js";
+import { createAgentBody } from "./agent-creation.js";
 import { normalizeAppServerModels } from "./app-server-models.js";
 import {
   buildCanUseToolContext,
@@ -99,151 +94,9 @@ export type AppServerSessionOptions = Partial<LettaCodeRemoteClientOptions> & {
   connect?: (
     sessionEnv?: Record<string, string>,
   ) => Promise<{ url: string; close(): void }>;
-  /** Whether SDK create-agent payloads should add the origin tag automatically. */
-  includeSdkOriginTag?: boolean;
 };
 
 export type AppServerSessionMode = RuntimeSessionMode;
-
-function isPresetSystemPrompt(value: string): boolean {
-  return [
-    "default",
-    "letta-claude",
-    "letta-codex",
-    "letta-gemini",
-    "claude",
-    "codex",
-    "gemini",
-  ].includes(value);
-}
-
-function assertRemoteCreateAgentOptionsSupported(options: CreateAgentOptions): void {
-  if (options.allowedTools !== undefined || options.disallowedTools !== undefined) {
-    throw new Error("App-server createAgent() does not yet support allowedTools/disallowedTools.");
-  }
-  if (options.canUseTool !== undefined) {
-    throw new Error("App-server createAgent() does not yet support canUseTool callbacks.");
-  }
-  if (options.systemInfoReminder !== undefined) {
-    throw new Error("App-server createAgent() does not yet support systemInfoReminder overrides.");
-  }
-  if (options.dreaming?.behavior !== undefined) {
-    throw new Error("App-server createAgent() does not yet support dreaming.behavior overrides.");
-  }
-}
-
-function normalizeMemoryBlock(block: Record<string, unknown>): Record<string, unknown> {
-  const normalized = { ...block };
-  if (normalized.value === undefined && typeof normalized.content === "string") {
-    normalized.value = normalized.content;
-  }
-  return normalized;
-}
-
-function upsertMemoryBlock(
-  blocks: Array<Record<string, unknown>>,
-  block: Record<string, unknown>,
-): void {
-  const label = block.label;
-  if (typeof label === "string") {
-    const existingIndex = blocks.findIndex((candidate) => candidate.label === label);
-    if (existingIndex >= 0) {
-      blocks[existingIndex] = block;
-      return;
-    }
-  }
-  blocks.push(block);
-}
-
-export async function createAgentBody(
-  options: CreateAgentOptions,
-  settings: { includeSdkOriginTag?: boolean } = {},
-): Promise<Record<string, unknown>> {
-  assertRemoteCreateAgentOptionsSupported(options);
-
-  const includeOriginTag = settings.includeSdkOriginTag ?? true;
-  const body = await buildInitialAgentBody(options);
-
-  if (Array.isArray(body.tags)) {
-    body.tags = body.tags.filter(
-      (tag) =>
-        (includeOriginTag || tag !== LETTA_CODE_ORIGIN_TAG) &&
-        (options.memfs !== false || tag !== GIT_MEMORY_ENABLED_TAG),
-    );
-  }
-
-  if (options.embedding !== undefined) body.embedding = options.embedding;
-  if (options.hidden !== undefined) body.hidden = options.hidden;
-  // When baseTools is omitted, the harness applies its created-agent
-  // defaults (web_search, fetch_webpage). An explicit list is pinned exactly:
-  // `tools` alone does not suppress the Letta agent type's defaults, so both
-  // default tool attachment and its default tool rules are disabled here.
-  if (options.baseTools === undefined) {
-    delete body.tools;
-    delete body.include_base_tools;
-    delete body.include_base_tool_rules;
-  } else {
-    body.tools = options.baseTools;
-    body.include_base_tools = false;
-    body.include_base_tool_rules = false;
-  }
-
-  if (options.systemPrompt === undefined) {
-    if (options.memfs === false) {
-      body.system = buildSystemPrompt("default", "standard");
-    }
-  } else {
-    if (typeof options.systemPrompt === "string") {
-      if (isPresetSystemPrompt(options.systemPrompt)) {
-        throw new Error("createAgent() does not yet support system prompt presets for this backend.");
-      }
-      body.system = options.systemPrompt;
-    } else {
-      throw new Error("createAgent() does not yet support system prompt preset objects for this backend.");
-    }
-  }
-
-  const hasMemoryConfiguration =
-    Array.isArray(body.memory_blocks) ||
-    options.memory !== undefined ||
-    options.persona !== undefined ||
-    options.human !== undefined;
-  const memoryBlocks = Array.isArray(body.memory_blocks)
-    ? body.memory_blocks
-        .filter(
-          (block): block is Record<string, unknown> =>
-            block !== null && typeof block === "object",
-        )
-        .map((block) => ({ ...block }))
-    : [];
-  const blockIds: string[] = [];
-  for (const item of options.memory ?? []) {
-    if (typeof item === "string") {
-      throw new Error("App-server createAgent() does not yet support memory preset names.");
-    }
-    if ("blockId" in item) {
-      blockIds.push(item.blockId);
-    } else {
-      upsertMemoryBlock(
-        memoryBlocks,
-        normalizeMemoryBlock(item as unknown as Record<string, unknown>),
-      );
-    }
-  }
-  if (options.persona !== undefined) {
-    upsertMemoryBlock(memoryBlocks, {
-      label: "persona",
-      value: options.persona,
-    });
-  }
-  if (options.human !== undefined) {
-    upsertMemoryBlock(memoryBlocks, { label: "human", value: options.human });
-  }
-  if (hasMemoryConfiguration) body.memory_blocks = memoryBlocks;
-  if (blockIds.length > 0) body.block_ids = blockIds;
-
-  return body;
-}
 
 export function externalToolGroups(tools: AnyAgentTool[] | undefined): Array<Record<string, unknown>> | undefined {
   if (!tools || tools.length === 0) return undefined;
@@ -885,9 +738,7 @@ export class AppServerSession extends RemoteClientSessionCore {
 
     if (this.mode.kind === "create-agent") {
       command.create_agent = {
-        body: await createAgentBody(this.mode.options, {
-          includeSdkOriginTag: this.remoteOptions.includeSdkOriginTag,
-        }),
+        body: await createAgentBody(this.mode.options),
         // Hidden (worker-style) agents default to unpinned.
         pin_global:
           this.remoteOptions.pinGlobalAgent ??

--- a/src/cloud-session.ts
+++ b/src/cloud-session.ts
@@ -5,10 +5,10 @@ import {
   createAppServerClient,
   type AppServerClient,
 } from "@letta-ai/letta-code/app-server-client";
+import { createAgentBody } from "./agent-creation.js";
 import {
   AppServerRuntimeController,
   agentToolNames,
-  createAgentBody,
   createExternalToolCallHandler,
   externalToolGroups,
   registerAppServerControlRequestHandler,

--- a/src/tests/app-server-session.test.ts
+++ b/src/tests/app-server-session.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
-  buildCreateAgentRequestForPersonality,
+  buildCreateAgentRequest,
   buildSystemPrompt,
   LETTA_CODE_AGENT_TYPE,
 } from "@letta-ai/letta-code/agent-presets";
-import { createAgentBody } from "../app-server-session.js";
+import { createAgentBody } from "../agent-creation.js";
 
 describe("createAgentBody", () => {
   test("builds a generic harness agent when personality is omitted", async () => {
@@ -18,13 +18,13 @@ describe("createAgentBody", () => {
       initial_message_sequence: [],
       parallel_tool_calls: true,
       compaction_settings: { model: "letta/auto" },
+      tools: ["web_search", "fetch_webpage"],
+      include_base_tools: false,
+      include_base_tool_rules: false,
     });
     expect(body).not.toHaveProperty("name");
     expect(body).not.toHaveProperty("description");
     expect(body).not.toHaveProperty("memory_blocks");
-    expect(body).not.toHaveProperty("tools");
-    expect(body).not.toHaveProperty("include_base_tools");
-    expect(body).not.toHaveProperty("include_base_tool_rules");
   });
 
   test("uses caller memory as the complete identity without a personality preset", async () => {
@@ -49,17 +49,41 @@ describe("createAgentBody", () => {
       personality: "memo",
       model: "openai/gpt-5.2",
     });
-    const expected = {
-      ...(await buildCreateAgentRequestForPersonality({
+    expect(body).toEqual(
+      await buildCreateAgentRequest({
         personalityId: "memo",
         model: "openai/gpt-5.2",
-      })),
-    } as unknown as Record<string, unknown>;
-    delete expected.tools;
-    delete expected.include_base_tools;
-    delete expected.include_base_tool_rules;
+      }),
+    );
+  });
 
-    expect(body).toEqual(expected);
+  test("translates convenience memory inputs before canonical creation", async () => {
+    const body = await createAgentBody({
+      personality: "memo",
+      memory: [
+        { label: "persona", value: "Memory persona" },
+        { blockId: "block-shared" },
+      ],
+      persona: "Convenience persona",
+      human: "Convenience human",
+    });
+
+    expect(body.memory_blocks).toEqual(
+      expect.arrayContaining([
+        { label: "persona", value: "Convenience persona" },
+        { label: "human", value: "Convenience human" },
+      ]),
+    );
+    expect(body.block_ids).toEqual(["block-shared"]);
+  });
+
+  test("keeps MemFS mode and exact base tools in the canonical request", async () => {
+    const body = await createAgentBody({ memfs: false, baseTools: [] });
+    expect(body.system).toBe(buildSystemPrompt("default", "standard"));
+    expect(body.tags).toEqual(["origin:letta-code"]);
+    expect(body.tools).toEqual([]);
+    expect(body.include_base_tools).toBe(false);
+    expect(body.include_base_tool_rules).toBe(false);
   });
 
   test("preserves custom prompts", async () => {

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1482,7 +1482,7 @@ describe("LettaAgentClient", () => {
     });
   });
 
-  test("createAgent leaves server-side tools to the harness defaults when baseTools is omitted", async () => {
+  test("createAgent uses the canonical server-tool defaults when baseTools is omitted", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({
       backend: "remote",
@@ -1497,10 +1497,11 @@ describe("LettaAgentClient", () => {
     const command = fakeControlSocket().sent[0] as {
       create_agent?: { body?: Record<string, unknown> };
     };
-    // The harness applies its created-agent defaults (web_search,
-    // fetch_webpage); the SDK does not pin them client-side.
-    expect(command.create_agent?.body).not.toHaveProperty("tools");
-    expect(command.create_agent?.body).not.toHaveProperty("include_base_tools");
+    expect(command.create_agent?.body).toMatchObject({
+      tools: ["web_search", "fetch_webpage"],
+      include_base_tools: false,
+      include_base_tool_rules: false,
+    });
   });
 
   test("baseTools: [] attaches no server-side tools", async () => {
@@ -1553,7 +1554,7 @@ describe("LettaAgentClient", () => {
     });
   });
 
-  test("default toolset contract: harness owns both defaults; SDK only excludes interactive tools", async () => {
+  test("default toolset contract: canonical creation pins server defaults and turns use harness client tools", async () => {
     FakeAppServerSocket.instances = [];
     const client = new LettaAgentClient({
       backend: "remote",
@@ -1561,16 +1562,19 @@ describe("LettaAgentClient", () => {
       WebSocket: FakeAppServerSocket,
     });
 
-    // 1. Creation sends no tool fields — the harness applies its
-    //    created-agent defaults (web_search, fetch_webpage).
+    // 1. Creation pins the canonical server-side defaults and disables the
+    //    API's legacy base-tool union.
     const agentId = await client.createAgent({
       model: "anthropic/claude-sonnet-4",
     });
     const createCommand = fakeControlSocket().sent[0] as {
       create_agent?: { body?: Record<string, unknown> };
     };
-    expect(createCommand.create_agent?.body).not.toHaveProperty("tools");
-    expect(createCommand.create_agent?.body).not.toHaveProperty("include_base_tools");
+    expect(createCommand.create_agent?.body).toMatchObject({
+      tools: ["web_search", "fetch_webpage"],
+      include_base_tools: false,
+      include_base_tool_rules: false,
+    });
 
     // 2. Every turn keeps the harness default toolset (no pinned allowlist)
     //    and excludes interactive user-input tools via the protocol flag.


### PR DESCRIPTION
## Summary
- replace the SDK-owned agent request builder and post-build mutations with the canonical builder exported by Letta Code
- preserve SDK convenience inputs by translating persona, human, memory, and block references before canonical creation
- restore the canonical web_search and fetch_webpage defaults while preserving explicit empty and custom base-tool lists
- remove the dead origin-tag suppression path so identity, MemFS, and creation tags stay coherent
- lock @letta-ai/letta-code 0.30.5, which contains the shared creation builder

## Verification
- bun run check
- bun test (208 passed, 11 live integration tests skipped)
- bun run build

👾 Generated with [Letta Code](https://letta.com)